### PR TITLE
fix: use checkout completion time for placed order events

### DIFF
--- a/Plugins/Ekom.Klaviyo/Events/KlaviyoEkomEvents.cs
+++ b/Plugins/Ekom.Klaviyo/Events/KlaviyoEkomEvents.cs
@@ -127,7 +127,7 @@ internal sealed class KlaviyoEkomEvents : IComponent
         if (orderInfo == null)
             return;
 
-        var klaviyoOrder = orderInfo.ToKlaviyoPlacedOrder(_opt);
+        var klaviyoOrder = orderInfo.ToKlaviyoPlacedOrder(_opt, DateTimeOffset.UtcNow);
 
         using var scope = _scopeFactory.CreateScope();
         var orderService = scope.ServiceProvider.GetRequiredService<IKlaviyoOrderService>();

--- a/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
@@ -9,7 +9,7 @@ namespace Ekom.Klaviyo.Mappers;
 
 public static class OrderMapper
 {
-    public static KlaviyoPlacedOrder ToKlaviyoPlacedOrder(this IOrderInfo order, KlaviyoOptions opt)
+    public static KlaviyoPlacedOrder ToKlaviyoPlacedOrder(this IOrderInfo order, KlaviyoOptions opt, DateTimeOffset? placedAt = null)
     {
 
         var storeOptions = opt.Stores.FirstOrDefault(x => x.Alias.InvariantEquals(order.StoreInfo.Alias));
@@ -79,7 +79,7 @@ public static class OrderMapper
         {
             OrderId = order.KlaviyoUniqueId(),
             OrderNumber = order.OrderNumber,
-            PlacedAt = order.PaidDate ?? order.CreateDate,
+            PlacedAt = placedAt ?? order.PaidDate ?? order.CreateDate,
             Value = order.ChargedAmount.Value,
             ValueFormatted = order.ChargedAmount.CurrencyString,
             Currency = order.StoreInfo.Currency.ISOCurrencySymbol,


### PR DESCRIPTION
## Summary
- use the actual checkout completion timestamp for Klaviyo `Placed Order` events instead of the order creation date
- pass the completion-time override from the checkout completion event into the Klaviyo order mapper
- prevent Klaviyo timelines from showing `Placed Order` before `Added to Cart` and `Started Checkout`