### PR TITLE
feat(order): add activity log service and manager UI

### DIFF
--- a/Ekom/Ekom.AspNetCore/Registrations.cs
+++ b/Ekom/Ekom.AspNetCore/Registrations.cs
@@ -96,6 +96,10 @@ static class Registrations
         services.AddTransient<OrderRepository>();
         services.AddTransient<CouponRepository>();
         services.AddTransient<ActivityLogRepository>();
+        services.AddSingleton<OrderActivityLogDispatcher>();
+        services.AddSingleton<IOrderActivityLogDispatcher>(sp => sp.GetRequiredService<OrderActivityLogDispatcher>());
+        services.AddHostedService(sp => sp.GetRequiredService<OrderActivityLogDispatcher>());
+        services.AddTransient<IOrderActivityLogService, OrderActivityLogService>();
         services.AddTransient<IProductFilterService, ProductFilterService>();
 
         services.AddSingleton<IObjectFactory<IStore>, StoreFactory>();
@@ -160,7 +164,8 @@ static class Registrations
                 f.GetService<CheckoutService>(),
                 f.GetService<IStoreService>(),
                 f.GetService<OrderRepository>(),
-                f.GetService<CheckoutControllerService>()
+                f.GetService<CheckoutControllerService>(),
+                f.GetService<IOrderActivityLogService>()
             )
         );
         services.AddTransient<Providers>(f =>

--- a/Ekom/Ekom.U10/EnsureTablesExist.cs
+++ b/Ekom/Ekom.U10/EnsureTablesExist.cs
@@ -34,6 +34,24 @@ class MigrationCreateTables : MigrationBase
     }
 }
 
+class MigrationAddOrderActivityLogTypeColumn : MigrationBase
+{
+    readonly DatabaseService _dbService;
+
+    public MigrationAddOrderActivityLogTypeColumn(
+        DatabaseService dbService,
+        IMigrationContext context)
+        : base(context)
+    {
+        _dbService = dbService;
+    }
+
+    protected override void Migrate()
+    {
+        _dbService.EnsureOrderActivityLogTypeColumn();
+    }
+}
+
 class EkomMigrationPlan : MigrationPlan
 {
     public const string OrderDataUniqueIndex = "IX_EkomOrders_UniqueId";
@@ -43,6 +61,9 @@ class EkomMigrationPlan : MigrationPlan
     {
         From(string.Empty)
             .To<MigrationCreateTables>("1"); // Run only if the state is empty
+
+        From("1")
+            .To<MigrationAddOrderActivityLogTypeColumn>("2");
     }
 }
 
@@ -83,15 +104,23 @@ class EnsureTablesExist : IComponent
 
         var currentState = keyValueService.GetValue("Umbraco.Core.Upgrader.State+Ekom");
 
-        if (string.IsNullOrEmpty(currentState)) // Run only if the state is empty
+        if (string.IsNullOrEmpty(currentState))
         {
             logger.LogInformation("Running initial database setup for Ekom.");
 
             var upgrader = new Upgrader(new EkomMigrationPlan());
             upgrader.Execute(_migrationPlanExecutor, scopeProvider, keyValueService);
 
-            // Mark as complete so it never runs again
-            keyValueService.SetValue("Umbraco.Core.Upgrader.State+Ekom", "1");
+            keyValueService.SetValue("Umbraco.Core.Upgrader.State+Ekom", "2");
+        }
+        else if (currentState == "1")
+        {
+            logger.LogInformation("Running Ekom database activity log type migration.");
+
+            var upgrader = new Upgrader(new EkomMigrationPlan());
+            upgrader.Execute(_migrationPlanExecutor, scopeProvider, keyValueService);
+
+            keyValueService.SetValue("Umbraco.Core.Upgrader.State+Ekom", "2");
         }
         else
         {

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -3,10 +3,18 @@
 
   function controller($scope, notificationsService, resources, $document, eventsService, state, $timeout) {
     var managerState = state.getState();
+    var activityLogPreviewCharacterLimit = 180;
+    var activityLogTypeInfo = 0;
+    var activityLogTypeSuccess = 1;
+    var activityLogTypeAlert = 2;
 
     $scope.visibleDropdowns = {};
     $scope.labelDropdowns = {};
     $scope.statusList = managerState.statusList;
+    $scope.activityLogs = [];
+    $scope.activityLogsLoading = false;
+    $scope.activityLogsError = false;
+    $scope.activityLogExpandedStates = {};
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -66,6 +74,8 @@
           notify: notify.checked
         })
           .then(function () {
+            $scope.model.editModel.order.orderStatus = $scope.orderChangeStatus.value;
+            loadActivityLogs();
             notificationsService.success("Success", "Order status updated.");
             eventsService.emit("order.changed", {});
           }, function () {
@@ -210,6 +220,65 @@
         shipping.phone
       );
     };
+
+    $scope.toggleActivityLog = function (index) {
+      $scope.activityLogExpandedStates[index] = !$scope.activityLogExpandedStates[index];
+    };
+
+    $scope.isActivityLogExpanded = function (index) {
+      return !!$scope.activityLogExpandedStates[index];
+    };
+
+    $scope.canExpandActivityLog = function (log) {
+      return !!(log && log.message && log.message.length > activityLogPreviewCharacterLimit);
+    };
+
+    $scope.getActivityLogIcon = function (log) {
+      switch ((log && log.logType)) {
+        case activityLogTypeSuccess:
+          return "✓";
+        case activityLogTypeAlert:
+          return "!";
+        default:
+          return "i";
+      }
+    };
+
+    $scope.getActivityLogTypeClass = function (log) {
+      switch ((log && log.logType)) {
+        case activityLogTypeSuccess:
+          return "ekmOrderActivityLog__icon--success";
+        case activityLogTypeAlert:
+          return "ekmOrderActivityLog__icon--alert";
+        default:
+          return "ekmOrderActivityLog__icon--info";
+      }
+    };
+
+    function loadActivityLogs() {
+      var order = $scope.model && $scope.model.editModel && $scope.model.editModel.order;
+
+      if (!order || !order.uniqueId) {
+        return;
+      }
+
+      $scope.activityLogsLoading = true;
+      $scope.activityLogsError = false;
+
+      resources.OrderLogs(order.uniqueId)
+        .then(function (result) {
+          $scope.activityLogs = result.data || [];
+          $scope.activityLogExpandedStates = {};
+        }, function () {
+          $scope.activityLogs = [];
+          $scope.activityLogsError = true;
+        })
+        .finally(function () {
+          $scope.activityLogsLoading = false;
+        });
+    }
+
+    loadActivityLogs();
 
     var printOrderButton = document.getElementById("printOrder");
 

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -55,6 +55,9 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       OrderInfo: function (orderId) {
         return get(backofficeBaseUrl + "OrderInfo/" + orderId);
       },
+      OrderLogs: function (orderId) {
+        return get(backofficeBaseUrl + "OrderLogs/" + orderId);
+      },
       Charts: function (query) {
         return get(backofficeBaseUrl + "Charts", query);
       },

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
@@ -112,6 +112,91 @@
     flex: 1;
 }
 
+.ekmOrderActivityLog {
+    margin-top: 30px;
+}
+
+.ekmOrderActivityLog__list {
+    border-top: 1px solid #eee;
+}
+
+.ekmOrderActivityLog__item {
+    border-bottom: 1px solid #eee;
+    padding: 12px 0;
+}
+
+.ekmOrderActivityLog__content {
+    align-items: flex-start;
+    display: flex;
+    gap: 12px;
+}
+
+.ekmOrderActivityLog__body {
+    flex: 1;
+    min-width: 0;
+}
+
+.ekmOrderActivityLog__icon {
+    align-items: center;
+    border-radius: 50%;
+    display: inline-flex;
+    flex: 0 0 20px;
+    font-size: 12px;
+    font-weight: 700;
+    height: 20px;
+    justify-content: center;
+    line-height: 1;
+    margin-top: 1px;
+    width: 20px;
+}
+
+.ekmOrderActivityLog__icon--info {
+    background: #eef3f8;
+    color: #46607a;
+}
+
+.ekmOrderActivityLog__icon--success {
+    background: #edf8f0;
+    color: #247f45;
+}
+
+.ekmOrderActivityLog__icon--alert {
+    background: #fff4e5;
+    color: #ad5f00;
+}
+
+.ekmOrderActivityLog__date {
+    color: #666;
+    font-size: 12px;
+    margin-bottom: 6px;
+}
+
+.ekmOrderActivityLog__message {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    display: -webkit-box;
+    line-height: 1.5;
+    overflow: hidden;
+    white-space: normal;
+    word-break: break-word;
+}
+
+.ekmOrderActivityLog__message--expanded {
+    -webkit-line-clamp: unset;
+    display: block;
+    overflow: visible;
+}
+
+.ekmOrderActivityLog__toggle {
+    color: #1b264f;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 8px;
+    padding: 0;
+    text-decoration: underline;
+}
+
 @media only screen and (max-width: 800px) {
     .ekmGrid {
         grid-template-columns: 1fr;

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -237,4 +237,27 @@
       </div>
     </div>
   </div>
+
+  <div class="ekmOrderActivityLog">
+    <h4>Activity log</h4>
+
+    <p ng-if="activityLogsLoading">Loading activity...</p>
+    <p ng-if="!activityLogsLoading && activityLogsError">Unable to load activity log.</p>
+    <p ng-if="!activityLogsLoading && !activityLogsError && activityLogs.length === 0">No activity yet.</p>
+
+    <div class="ekmOrderActivityLog__list" ng-if="!activityLogsLoading && !activityLogsError && activityLogs.length > 0">
+      <div class="ekmOrderActivityLog__item" ng-repeat="log in activityLogs track by $index">
+        <div class="ekmOrderActivityLog__content">
+          <span class="ekmOrderActivityLog__icon" ng-class="getActivityLogTypeClass(log)">{{ getActivityLogIcon(log) }}</span>
+          <div class="ekmOrderActivityLog__body">
+            <div class="ekmOrderActivityLog__date">{{ log.date | date:'dd. MMMM yyyy HH:mm' }}</div>
+            <div class="ekmOrderActivityLog__message" ng-class="{ 'ekmOrderActivityLog__message--expanded': isActivityLogExpanded($index) }">{{ log.message }}</div>
+            <button type="button" class="btn-reset ekmOrderActivityLog__toggle" ng-if="canExpandActivityLog(log)" ng-click="toggleActivityLog($index)">
+              {{ isActivityLogExpanded($index) ? 'Show less' : 'Show more' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </article>

--- a/Ekom/Ekom/API/Order.cs
+++ b/Ekom/Ekom/API/Order.cs
@@ -29,6 +29,7 @@ public partial class Order
     readonly IStoreService _storeSvc;
     readonly OrderRepository _orderRepo;
     readonly CheckoutControllerService _checkoutControllerService;
+    readonly IOrderActivityLogService _orderActivityLogService;
 
     /// <summary>
     /// ctor
@@ -42,7 +43,8 @@ public partial class Order
         CheckoutService checkoutService,
         IStoreService storeService,
         OrderRepository orderRepo,
-        CheckoutControllerService checkoutControllerService)
+        CheckoutControllerService checkoutControllerService,
+        IOrderActivityLogService orderActivityLogService)
     {
         _discountCache = discountCache;
         _orderService = orderService;
@@ -53,6 +55,7 @@ public partial class Order
         _logger = logger;
         _orderRepo = orderRepo;
         _checkoutControllerService = checkoutControllerService;
+        _orderActivityLogService = orderActivityLogService;
     }
 
     public IOrderInfo? GetOrder() => GetOrderAsync().GetAwaiter().GetResult();
@@ -291,6 +294,39 @@ public partial class Order
     public async Task UpdateStatusAsync(OrderStatus newStatus, Guid orderId, string? userName = null, ChangeOrderSettings? settings = null, CancellationToken ct = default)
     {
         await _orderService.ChangeOrderStatusAsync(orderId, newStatus, userName, settings, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Add an activity log entry to an existing order.
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when orderId or message is invalid.</exception>
+    /// <exception cref="OrderInfoNotFoundException">Thrown when no order exists for the provided orderId.</exception>
+    public async Task AddActivityLogAsync(
+        Guid orderId,
+        string message,
+        string? userName = null,
+        OrderActivityLogType logType = OrderActivityLogType.Info,
+        CancellationToken ct = default)
+    {
+        if (orderId == Guid.Empty)
+        {
+            throw new ArgumentException("Order id cannot be empty.", nameof(orderId));
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            throw new ArgumentException("Message cannot be null or empty.", nameof(message));
+        }
+
+        OrderInfo? orderInfo = await _orderService.GetOrderAsync(orderId, ct).ConfigureAwait(false);
+
+        if (orderInfo == null)
+        {
+            throw new OrderInfoNotFoundException();
+        }
+
+        await _orderActivityLogService.AddOrderLogAsync(orderId, message, userName, logType, ct)
             .ConfigureAwait(false);
     }
 

--- a/Ekom/Ekom/Controllers/EkomManagerController.cs
+++ b/Ekom/Ekom/Controllers/EkomManagerController.cs
@@ -18,12 +18,14 @@ public class EkomManagerController : ControllerBase
     readonly ManagerRepository _repo;
     readonly IManagerAccessService _managerAccessService;
     readonly INodeService _nodeService;
+    readonly IOrderActivityLogService _orderActivityLogService;
     readonly ILogger<EkomManagerController> _logger;
-    public EkomManagerController(ManagerRepository repo, IManagerAccessService managerAccessService, INodeService nodeService, ILogger<EkomManagerController> logger)
+    public EkomManagerController(ManagerRepository repo, IManagerAccessService managerAccessService, INodeService nodeService, IOrderActivityLogService orderActivityLogService, ILogger<EkomManagerController> logger)
     {
         _repo = repo;
         _managerAccessService = managerAccessService;
         _nodeService = nodeService;
+        _orderActivityLogService = orderActivityLogService;
         _logger = logger;
     }
 
@@ -74,6 +76,30 @@ public class EkomManagerController : ControllerBase
             return StatusCode(500, "An unexpected error occurred.");
         }
 
+    }
+
+    [HttpGet]
+    [Route("OrderLogs/{orderId}")]
+    [UmbracoUserAuthorize]
+    public async Task<IActionResult> GetOrderLogsAsync(Guid orderId, CancellationToken ct = default)
+    {
+        try
+        {
+            var orderData = await _repo.GetOrderAsync(orderId, ct);
+
+            if (!CanAccessStore(orderData.StoreAlias))
+            {
+                return ForbidStore(orderData.StoreAlias);
+            }
+
+            return Ok(await _orderActivityLogService.GetOrderLogsAsync(orderId, ct).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get order logs. {OrderId}", orderId);
+
+            return StatusCode(500, "An unexpected error occurred.");
+        }
     }
 
     [HttpGet]
@@ -139,7 +165,7 @@ public class EkomManagerController : ControllerBase
 
         if (Enum.TryParse(orderStatus, out OrderStatus status))
         {
-            await Order.Instance.UpdateStatusAsync(status, orderId, null, new ChangeOrderSettings
+            await Order.Instance.UpdateStatusAsync(status, orderId, HttpContext?.User?.Identity?.Name, new ChangeOrderSettings
             {
                 FireEvents = notify
 

--- a/Ekom/Ekom/Models/Data/OrderActivityLog.cs
+++ b/Ekom/Ekom/Models/Data/OrderActivityLog.cs
@@ -18,6 +18,10 @@ namespace Ekom.Models
         public string UserName { get; set; }
         [Column, NotNull]
         public DateTime Date { get; set; }
+
+        [Column, NotNull]
+        public OrderActivityLogType LogType { get; set; }
+
         public string OrderNumber { get; set; }
     }
 }

--- a/Ekom/Ekom/Models/OrderActivityLogEntry.cs
+++ b/Ekom/Ekom/Models/OrderActivityLogEntry.cs
@@ -1,0 +1,12 @@
+namespace Ekom.Models;
+
+public sealed class OrderActivityLogEntry
+{
+    public string Message { get; set; } = string.Empty;
+
+    public string UserName { get; set; } = string.Empty;
+
+    public DateTime Date { get; set; }
+
+    public OrderActivityLogType LogType { get; set; }
+}

--- a/Ekom/Ekom/Models/OrderActivityLogType.cs
+++ b/Ekom/Ekom/Models/OrderActivityLogType.cs
@@ -1,0 +1,8 @@
+namespace Ekom.Models;
+
+public enum OrderActivityLogType
+{
+    Info = 0,
+    Success = 1,
+    Alert = 2,
+}

--- a/Ekom/Ekom/Repositories/ActivityLogRepository.cs
+++ b/Ekom/Ekom/Repositories/ActivityLogRepository.cs
@@ -4,7 +4,7 @@ using LinqToDB;
 using Microsoft.Extensions.Logging;
 
 namespace Ekom.Repositories;
-class ActivityLogRepository
+public class ActivityLogRepository
 {
     readonly ILogger _logger;
     readonly DatabaseFactory _databaseFactory;
@@ -17,18 +17,43 @@ class ActivityLogRepository
         _databaseFactory = databaseFactory;
     }
 
-    public async Task InsertAsync(Guid Key, string Log, string UserName)
-    {
-        await using DbContext db = _databaseFactory.GetDatabase();
+    public Task InsertAsync(Guid key, string log, string userName)
+        => InsertAsync(
+            new[]
+            {
+                new OrderActivityLogWrite(
+                    key,
+                    log,
+                    userName,
+                    DateTime.Now,
+                    OrderActivityLogType.Info),
+            },
+            CancellationToken.None);
 
-        await db.InsertAsync(new OrderActivityLog
+    public async Task InsertAsync(IReadOnlyCollection<OrderActivityLogWrite> items, CancellationToken ct = default)
+    {
+        if (items.Count == 0)
         {
-            UniqueID = Guid.NewGuid(),
-            Key = Key,
-            Log = Log,
-            UserName = UserName,
-            Date = DateTime.Now,
-        }).ConfigureAwait(false);
+            return;
+        }
+
+        await using DbContext db = _databaseFactory.GetDatabase();
+        await using var transaction = await db.BeginTransactionAsync().ConfigureAwait(false);
+
+        foreach (OrderActivityLogWrite item in items)
+        {
+            await db.InsertAsync(new OrderActivityLog
+            {
+                UniqueID = Guid.NewGuid(),
+                Key = item.OrderId,
+                Log = item.Message,
+                UserName = item.UserName,
+                Date = item.Date,
+                LogType = item.LogType,
+            }, token: ct).ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
     }
 
     public async Task<List<OrderActivityLog>> GetLatestActivityLogsOrdersByUserAsync(string userName)
@@ -40,8 +65,9 @@ class ActivityLogRepository
                   ,a.[Key]
                   ,a.[Log]
                   ,a.[UserName]
-                  ,a.[DATE],
- 	              b.orderNumber as OrderNumber
+                  ,a.[DATE]
+                  ,a.[LogType],
+  	              b.orderNumber as OrderNumber
               FROM [EkomOrdersActivityLog] a
               left join EkomOrders b on b.UniqueId = a.[Key]
               WHERE a.[UserName] = @0
@@ -51,8 +77,9 @@ class ActivityLogRepository
                   ,a.[Key]
                   ,a.[Log]
                   ,a.[UserName]
-                  ,a.[DATE],
- 	              b.orderNumber as OrderNumber
+                  ,a.[DATE]
+                  ,a.[LogType],
+  	              b.orderNumber as OrderNumber
               FROM [EkomOrdersActivityLog] a
               left join EkomOrders b on b.UniqueId = a.[Key]
               WHERE a.[UserName] = @0
@@ -76,8 +103,9 @@ class ActivityLogRepository
                         ,a.[Key]
                         ,a.[Log]
                         ,a.[UserName]
-                        ,a.[DATE],
- 	                    b.orderNumber as OrderNumber
+                        ,a.[DATE]
+                        ,a.[LogType],
+  	                    b.orderNumber as OrderNumber
                     FROM [EkomOrdersActivityLog] a
                     left join EkomOrders b on b.UniqueId = a.[Key]
                     WHERE UserName != 'Customer' AND UserName != ''
@@ -87,8 +115,9 @@ class ActivityLogRepository
                         ,a.[Key]
                         ,a.[Log]
                         ,a.[UserName]
-                        ,a.[DATE],
- 	                    b.orderNumber as OrderNumber
+                        ,a.[DATE]
+                        ,a.[LogType],
+  	                    b.orderNumber as OrderNumber
                     FROM [EkomOrdersActivityLog] a
                     left join EkomOrders b on b.UniqueId = a.[Key]
                     WHERE UserName != 'Customer' AND UserName != ''
@@ -111,7 +140,8 @@ class ActivityLogRepository
                       ,a.[Key]
                       ,a.[Log]
                       ,a.[UserName]
-                      ,a.[DATE],
+                      ,a.[DATE]
+                      ,a.[LogType],
 	                  b.orderNumber as OrderNumber
                   FROM [EkomOrdersActivityLog] a
                   left join EkomOrders b on b.UniqueId = a.[Key]
@@ -124,17 +154,23 @@ class ActivityLogRepository
     public async Task<List<OrderActivityLog>> GetLogsAsync(Guid uniqueId)
     {
         await using DbContext db = _databaseFactory.GetDatabase();
-        return await db.FromSql<OrderActivityLog>(@"SELECT a.[UniqueId]
-                        ,a.[Key]
-                        ,a.[Log]
-                        ,a.[UserName]
-                        ,a.[DATE],
-	                    b.orderNumber as OrderNumber
-                    FROM [EkomOrdersActivityLog] a
-                    left join EkomOrders b on b.UniqueId = a.[Key]
-                    WHERE a.[Key] = @0
-                    order by Date desc",
-                uniqueId)
+
+        return await (
+            from activityLog in db.OrderActivityLog
+            from order in db.OrderData
+                .LeftJoin(x => x.UniqueId == activityLog.Key)
+            where activityLog.Key == uniqueId
+            orderby activityLog.Date descending
+            select new OrderActivityLog
+            {
+                UniqueID = activityLog.UniqueID,
+                Key = activityLog.Key,
+                Log = activityLog.Log,
+                UserName = activityLog.UserName,
+                Date = activityLog.Date,
+                LogType = activityLog.LogType,
+                OrderNumber = order != null ? order.OrderNumber : string.Empty,
+            })
             .ToListAsync()
             .ConfigureAwait(false);
     }

--- a/Ekom/Ekom/Services/CheckoutService.cs
+++ b/Ekom/Ekom/Services/CheckoutService.cs
@@ -19,7 +19,9 @@ class CheckoutService
     readonly OrderRepository _orderRepo;
     readonly CouponRepository _couponRepo;
     readonly OrderService _orderService;
+    readonly IOrderActivityLogService _orderActivityLogService;
     readonly IMailService _mailService;
+
     public CheckoutService(
         ILogger<CheckoutService> logger,
         Configuration config,
@@ -27,6 +29,7 @@ class CheckoutService
         CouponRepository couponRepo,
         OrderService orderService,
         DiscountStockRepository discountStockRepo,
+        IOrderActivityLogService orderActivityLogService,
         IMailService mailService)
     {
         _logger = logger;
@@ -35,6 +38,7 @@ class CheckoutService
         _couponRepo = couponRepo;
         _orderService = orderService;
         _discountStockRepo = discountStockRepo;
+        _orderActivityLogService = orderActivityLogService;
         _mailService = mailService;
     }
 
@@ -129,8 +133,19 @@ class CheckoutService
             if (model.UpdateOrderStatus)
             {
                 await _orderService.ChangeOrderStatusAsync(o.UniqueId, OrderStatus.ReadyForDispatch)
-                .ConfigureAwait(false);
+                    .ConfigureAwait(false);
             }
+
+            string completionMessage = model.UpdateOrderStatus
+                ? "Order Completed."
+                : "Order Completed. Offline payment.";
+
+            await _orderActivityLogService.AddOrderLogAsync(
+                    o.UniqueId,
+                    completionMessage,
+                    logType: OrderActivityLogType.Success,
+                    ct: ct)
+                .ConfigureAwait(false);
         }
         catch (NotEnoughStockException ex)
         {

--- a/Ekom/Ekom/Services/DatabaseService.cs
+++ b/Ekom/Ekom/Services/DatabaseService.cs
@@ -67,4 +67,47 @@ internal class DatabaseService
         }
 
     }
+
+    internal virtual void EnsureOrderActivityLogTypeColumn()
+    {
+        try
+        {
+            using Repositories.DbContext db = _databaseFactory.GetDatabase();
+
+            if (_databaseFactory.IsSqlServer)
+            {
+                db.Execute(@"
+IF NOT EXISTS (
+    SELECT 1
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_NAME = 'EkomOrdersActivityLog'
+      AND COLUMN_NAME = 'LogType'
+)
+BEGIN
+    ALTER TABLE [dbo].[EkomOrdersActivityLog]
+    ADD [LogType] int NOT NULL
+        CONSTRAINT [DF_EkomOrdersActivityLog_LogType] DEFAULT (0);
+END");
+
+                return;
+            }
+
+            if (_databaseFactory.IsSqlite)
+            {
+                var hasColumn = db.Execute<int>(@"
+SELECT COUNT(1)
+FROM pragma_table_info('EkomOrdersActivityLog')
+WHERE name = 'LogType';");
+
+                if (hasColumn == 0)
+                {
+                    db.Execute("ALTER TABLE EkomOrdersActivityLog ADD COLUMN LogType INTEGER NOT NULL DEFAULT 0;");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to ensure activity log type column exists");
+        }
+    }
 }

--- a/Ekom/Ekom/Services/IOrderActivityLogService.cs
+++ b/Ekom/Ekom/Services/IOrderActivityLogService.cs
@@ -1,0 +1,10 @@
+using Ekom.Models;
+
+namespace Ekom.Services;
+
+public interface IOrderActivityLogService
+{
+    Task AddOrderLogAsync(Guid orderId, string message, string? userName = null, OrderActivityLogType logType = OrderActivityLogType.Info, CancellationToken ct = default);
+
+    Task<IReadOnlyList<OrderActivityLogEntry>> GetOrderLogsAsync(Guid orderId, CancellationToken ct = default);
+}

--- a/Ekom/Ekom/Services/OrderActivityLogDispatcher.cs
+++ b/Ekom/Ekom/Services/OrderActivityLogDispatcher.cs
@@ -1,0 +1,99 @@
+using Ekom.Models;
+using Ekom.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Threading.Channels;
+
+namespace Ekom.Services;
+
+public interface IOrderActivityLogDispatcher
+{
+    ValueTask EnqueueAsync(OrderActivityLogWrite work, CancellationToken ct = default);
+}
+
+public sealed record OrderActivityLogWrite(
+    Guid OrderId,
+    string Message,
+    string UserName,
+    DateTime Date,
+    OrderActivityLogType LogType);
+
+public sealed class OrderActivityLogDispatcher : BackgroundService, IOrderActivityLogDispatcher
+{
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(500);
+    private const int MaxBatchSize = 50;
+    private const int MaxQueueSize = 1000;
+
+    private readonly Channel<OrderActivityLogWrite> _channel;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OrderActivityLogDispatcher> _logger;
+
+    public OrderActivityLogDispatcher(
+        IServiceScopeFactory scopeFactory,
+        ILogger<OrderActivityLogDispatcher> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+        _channel = Channel.CreateBounded<OrderActivityLogWrite>(new BoundedChannelOptions(MaxQueueSize)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    public ValueTask EnqueueAsync(OrderActivityLogWrite work, CancellationToken ct = default)
+        => _channel.Writer.WriteAsync(work, ct);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                bool hasItem = await _channel.Reader.WaitToReadAsync(stoppingToken).ConfigureAwait(false);
+                if (!hasItem)
+                {
+                    continue;
+                }
+
+                await Task.Delay(FlushInterval, stoppingToken).ConfigureAwait(false);
+
+                List<OrderActivityLogWrite> batch = DrainBatch();
+                if (batch.Count == 0)
+                {
+                    continue;
+                }
+
+                using IServiceScope scope = _scopeFactory.CreateScope();
+                ActivityLogRepository repository = scope.ServiceProvider.GetRequiredService<ActivityLogRepository>();
+
+                await repository.InsertAsync(batch, stoppingToken).ConfigureAwait(false);
+
+                _logger.LogDebug("Inserted {Count} order activity logs in background batch.", batch.Count);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Order activity log dispatcher failed processing a batch.");
+                await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private List<OrderActivityLogWrite> DrainBatch()
+    {
+        var batch = new List<OrderActivityLogWrite>(MaxBatchSize);
+
+        while (batch.Count < MaxBatchSize && _channel.Reader.TryRead(out OrderActivityLogWrite? work))
+        {
+            batch.Add(work);
+        }
+
+        return batch;
+    }
+}

--- a/Ekom/Ekom/Services/OrderActivityLogService.cs
+++ b/Ekom/Ekom/Services/OrderActivityLogService.cs
@@ -1,0 +1,72 @@
+using Ekom.Models;
+using Ekom.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Ekom.Services;
+
+public sealed class OrderActivityLogService : IOrderActivityLogService
+{
+    private readonly ActivityLogRepository _activityLogRepository;
+    private readonly IOrderActivityLogDispatcher _dispatcher;
+    private readonly ILogger<OrderActivityLogService> _logger;
+
+    public OrderActivityLogService(
+        ActivityLogRepository activityLogRepository,
+        IOrderActivityLogDispatcher dispatcher,
+        ILogger<OrderActivityLogService> logger)
+    {
+        _activityLogRepository = activityLogRepository;
+        _dispatcher = dispatcher;
+        _logger = logger;
+    }
+
+    public async Task AddOrderLogAsync(Guid orderId, string message, string? userName = null, OrderActivityLogType logType = OrderActivityLogType.Info, CancellationToken ct = default)
+    {
+        if (orderId == Guid.Empty)
+        {
+            throw new ArgumentException("Order id cannot be empty.", nameof(orderId));
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            throw new ArgumentException("Message cannot be null or empty.", nameof(message));
+        }
+
+        string normalizedUserName = string.IsNullOrWhiteSpace(userName)
+            ? "Customer"
+            : userName.Trim();
+
+        await _dispatcher.EnqueueAsync(
+                new OrderActivityLogWrite(
+                    orderId,
+                    message,
+                    normalizedUserName,
+                    DateTime.Now,
+                    logType),
+                CancellationToken.None)
+            .ConfigureAwait(false);
+
+        _logger.LogDebug("Queued activity log for order {OrderId}", orderId);
+    }
+
+    public async Task<IReadOnlyList<OrderActivityLogEntry>> GetOrderLogsAsync(Guid orderId, CancellationToken ct = default)
+    {
+        if (orderId == Guid.Empty)
+        {
+            return Array.Empty<OrderActivityLogEntry>();
+        }
+
+        List<OrderActivityLog> logs = await _activityLogRepository.GetLogsAsync(orderId)
+            .ConfigureAwait(false);
+
+        return logs
+            .Select(x => new OrderActivityLogEntry
+            {
+                Message = x.Log,
+                UserName = x.UserName,
+                Date = x.Date,
+                LogType = x.LogType,
+            })
+            .ToList();
+    }
+}

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -64,7 +64,7 @@ partial class OrderService
     readonly IMemberService _memberService;
     readonly DiscountCache _discountCache;
     readonly IOrderTrackingService _orderTrackingService;
-    readonly ActivityLogRepository _activityLogRepository;
+    readonly IOrderActivityLogService _orderActivityLogService;
     readonly OrderRepository _orderRepository;
     readonly CouponRepository _couponRepository;
     readonly IStoreService _storeSvc;
@@ -81,7 +81,7 @@ partial class OrderService
         Configuration config,
         OrderRepository orderRepo,
         CouponRepository couponRepository,
-        ActivityLogRepository activityLogRepository,
+        IOrderActivityLogService orderActivityLogService,
         ILogger<OrderService> logger,
         IStoreService storeService,
         IMemoryCache memoryCache,
@@ -94,7 +94,7 @@ partial class OrderService
         _config = config;
         _orderRepository = orderRepo;
         _couponRepository = couponRepository;
-        _activityLogRepository = activityLogRepository;
+        _orderActivityLogService = orderActivityLogService;
         _storeSvc = storeService;
         _discountCache = discountCache;
         _orderTrackingService = orderTrackingService;
@@ -111,7 +111,7 @@ partial class OrderService
         Configuration config,
         OrderRepository orderRepo,
         CouponRepository couponRepository,
-        ActivityLogRepository activityLogRepository,
+        IOrderActivityLogService orderActivityLogService,
         ILogger<OrderService> logger,
         IStoreService storeService,
         IMemoryCache memoryCache,
@@ -119,7 +119,7 @@ partial class OrderService
         DiscountCache discountCache,
         IOrderTrackingService orderTrackingService,
         IHttpContextAccessor httpContextAccessor)
-        : this(config, orderRepo, couponRepository, activityLogRepository, logger, storeService, memoryCache, memberService, discountCache, orderTrackingService)
+        : this(config, orderRepo, couponRepository, orderActivityLogService, logger, storeService, memoryCache, memberService, discountCache, orderTrackingService)
     {
 
         try
@@ -429,12 +429,11 @@ partial class OrderService
 
         }
 
-        await _activityLogRepository.InsertAsync(
+        await _orderActivityLogService.AddOrderLogAsync(
             uniqueId,
             $"Order status changed. From: {oldStatus.ToString()} To: {status.ToString()}",
-            string.IsNullOrEmpty(userName)
-                ? "Customer"
-                : userName)
+            userName,
+            ct: ct)
             .ConfigureAwait(false);
 
         _logger.LogDebug(
@@ -1155,6 +1154,8 @@ partial class OrderService
                     .FirstOrDefault(x => x.Product.Key == product.Key);
             }
 
+            var isNewOrderLine = false;
+
             if (orderLine != null && action != OrderAction.New)
             {
                 _logger.LogDebug("AddOrderLineToOrderInfo: existingOrderLine Found");
@@ -1212,6 +1213,7 @@ partial class OrderService
                 );
 
                 orderInfo.orderLines.Add(orderLine);
+                isNewOrderLine = true;
             }
 
             var productDiscount = product.ProductDiscount();
@@ -1257,8 +1259,19 @@ partial class OrderService
             OrderEvents.OnUpdatedOrderline(this, updatedEventArgs);
             await OrderEvents.OnUpdatedOrderlineAsync(this, updatedEventArgs, ct);
 
-            return await UpdateOrderAndOrderInfoAsync(addedEventArgs.OrderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
+            var updatedOrderInfo = await UpdateOrderAndOrderInfoAsync(addedEventArgs.OrderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
                 .ConfigureAwait(false);
+
+            if (isNewOrderLine)
+            {
+                await _orderActivityLogService.AddOrderLogAsync(
+                        updatedOrderInfo.UniqueId,
+                        $"Order line added. Product: {orderLine.Product.Title}",
+                        ct: ct)
+                    .ConfigureAwait(false);
+            }
+
+            return updatedOrderInfo;
         }
         finally
         {
@@ -1368,6 +1381,7 @@ partial class OrderService
                 if (string.IsNullOrWhiteSpace(previousCustomerEmail)
                     && !string.IsNullOrWhiteSpace(newCustomerEmail))
                 {
+
                     await OrderEvents.OnCustomerEmailAddedAsync(this, new CustomerEmailAddedEventArgs
                     {
                         OrderInfo = orderInfo,
@@ -1734,6 +1748,8 @@ partial class OrderService
         {
             if (shippingProviderId == Guid.Empty) return orderInfo;
 
+            Guid previousShippingProviderId = orderInfo.ShippingProvider?.Key ?? Guid.Empty;
+
             IShippingProvider? provider = Providers.Instance.GetShippingProvider(shippingProviderId, store);
 
             if (provider == null) return orderInfo;
@@ -1744,8 +1760,20 @@ partial class OrderService
 
             await UpdateCustomerInformationInProvidersAsync(allData, orderInfo, ct);
 
-            return await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
+            OrderInfo updatedOrderInfo = await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
                 .ConfigureAwait(false);
+
+            if (previousShippingProviderId != provider.Key)
+            {
+                await _orderActivityLogService.AddOrderLogAsync(
+                        updatedOrderInfo.UniqueId,
+                        $"Shipping provider added. Provider: {provider.Title}",
+                        logType: OrderActivityLogType.Info,
+                        ct: ct)
+                    .ConfigureAwait(false);
+            }
+
+            return updatedOrderInfo;
 
         }
         finally
@@ -1795,6 +1823,8 @@ partial class OrderService
         {
             if (paymentProviderId == Guid.Empty) return orderInfo;
 
+            Guid previousPaymentProviderId = orderInfo.PaymentProvider?.Key ?? Guid.Empty;
+
             IPaymentProvider? provider = Providers.Instance.GetPaymentProvider(paymentProviderId, store);
 
             if (provider == null) return orderInfo;
@@ -1805,8 +1835,20 @@ partial class OrderService
 
             await UpdateCustomerInformationInProvidersAsync(allData, orderInfo, ct);
 
-            return await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
+            OrderInfo updatedOrderInfo = await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
                 .ConfigureAwait(false);
+
+            if (previousPaymentProviderId != provider.Key)
+            {
+                await _orderActivityLogService.AddOrderLogAsync(
+                        updatedOrderInfo.UniqueId,
+                        $"Payment provider added. Provider: {provider.Title}",
+                        logType: OrderActivityLogType.Info,
+                        ct: ct)
+                    .ConfigureAwait(false);
+            }
+
+            return updatedOrderInfo;
 
         }
         finally

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -3,10 +3,18 @@
 
   function controller($scope, notificationsService, resources, $document, eventsService, state, $timeout) {
     var managerState = state.getState();
+    var activityLogPreviewCharacterLimit = 180;
+    var activityLogTypeInfo = 0;
+    var activityLogTypeSuccess = 1;
+    var activityLogTypeAlert = 2;
 
     $scope.visibleDropdowns = {};
     $scope.labelDropdowns = {};
     $scope.statusList = managerState.statusList;
+    $scope.activityLogs = [];
+    $scope.activityLogsLoading = false;
+    $scope.activityLogsError = false;
+    $scope.activityLogExpandedStates = {};
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -66,6 +74,8 @@
           notify: notify.checked
         })
           .then(function () {
+            $scope.model.editModel.order.orderStatus = $scope.orderChangeStatus.value;
+            loadActivityLogs();
             notificationsService.success("Success", "Order status updated.");
             eventsService.emit("order.changed", {});
           }, function () {
@@ -210,6 +220,65 @@
         shipping.phone
       );
     };
+
+    $scope.toggleActivityLog = function (index) {
+      $scope.activityLogExpandedStates[index] = !$scope.activityLogExpandedStates[index];
+    };
+
+    $scope.isActivityLogExpanded = function (index) {
+      return !!$scope.activityLogExpandedStates[index];
+    };
+
+    $scope.canExpandActivityLog = function (log) {
+      return !!(log && log.message && log.message.length > activityLogPreviewCharacterLimit);
+    };
+
+    $scope.getActivityLogIcon = function (log) {
+      switch ((log && log.logType)) {
+        case activityLogTypeSuccess:
+          return "✓";
+        case activityLogTypeAlert:
+          return "!";
+        default:
+          return "i";
+      }
+    };
+
+    $scope.getActivityLogTypeClass = function (log) {
+      switch ((log && log.logType)) {
+        case activityLogTypeSuccess:
+          return "ekmOrderActivityLog__icon--success";
+        case activityLogTypeAlert:
+          return "ekmOrderActivityLog__icon--alert";
+        default:
+          return "ekmOrderActivityLog__icon--info";
+      }
+    };
+
+    function loadActivityLogs() {
+      var order = $scope.model && $scope.model.editModel && $scope.model.editModel.order;
+
+      if (!order || !order.uniqueId) {
+        return;
+      }
+
+      $scope.activityLogsLoading = true;
+      $scope.activityLogsError = false;
+
+      resources.OrderLogs(order.uniqueId)
+        .then(function (result) {
+          $scope.activityLogs = result.data || [];
+          $scope.activityLogExpandedStates = {};
+        }, function () {
+          $scope.activityLogs = [];
+          $scope.activityLogsError = true;
+        })
+        .finally(function () {
+          $scope.activityLogsLoading = false;
+        });
+    }
+
+    loadActivityLogs();
 
     var printOrderButton = document.getElementById("printOrder");
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -55,6 +55,9 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       OrderInfo: function (orderId) {
         return get(backofficeBaseUrl + "OrderInfo/" + orderId);
       },
+      OrderLogs: function (orderId) {
+        return get(backofficeBaseUrl + "OrderLogs/" + orderId);
+      },
       Charts: function (query) {
         return get(backofficeBaseUrl + "Charts", query);
       },

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
@@ -112,6 +112,91 @@
     flex: 1;
 }
 
+.ekmOrderActivityLog {
+    margin-top: 30px;
+}
+
+.ekmOrderActivityLog__list {
+    border-top: 1px solid #eee;
+}
+
+.ekmOrderActivityLog__item {
+    border-bottom: 1px solid #eee;
+    padding: 12px 0;
+}
+
+.ekmOrderActivityLog__content {
+    align-items: flex-start;
+    display: flex;
+    gap: 12px;
+}
+
+.ekmOrderActivityLog__body {
+    flex: 1;
+    min-width: 0;
+}
+
+.ekmOrderActivityLog__icon {
+    align-items: center;
+    border-radius: 50%;
+    display: inline-flex;
+    flex: 0 0 20px;
+    font-size: 12px;
+    font-weight: 700;
+    height: 20px;
+    justify-content: center;
+    line-height: 1;
+    margin-top: 1px;
+    width: 20px;
+}
+
+.ekmOrderActivityLog__icon--info {
+    background: #eef3f8;
+    color: #46607a;
+}
+
+.ekmOrderActivityLog__icon--success {
+    background: #edf8f0;
+    color: #247f45;
+}
+
+.ekmOrderActivityLog__icon--alert {
+    background: #fff4e5;
+    color: #ad5f00;
+}
+
+.ekmOrderActivityLog__date {
+    color: #666;
+    font-size: 12px;
+    margin-bottom: 6px;
+}
+
+.ekmOrderActivityLog__message {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    display: -webkit-box;
+    line-height: 1.5;
+    overflow: hidden;
+    white-space: normal;
+    word-break: break-word;
+}
+
+.ekmOrderActivityLog__message--expanded {
+    -webkit-line-clamp: unset;
+    display: block;
+    overflow: visible;
+}
+
+.ekmOrderActivityLog__toggle {
+    color: #1b264f;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 8px;
+    padding: 0;
+    text-decoration: underline;
+}
+
 @media only screen and (max-width: 800px) {
     .ekmGrid {
         grid-template-columns: 1fr;

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -237,4 +237,27 @@
       </div>
     </div>
   </div>
+
+  <div class="ekmOrderActivityLog">
+    <h4>Activity log</h4>
+
+    <p ng-if="activityLogsLoading">Loading activity...</p>
+    <p ng-if="!activityLogsLoading && activityLogsError">Unable to load activity log.</p>
+    <p ng-if="!activityLogsLoading && !activityLogsError && activityLogs.length === 0">No activity yet.</p>
+
+    <div class="ekmOrderActivityLog__list" ng-if="!activityLogsLoading && !activityLogsError && activityLogs.length > 0">
+      <div class="ekmOrderActivityLog__item" ng-repeat="log in activityLogs track by $index">
+        <div class="ekmOrderActivityLog__content">
+          <span class="ekmOrderActivityLog__icon" ng-class="getActivityLogTypeClass(log)">{{ getActivityLogIcon(log) }}</span>
+          <div class="ekmOrderActivityLog__body">
+            <div class="ekmOrderActivityLog__date">{{ log.date | date:'dd. MMMM yyyy HH:mm' }}</div>
+            <div class="ekmOrderActivityLog__message" ng-class="{ 'ekmOrderActivityLog__message--expanded': isActivityLogExpanded($index) }">{{ log.message }}</div>
+            <button type="button" class="btn-reset ekmOrderActivityLog__toggle" ng-if="canExpandActivityLog(log)" ng-click="toggleActivityLog($index)">
+              {{ isActivityLogExpanded($index) ? 'Show less' : 'Show more' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </article>

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -12,7 +12,7 @@
         }
     },
     "ConnectionStrings": {
-        "umbracoDbDSN": "Server=THOR;Initial Catalog=Ekom;Authentication=Active Directory Interactive;Encrypt=True;Trust Server Certificate=True",
+        "umbracoDbDSN": "Server=THOR.intra.vettvangur.is;Initial Catalog=Ekom;Authentication=Active Directory Interactive;Encrypt=True;Trust Server Certificate=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
     },
     "Algolia": {


### PR DESCRIPTION
## Summary
- add a reusable order activity log service with batched background writes and an API method for inserting order activity logs
- add activity log types and a migration for storing info, success, and alert entries in the activity log table
- render order activity logs in the manager order view, including icons and logs for checkout, provider changes, and completed orders

## Test Plan
- build `Ekom/Ekom/Ekom.csproj`
- build `Ekom Build.sln`
- verify the manager order overlay shows activity logs with icons and expandable long messages
- verify new order events create activity log entries for checkout start, order line add, provider assignment, and order completion