### PR TITLE
fix: allow manager access when no store permissions are configured

### DIFF
--- a/Ekom/Ekom/Services/ManagerAccessService.cs
+++ b/Ekom/Ekom/Services/ManagerAccessService.cs
@@ -53,6 +53,11 @@ public sealed class ManagerAccessService : IManagerAccessService
         var normalizedStoreAlias = storeAlias.Trim();
         var permissions = _options.Value.Manager.StoreGroupPermissions;
 
+        if (permissions.Count == 0)
+        {
+            return true;
+        }
+
         if (!TryGetAllowedGroupsForStore(permissions, normalizedStoreAlias, out var allowedGroups))
         {
             return false;
@@ -86,6 +91,13 @@ public sealed class ManagerAccessService : IManagerAccessService
     public IEnumerable<IStore> GetAllowedStores()
     {
         if (_securityService.IsCurrentUserAdmin())
+        {
+            return _storeService.GetAllStores();
+        }
+
+        var permissions = _options.Value.Manager.StoreGroupPermissions;
+
+        if (permissions.Count == 0)
         {
             return _storeService.GetAllStores();
         }


### PR DESCRIPTION
## Summary
- return `true` from `CanAccessStore` when no `StoreGroupPermissions` are configured
- return all stores from `GetAllowedStores` when store group permissions are not configured
- keep manager access behavior aligned with the existing no-permissions fallback

## Verification
- `dotnet build \"Ekom/Ekom/Ekom.csproj\"`