### PR TITLE
fix: add optional tracking payload logging

### DIFF
--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -121,7 +121,13 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         var endpoint = _options.Value.Ga4.Testing ? "debug/mp/collect" : "mp/collect";
         var url = $"https://www.google-analytics.com/{endpoint}?measurement_id={storeOptions.MeasurementId}&api_secret={storeOptions.ApiSecret}";
-        using var content = new StringContent(JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+        var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
+        if (_options.Value.LogPurchaseEventData)
+        {
+            _logger.LogInformation("GA4 purchase event payload for store {StoreAlias}: {Payload}", request.StoreAlias, payloadJson);
+        }
+
+        using var content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
         using var response = await _httpClientFactory.CreateClient().PostAsync(url, content, ct).ConfigureAwait(false);
         var responseBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
 

--- a/Ekom/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom/Tracking/MetaTrackingService.cs
@@ -82,7 +82,13 @@ public sealed class MetaTrackingService : IMetaTrackingService
         };
 
         var url = $"{storeOptions.PixelId}/events?access_token={storeOptions.AccessToken}";
-        using var content = new StringContent(JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+        var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
+        if (_options.Value.LogPurchaseEventData)
+        {
+            _logger.LogInformation("Meta purchase event payload for store {StoreAlias}: {Payload}", request.StoreAlias, payloadJson);
+        }
+
+        using var content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)

--- a/Ekom/Ekom/Tracking/TrackingOptions.cs
+++ b/Ekom/Ekom/Tracking/TrackingOptions.cs
@@ -6,6 +6,7 @@ public sealed class TrackingOptions
 {
     public bool Enabled { get; set; }
     public bool CaptureEnabled { get; set; } = true;
+    public bool LogPurchaseEventData { get; set; }
     public string CookieName { get; set; } = "EkomTracking";
     public double CookieLifetimeDays { get; set; } = 30;
     public string? SiteBaseUrl { get; set; }

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Ekom tracking supports order-level `Consent` and `Tracking` data for automatic G
 
 - `Ekom:Tracking:Enabled` turns tracking features on or off.
 - `Ekom:Tracking:CaptureEnabled` controls whether Ekom captures consent and browser tracking data from incoming requests.
+- `Ekom:Tracking:LogPurchaseEventData` controls whether outbound GA4 and Meta purchase payloads are logged before dispatch.
 - `Ekom:Tracking:CookieName` and `Ekom:Tracking:CookieLifetimeDays` control Ekom's own tracking cookie.
 - `Ekom:Tracking:SiteBaseUrl` is used as a fallback base URL when no landing URL can be resolved from the request.
 - `Ekom:Tracking:Consent` defines the default consent cookie/header names and fallback values.
@@ -143,6 +144,7 @@ Full tracking config example:
 "Tracking": {
   "Enabled": true,
   "CaptureEnabled": true,
+  "LogPurchaseEventData": false,
   "CookieName": "EkomTracking",
   "CookieLifetimeDays": 30,
   "SiteBaseUrl": "https://www.example.com",

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -215,6 +215,7 @@
         "Tracking": {
             "Enabled": true,
             "CaptureEnabled": true,
+            "LogPurchaseEventData": false,
             "CookieName": "EkomTracking",
             "CookieLifetimeDays": 30,
             "SiteBaseUrl": "https://localhost:44317",


### PR DESCRIPTION
## Summary
- add a new `Ekom:Tracking:LogPurchaseEventData` setting to control purchase payload logging
- log outbound GA4 and Meta purchase payloads before dispatch when the setting is enabled
- document the new appsettings option in the root README and sample site config

## Test Plan
- run `dotnet build "Ekom Build.sln"`
- enable `Ekom:Tracking:LogPurchaseEventData` and verify GA4 and Meta purchase payloads are written to logs during purchase tracking