### PR TITLE
fix: flatten placed order item fields for Klaviyo

### DIFF
--- a/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
@@ -106,6 +106,13 @@ public static class OrderMapper
     internal static object ToPlacedOrderEvent(this KlaviyoPlacedOrder o, KlaviyoOptions opt)
     {
         JsonObject? shippingTo = null;
+        var itemSkus = o.Items
+            .Select(x => x.Sku)
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+        var itemNames = o.Items
+            .Select(x => x.Name)
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+        var itemCount = o.Items.Sum(x => x.Quantity);
 
         if (o.ShipTo is not null)
         {
@@ -162,6 +169,9 @@ public static class OrderMapper
             ["tax_value"] = o.TaxValue,
             ["shipping_to"] = shippingTo,
             ["items"] = o.Items.ToOrderLinesEvent(),
+            ["item_skus_text"] = string.Join("|", itemSkus),
+            ["item_names_text"] = string.Join("|", itemNames),
+            ["item_count"] = itemCount,
             ["store_alias"] = o.StoreAlias
         };
 


### PR DESCRIPTION
## Summary
- keep the existing `items` array in the Klaviyo placed order payload
- add flat `item_skus_text` and `item_names_text` fields so Klaviyo flows can filter on order item values without traversing objects in the array
- add `item_count` as the sum of order line quantities for placed order events

## Test Plan
- run `dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj"`
- verify the placed order event still includes `items`
- verify the placed order event now includes `item_skus_text`, `item_names_text`, and `item_count`