### PR TITLE
fix: avoid manager order status dirty prompts

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/ekmManager.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/ekmManager.html
@@ -125,7 +125,7 @@
                 <div class="umb-table-cell" title="{{order.uniqueId}}">{{ order.referenceId }}</div>
                 <div class="umb-table-cell">
                   <div class="mt-2 grid grid-cols-1">
-                    <select class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6"
+                    <select no-dirty-check class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6"
                             ng-model="order.orderStatusCol"
                             ng-options="s.enumValue as s.label for s in statusList"
                             ng-change="onStatusChanged(order)">

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/ekmManager.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/ekmManager.html
@@ -125,7 +125,7 @@
                 <div class="umb-table-cell" title="{{order.uniqueId}}">{{ order.referenceId }}</div>
                 <div class="umb-table-cell">
                   <div class="mt-2 grid grid-cols-1">
-                    <select class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6"
+                    <select no-dirty-check class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-1.5 pl-3 pr-8 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-indigo-600 sm:text-sm/6"
                             ng-model="order.orderStatusCol"
                             ng-options="s.enumValue as s.label for s in statusList"
                             ng-change="onStatusChanged(order)">

--- a/Samples/U10/Ekom.Site/Ekom.Site.csproj
+++ b/Samples/U10/Ekom.Site/Ekom.Site.csproj
@@ -54,6 +54,8 @@
       <None Include="App_Plugins\Ekom\Manager\libs\chart4.3.0.min.js" />
       <None Include="App_Plugins\Ekom\Manager\package.manifest" />
       <None Include="App_Plugins\Ekom\Manager\resources\ekmManager.resources.js" />
+      <None Include="App_Plugins\Ekom\Manager\services\ekmManager.charts.js" />
+      <None Include="App_Plugins\Ekom\Manager\services\ekmManager.state.js" />
       <None Include="App_Plugins\Ekom\Shared\Chosen\angular-chosen.min.js" />
       <None Include="App_Plugins\Ekom\Shared\Chosen\chosen.jquery.min.js" />
       <None Include="App_Plugins\Ekom\Shared\ekmUtility.js" />


### PR DESCRIPTION
## Summary
- add `no-dirty-check` to the manager order status select so changing status does not trigger unsaved-change prompts
- mirror the same manager view update in the Umbraco 10 sample site
- include the manager chart and state service files in the sample site project so the sample plugin assets stay in sync