### PR TITLE
fix: add tracking activity log entries

### DIFF
--- a/Ekom/Ekom/Tracking/Ga4PurchaseRequest.cs
+++ b/Ekom/Ekom/Tracking/Ga4PurchaseRequest.cs
@@ -2,6 +2,7 @@ namespace Ekom.Tracking;
 
 public sealed class Ga4PurchaseRequest
 {
+    public Guid OrderUniqueId { get; set; }
     public string StoreAlias { get; set; } = string.Empty;
     public string? ClientId { get; set; }
     public long? SessionId { get; set; }

--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -121,7 +121,13 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         var endpoint = _options.Value.Ga4.Testing ? "debug/mp/collect" : "mp/collect";
         var url = $"https://www.google-analytics.com/{endpoint}?measurement_id={storeOptions.MeasurementId}&api_secret={storeOptions.ApiSecret}";
-        using var content = new StringContent(JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+        var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
+        if (_options.Value.LogPurchaseEventData)
+        {
+            _logger.LogInformation("GA4 purchase event payload for store {StoreAlias}: {Payload}", request.StoreAlias, payloadJson);
+        }
+
+        using var content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
         using var response = await _httpClientFactory.CreateClient().PostAsync(url, content, ct).ConfigureAwait(false);
         var responseBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
 

--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -1,5 +1,7 @@
 using Ekom.API;
 using Ekom.Models;
+using Ekom.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text;
@@ -12,15 +14,18 @@ public sealed class Ga4TrackingService : IGa4TrackingService
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<TrackingOptions> _options;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<Ga4TrackingService> _logger;
 
     public Ga4TrackingService(
         IHttpClientFactory httpClientFactory,
         IOptions<TrackingOptions> options,
+        IServiceScopeFactory scopeFactory,
         ILogger<Ga4TrackingService> logger)
     {
         _httpClientFactory = httpClientFactory;
         _options = options;
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -45,6 +50,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         var request = new Ga4PurchaseRequest
         {
+            OrderUniqueId = orderInfo.UniqueId,
             StoreAlias = orderInfo.StoreInfo.Alias,
             ClientId = clientId,
             SessionId = sessionId,
@@ -133,9 +139,12 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         if (!response.IsSuccessStatusCode)
         {
+            await WriteActivityLogAsync(request.OrderUniqueId, $"GA4 purchase event failed ({(int)response.StatusCode})").ConfigureAwait(false);
             _logger.LogWarning("GA4 tracking failed for store {StoreAlias}. Status: {StatusCode}. Response: {Response}", request.StoreAlias, response.StatusCode, responseBody);
             return;
         }
+
+        await WriteActivityLogAsync(request.OrderUniqueId, "GA4 purchase event sent").ConfigureAwait(false);
 
         if (_options.Value.Ga4.Testing && !string.IsNullOrWhiteSpace(responseBody))
         {
@@ -190,6 +199,20 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
     private static long? ParseLong(string? value)
         => long.TryParse(value, out var parsed) ? parsed : null;
+
+    private async Task WriteActivityLogAsync(Guid orderUniqueId, string message)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var activityLogRepository = scope.ServiceProvider.GetRequiredService<ActivityLogRepository>();
+            await activityLogRepository.InsertAsync(orderUniqueId, message, "System").ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write GA4 activity log for order {OrderUniqueId}.", orderUniqueId);
+        }
+    }
 
     private static string GenerateClientId()
         => $"{Random.Shared.Next(100000000, 999999999)}.{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";

--- a/Ekom/Ekom/Tracking/MetaPurchaseRequest.cs
+++ b/Ekom/Ekom/Tracking/MetaPurchaseRequest.cs
@@ -2,6 +2,7 @@ namespace Ekom.Tracking;
 
 public sealed class MetaPurchaseRequest
 {
+    public Guid OrderUniqueId { get; set; }
     public string StoreAlias { get; set; } = string.Empty;
     public string EventName { get; set; } = "Purchase";
     public long? EventTimeUnix { get; set; }

--- a/Ekom/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom/Tracking/MetaTrackingService.cs
@@ -1,5 +1,7 @@
 using Ekom.Models;
+using Ekom.Repositories;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Security.Cryptography;
@@ -18,12 +20,14 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
     private readonly HttpClient _httpClient;
     private readonly IOptions<TrackingOptions> _options;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<MetaTrackingService> _logger;
 
-    public MetaTrackingService(HttpClient httpClient, IOptions<TrackingOptions> options, ILogger<MetaTrackingService> logger)
+    public MetaTrackingService(HttpClient httpClient, IOptions<TrackingOptions> options, IServiceScopeFactory scopeFactory, ILogger<MetaTrackingService> logger)
     {
         _httpClient = httpClient;
         _options = options;
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -32,6 +36,7 @@ public sealed class MetaTrackingService : IMetaTrackingService
         var tracking = orderInfo.Tracking ?? new OrderTracking();
         var request = new MetaPurchaseRequest
         {
+            OrderUniqueId = orderInfo.UniqueId,
             StoreAlias = orderInfo.StoreInfo.Alias,
             EventTimeUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             EventId = orderInfo.OrderNumber,
@@ -94,8 +99,12 @@ public sealed class MetaTrackingService : IMetaTrackingService
         if (!response.IsSuccessStatusCode)
         {
             var responseBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            await WriteActivityLogAsync(request.OrderUniqueId, $"Meta purchase event failed ({(int)response.StatusCode})").ConfigureAwait(false);
             _logger.LogWarning("Meta tracking failed for store {StoreAlias}. Status: {StatusCode}. Response: {Response}", request.StoreAlias, response.StatusCode, responseBody);
+            return;
         }
+
+        await WriteActivityLogAsync(request.OrderUniqueId, "Meta purchase event sent").ConfigureAwait(false);
     }
 
     private object BuildEvent(MetaPurchaseRequest request)
@@ -229,5 +238,19 @@ public sealed class MetaTrackingService : IMetaTrackingService
         using var sha = SHA256.Create();
         var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
         return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+    }
+
+    private async Task WriteActivityLogAsync(Guid orderUniqueId, string message)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var activityLogRepository = scope.ServiceProvider.GetRequiredService<ActivityLogRepository>();
+            await activityLogRepository.InsertAsync(orderUniqueId, message, "System").ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write Meta activity log for order {OrderUniqueId}.", orderUniqueId);
+        }
     }
 }

--- a/Ekom/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom/Tracking/MetaTrackingService.cs
@@ -82,7 +82,13 @@ public sealed class MetaTrackingService : IMetaTrackingService
         };
 
         var url = $"{storeOptions.PixelId}/events?access_token={storeOptions.AccessToken}";
-        using var content = new StringContent(JsonSerializer.Serialize(payload, JsonOptions), Encoding.UTF8, "application/json");
+        var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
+        if (_options.Value.LogPurchaseEventData)
+        {
+            _logger.LogInformation("Meta purchase event payload for store {StoreAlias}: {Payload}", request.StoreAlias, payloadJson);
+        }
+
+        using var content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
         using var response = await _httpClient.PostAsync(url, content, ct).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)

--- a/Ekom/Ekom/Tracking/TrackingOptions.cs
+++ b/Ekom/Ekom/Tracking/TrackingOptions.cs
@@ -6,6 +6,7 @@ public sealed class TrackingOptions
 {
     public bool Enabled { get; set; }
     public bool CaptureEnabled { get; set; } = true;
+    public bool LogPurchaseEventData { get; set; }
     public string CookieName { get; set; } = "EkomTracking";
     public double CookieLifetimeDays { get; set; } = 30;
     public string? SiteBaseUrl { get; set; }

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Ekom tracking supports order-level `Consent` and `Tracking` data for automatic G
 
 - `Ekom:Tracking:Enabled` turns tracking features on or off.
 - `Ekom:Tracking:CaptureEnabled` controls whether Ekom captures consent and browser tracking data from incoming requests.
+- `Ekom:Tracking:LogPurchaseEventData` controls whether outbound GA4 and Meta purchase payloads are logged before dispatch.
 - `Ekom:Tracking:CookieName` and `Ekom:Tracking:CookieLifetimeDays` control Ekom's own tracking cookie.
 - `Ekom:Tracking:SiteBaseUrl` is used as a fallback base URL when no landing URL can be resolved from the request.
 - `Ekom:Tracking:Consent` defines the default consent cookie/header names and fallback values.
@@ -143,6 +144,7 @@ Full tracking config example:
 "Tracking": {
   "Enabled": true,
   "CaptureEnabled": true,
+  "LogPurchaseEventData": false,
   "CookieName": "EkomTracking",
   "CookieLifetimeDays": 30,
   "SiteBaseUrl": "https://www.example.com",

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -215,6 +215,7 @@
         "Tracking": {
             "Enabled": true,
             "CaptureEnabled": true,
+            "LogPurchaseEventData": false,
             "CookieName": "EkomTracking",
             "CookieLifetimeDays": 30,
             "SiteBaseUrl": "https://localhost:44317",


### PR DESCRIPTION
## Summary
- add order unique ids to GA4 and Meta purchase requests so tracking sends can be tied back to the order activity log
- write order activity log entries when GA4 and Meta purchase events succeed or fail
- keep tracking send failures non-blocking by logging any activity log write issues as warnings

## Test Plan
- run `dotnet build "Ekom Build.sln"`
- complete a checkout with GA4 and Meta tracking enabled and verify order activity logs include send success or failure entries