### PR TITLE
fix: reduce backoffice language/store fetches

### DIFF
--- a/Ekom/Ekom.U10/Services/UmbracoService.cs
+++ b/Ekom/Ekom.U10/Services/UmbracoService.cs
@@ -4,7 +4,9 @@ using Ekom.Umb.Models;
 using Ekom.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
+using System.Collections.Concurrent;
 using System.Net;
+using System.Threading;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -16,6 +18,8 @@ namespace Ekom.Umb.Services;
 
 class UmbracoService : IUmbracoService
 {
+    private const string LanguagesCacheKey = "ekmLanguages";
+    private static readonly ConcurrentDictionary<string, Lazy<IReadOnlyList<UmbracoLanguage>>> _languageLocks = new();
     private readonly IDataTypeService _dataTypeService;
     private readonly IDomainService _domainService;
     private readonly INodeService _nodeService;
@@ -146,21 +150,51 @@ class UmbracoService : IUmbracoService
 
     public IEnumerable<UmbracoLanguage>? GetLanguages()
     {
-        return _runtimeCache.GetCacheItem("ekmLanguages", () => {
-            return _localizationService.GetAllLanguages().OrderByDescending(x => x.IsDefault).ThenBy(x => x.CultureName).Select(x => new UmbracoLanguage()
+        return _runtimeCache.GetCacheItem(LanguagesCacheKey, () =>
+        {
+            var lazy = _languageLocks.GetOrAdd(LanguagesCacheKey, _ =>
+                new Lazy<IReadOnlyList<UmbracoLanguage>>(
+                    LoadLanguages,
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+
+            try
+            {
+                return lazy.Value;
+            }
+            catch
+            {
+                _languageLocks.TryRemove(LanguagesCacheKey, out _);
+                throw;
+            }
+            finally
+            {
+                if (lazy.IsValueCreated)
+                {
+                    _languageLocks.TryRemove(LanguagesCacheKey, out _);
+                }
+            }
+        }, TimeSpan.FromHours(6));
+    }
+
+    private IReadOnlyList<UmbracoLanguage> LoadLanguages()
+    {
+        return _localizationService.GetAllLanguages()
+            .OrderByDescending(x => x.IsDefault)
+            .ThenBy(x => x.CultureName)
+            .Select(x => new UmbracoLanguage()
             {
                 Culture = x.CultureInfo,
                 CultureName = x.CultureName,
                 IsoCode = x.IsoCode
-            });
-        }, TimeSpan.FromMinutes(30));
+            })
+            .ToList();
     }
 
     public string DefaultLanguage()
     {
         return _runtimeCache.GetCacheItem("ekmDefaultLanguage", () => {
             return _localizationService.GetDefaultLanguageIsoCode();
-        }, TimeSpan.FromMinutes(30));
+        }, TimeSpan.FromHours(6));
     }
 
     private object FormatDataType(IDataType dtd)

--- a/Ekom/Ekom.U10/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.U10/UmbracoEventListeners.cs
@@ -456,6 +456,7 @@ class UmbracoEventListeners :
     public void Handle(LanguageCacheRefresherNotification notification)
     {
         _runtimeCache.Clear("ekmLanguages");
+        _runtimeCache.Clear("ekmDefaultLanguage");
     }
 
     private void RefreshCacheForRelatedNodes(int Id, bool remove = false)

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/DataTypes/PropertyEditor/js/ekmPropertyEditor.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/DataTypes/PropertyEditor/js/ekmPropertyEditor.controller.js
@@ -92,7 +92,7 @@
 
             $scope.model.value.type = "Language";
 
-            ekmResources.getLanguages().then(function (languages) {
+            ekmResources.getLanguagesByNode($routeParams.id).then(function (languages) {
 
               $scope.tabs = languages.map(x => ({ value: x.isoCode, text: x.cultureName }));
 

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Shared/ekmResources.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Shared/ekmResources.js
@@ -1,7 +1,13 @@
 /* Resources */
 angular.module('umbraco.resources').factory('Ekom.Resources',
   function ($q, $http, umbRequestHelper) {
-    return {
+    var languagesCache = null;
+    var languagesPromise = null;
+    var languagesByNodeCache = {};
+    var languagesByNodePromise = {};
+    var storesByNodeCache = {};
+    var storesByNodePromise = {};
+    var api = {
       getNonEkomDataTypes: function () {
         return umbRequestHelper.resourcePromise(
           $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "GetNonEkomDataTypes"),
@@ -21,16 +27,78 @@ angular.module('umbraco.resources').factory('Ekom.Resources',
         );
       },
       getLanguages: function () {
-        return umbRequestHelper.resourcePromise(
+        if (languagesCache) {
+          return $q.resolve(languagesCache);
+        }
+
+        if (languagesPromise) {
+          return languagesPromise;
+        }
+
+        languagesPromise = umbRequestHelper.resourcePromise(
           $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Languages"),
           'Failed to retrieve languages'
-        );
+        ).then(function (data) {
+          languagesCache = data;
+          return data;
+        }).finally(function () {
+          languagesPromise = null;
+        });
+
+        return languagesPromise;
+      },
+      getLanguagesByNode: function (id) {
+        if (!id) {
+          return api.getLanguages();
+        }
+
+        if (languagesByNodeCache[id]) {
+          return $q.resolve(languagesByNodeCache[id]);
+        }
+
+        if (languagesByNodePromise[id]) {
+          return languagesByNodePromise[id];
+        }
+
+        languagesByNodePromise[id] = umbRequestHelper.resourcePromise(
+          $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Languages/" + id),
+          'Failed to retrieve languages'
+        ).then(function (data) {
+          languagesByNodeCache[id] = data;
+          return data;
+        }).finally(function () {
+          languagesByNodePromise[id] = null;
+        });
+
+        return languagesByNodePromise[id];
       },
       getStoresByNode: function (id) {
-        return umbRequestHelper.resourcePromise(
+        if (!id) {
+          return umbRequestHelper.resourcePromise(
+            $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Stores/" + id),
+            'Failed to retrieve stores'
+          );
+        }
+
+        if (storesByNodeCache[id]) {
+          return $q.resolve(storesByNodeCache[id]);
+        }
+
+        if (storesByNodePromise[id]) {
+          return storesByNodePromise[id];
+        }
+
+        storesByNodePromise[id] = umbRequestHelper.resourcePromise(
           $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Stores/" + id),
           'Failed to retrieve stores'
-        );
+        ).then(function (data) {
+          storesByNodeCache[id] = data;
+          return data;
+        }).finally(function () {
+          storesByNodePromise[id] = null;
+        });
+
+        return storesByNodePromise[id];
       },
       getStores: function () {
         return umbRequestHelper.resourcePromise(
@@ -45,5 +113,6 @@ angular.module('umbraco.resources').factory('Ekom.Resources',
         );
       }
     };
+    return api;
   }
 );

--- a/Ekom/Ekom/Controllers/EkomBackofficeApiController.cs
+++ b/Ekom/Ekom/Controllers/EkomBackofficeApiController.cs
@@ -82,6 +82,40 @@ public class EkomBackofficeApiController : ControllerBase
         => _umbracoService.GetLanguages();
 
     [HttpGet]
+    [Route("Languages/{id:int}")]
+    [UmbracoUserAuthorize]
+    public IEnumerable<object> GetLanguagesByNode([FromRoute] int id)
+    {
+        var stores = LoadStores(id);
+        var supportedCultures = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var store in stores)
+        {
+            foreach (var culture in store.Cultures)
+            {
+                if (!string.IsNullOrWhiteSpace(culture.Name))
+                {
+                    supportedCultures.Add(culture.Name);
+                }
+            }
+        }
+
+        var languages = _umbracoService.GetLanguages();
+
+        if (languages == null)
+        {
+            return Array.Empty<object>();
+        }
+
+        if (supportedCultures.Count == 0)
+        {
+            return languages.ToList();
+        }
+
+        return languages.Where(language => supportedCultures.Contains(language.IsoCode)).ToList();
+    }
+
+    [HttpGet]
     [Route("Stores")]
     [UmbracoUserAuthorize]
     public async Task<IEnumerable<IStore>> GetAllStores()

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/PropertyEditor/js/ekmPropertyEditor.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/PropertyEditor/js/ekmPropertyEditor.controller.js
@@ -92,7 +92,7 @@
 
             $scope.model.value.type = "Language";
 
-            ekmResources.getLanguages().then(function (languages) {
+            ekmResources.getLanguagesByNode($routeParams.id).then(function (languages) {
 
               $scope.tabs = languages.map(x => ({ value: x.isoCode, text: x.cultureName }));
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Shared/ekmResources.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Shared/ekmResources.js
@@ -1,7 +1,13 @@
 /* Resources */
 angular.module('umbraco.resources').factory('Ekom.Resources',
   function ($q, $http, umbRequestHelper) {
-    return {
+    var languagesCache = null;
+    var languagesPromise = null;
+    var languagesByNodeCache = {};
+    var languagesByNodePromise = {};
+    var storesByNodeCache = {};
+    var storesByNodePromise = {};
+    var api = {
       getNonEkomDataTypes: function () {
         return umbRequestHelper.resourcePromise(
           $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "GetNonEkomDataTypes"),
@@ -21,16 +27,78 @@ angular.module('umbraco.resources').factory('Ekom.Resources',
         );
       },
       getLanguages: function () {
-        return umbRequestHelper.resourcePromise(
+        if (languagesCache) {
+          return $q.resolve(languagesCache);
+        }
+
+        if (languagesPromise) {
+          return languagesPromise;
+        }
+
+        languagesPromise = umbRequestHelper.resourcePromise(
           $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Languages"),
           'Failed to retrieve languages'
-        );
+        ).then(function (data) {
+          languagesCache = data;
+          return data;
+        }).finally(function () {
+          languagesPromise = null;
+        });
+
+        return languagesPromise;
+      },
+      getLanguagesByNode: function (id) {
+        if (!id) {
+          return api.getLanguages();
+        }
+
+        if (languagesByNodeCache[id]) {
+          return $q.resolve(languagesByNodeCache[id]);
+        }
+
+        if (languagesByNodePromise[id]) {
+          return languagesByNodePromise[id];
+        }
+
+        languagesByNodePromise[id] = umbRequestHelper.resourcePromise(
+          $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Languages/" + id),
+          'Failed to retrieve languages'
+        ).then(function (data) {
+          languagesByNodeCache[id] = data;
+          return data;
+        }).finally(function () {
+          languagesByNodePromise[id] = null;
+        });
+
+        return languagesByNodePromise[id];
       },
       getStoresByNode: function (id) {
-        return umbRequestHelper.resourcePromise(
+        if (!id) {
+          return umbRequestHelper.resourcePromise(
+            $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Stores/" + id),
+            'Failed to retrieve stores'
+          );
+        }
+
+        if (storesByNodeCache[id]) {
+          return $q.resolve(storesByNodeCache[id]);
+        }
+
+        if (storesByNodePromise[id]) {
+          return storesByNodePromise[id];
+        }
+
+        storesByNodePromise[id] = umbRequestHelper.resourcePromise(
           $http.get(Umbraco.Sys.ServerVariables.ekom.backofficeApiEndpoint + "Stores/" + id),
           'Failed to retrieve stores'
-        );
+        ).then(function (data) {
+          storesByNodeCache[id] = data;
+          return data;
+        }).finally(function () {
+          storesByNodePromise[id] = null;
+        });
+
+        return storesByNodePromise[id];
       },
       getStores: function () {
         return umbRequestHelper.resourcePromise(
@@ -45,5 +113,6 @@ angular.module('umbraco.resources').factory('Ekom.Resources',
         );
       }
     };
+    return api;
   }
 );


### PR DESCRIPTION
## Summary
- add node-scoped language endpoint with fallback to all languages when stores have no cultures
- coalesce and cache language/store requests in backoffice resource helpers
- avoid language cache stampede with single-flight runtime cache refresh