### PR TITLE
fix: remove coupon discounts without clearing manual discounts

### DIFF
--- a/Bruno/Order/Remove Coupon From Order.bru
+++ b/Bruno/Order/Remove Coupon From Order.bru
@@ -5,8 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/ekom/order/coupon/remove?storeAlias=store
-  body: json
+  url: {{baseUrl}}/ekom/order/coupon/remove
   auth: none
 }
 

--- a/Ekom/Ekom.Tests/Tests/OrderCouponTests.cs
+++ b/Ekom/Ekom.Tests/Tests/OrderCouponTests.cs
@@ -1,0 +1,89 @@
+using Ekom.API;
+using Ekom.Models;
+using Ekom.Tests.Objects;
+using Ekom.Utilities;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class OrderCouponTests
+{
+    [Fact]
+    public void TryRemoveCouponFromOrder_ClearsCouponAndDiscount_WhenCouponExists()
+    {
+        var orderInfo = CreateOrderInfo();
+        var discount = CreateDiscount();
+
+        SetProperty(orderInfo, nameof(OrderInfo.Coupon), "spring-sale");
+        SetProperty(orderInfo, nameof(OrderInfo.Discount), discount);
+
+        var result = InvokeTryRemoveCouponFromOrder(orderInfo);
+
+        Assert.True(result);
+        Assert.Null(orderInfo.Coupon);
+        Assert.Null(orderInfo.Discount);
+    }
+
+    [Fact]
+    public void TryRemoveCouponFromOrder_DoesNotClearDiscount_WhenCouponMissing()
+    {
+        var orderInfo = CreateOrderInfo();
+        var discount = CreateDiscount();
+
+        SetProperty(orderInfo, nameof(OrderInfo.Coupon), null);
+        SetProperty(orderInfo, nameof(OrderInfo.Discount), discount);
+
+        var result = InvokeTryRemoveCouponFromOrder(orderInfo);
+
+        Assert.False(result);
+        Assert.Null(orderInfo.Coupon);
+        Assert.Same(discount, orderInfo.Discount);
+    }
+
+    private static OrderInfo CreateOrderInfo()
+    {
+        var orderData = new OrderData
+        {
+            UniqueId = Guid.NewGuid(),
+            OrderNumber = "1",
+            OrderStatus = OrderStatus.Pending,
+            OrderInfo = string.Empty,
+            CustomerEmail = string.Empty,
+            CustomerUsername = string.Empty,
+            ShippingCountry = string.Empty,
+            Currency = "is-IS",
+            StoreAlias = Stores.Store_IS_24Vat_VatIncluded.Alias,
+        };
+
+        return new OrderInfo(orderData, Stores.Store_IS_24Vat_VatIncluded);
+    }
+
+    private static OrderedDiscount CreateDiscount()
+    {
+        return (OrderedDiscount)RuntimeHelpers.GetUninitializedObject(typeof(OrderedDiscount));
+    }
+
+    private static bool InvokeTryRemoveCouponFromOrder(OrderInfo orderInfo)
+    {
+        var orderServiceType = typeof(Order).Assembly.GetType("Ekom.Services.OrderService");
+        Assert.NotNull(orderServiceType);
+
+        var method = orderServiceType!.GetMethod("TryRemoveCouponFromOrder", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(null, new object[] { orderInfo });
+        Assert.IsType<bool>(result);
+
+        return (bool)result!;
+    }
+
+    private static void SetProperty(object instance, string propertyName, object? value)
+    {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+
+        property!.SetValue(instance, value);
+    }
+}

--- a/Ekom/Ekom/API/Order.Discounts.cs
+++ b/Ekom/Ekom/API/Order.Discounts.cs
@@ -86,7 +86,7 @@ public partial class Order
             throw new ArgumentException("string.IsNullOrEmpty", nameof(storeAlias));
         }
 
-        await _orderService.RemoveDiscountFromOrderAsync(storeAlias, ct: ct)
+        await _orderService.RemoveCouponFromOrderAsync(storeAlias, ct: ct)
             .ConfigureAwait(false);
     }
 

--- a/Ekom/Ekom/Services/OrderService.Discounts.cs
+++ b/Ekom/Ekom/Services/OrderService.Discounts.cs
@@ -164,6 +164,58 @@ partial class OrderService
     }
 
     /// <summary>
+    /// Removes the current order-level coupon discount only.
+    /// </summary>
+    public async Task RemoveCouponFromOrderAsync(string storeAlias, CancellationToken ct = default, DiscountOrderSettings? settings = null)
+    {
+        if (settings == null)
+        {
+            settings = new DiscountOrderSettings();
+        }
+
+        var orderInfo = await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
+
+        SemaphoreSlim semaphore = GetOrderLock(orderInfo);
+        if (!settings.IsEventHandler)
+        {
+            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+        }
+        try
+        {
+            if (!TryRemoveCouponFromOrder(orderInfo))
+            {
+                return;
+            }
+
+            if (settings.UpdateOrder)
+            {
+                await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
+                    .ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (!settings.IsEventHandler)
+            {
+                semaphore.Release();
+            }
+        }
+    }
+
+    private static bool TryRemoveCouponFromOrder(OrderInfo orderInfo)
+    {
+        if (string.IsNullOrWhiteSpace(orderInfo.Coupon))
+        {
+            return false;
+        }
+
+        orderInfo.Discount = null;
+        orderInfo.Coupon = null;
+
+        return true;
+    }
+
+    /// <summary>
     /// 
     /// </summary>
     /// <exception cref="ProductNotFoundException"></exception>


### PR DESCRIPTION
## Summary
- add a coupon-specific order removal path so removing a coupon does not clear non-coupon discounts
- update the order API and Bruno example to use the corrected coupon removal flow
- add focused tests covering coupon removal behavior when a coupon is present or missing

## Test Plan
- run `dotnet build "Ekom/Ekom/Ekom.csproj"`
- run `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~OrderCouponTests" -p:NoWarn=NU1605`