### PR TITLE
fix: send anonymous purchase events without tracking data

### DIFF
--- a/Ekom/Ekom.U10/TrackingAutomationEvents.cs
+++ b/Ekom/Ekom.U10/TrackingAutomationEvents.cs
@@ -31,7 +31,7 @@ internal sealed class TrackingAutomationEvents : IComponent
 
     private async Task OnCompleteCheckoutAsync(object sender, CompleteCheckoutEventArgs args, CancellationToken ct)
     {
-        if (!_options.Enabled || args.OrderInfo?.Tracking?.HasData() != true)
+        if (!_options.Enabled || args.OrderInfo == null)
         {
             return;
         }
@@ -40,10 +40,11 @@ internal sealed class TrackingAutomationEvents : IComponent
         var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
         var consent = args.OrderInfo.Consent;
 
-        if (_options.Ga4.Enabled && consentService.CanCaptureAnalytics(consent))
+        if (_options.Ga4.Enabled)
         {
             var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
             var request = ga4Service.CreatePurchaseRequest(args.OrderInfo);
+            request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(consent);
             var eventArgs = new Ga4PurchasePreparingEventArgs
             {
                 OrderInfo = args.OrderInfo,
@@ -59,10 +60,11 @@ internal sealed class TrackingAutomationEvents : IComponent
             }
         }
 
-        if (_options.Meta.Enabled && consentService.CanCaptureMarketing(consent))
+        if (_options.Meta.Enabled)
         {
             var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
             var request = metaService.CreatePurchaseRequest(args.OrderInfo);
+            request.HasMarketingConsent = consentService.CanCaptureMarketing(consent);
             var eventArgs = new MetaPurchasePreparingEventArgs
             {
                 OrderInfo = args.OrderInfo,

--- a/Ekom/Ekom/Tracking/Ga4PurchaseRequest.cs
+++ b/Ekom/Ekom/Tracking/Ga4PurchaseRequest.cs
@@ -3,6 +3,7 @@ namespace Ekom.Tracking;
 public sealed class Ga4PurchaseRequest
 {
     public string StoreAlias { get; set; } = string.Empty;
+    public bool HasAnalyticsConsent { get; set; }
     public string? ClientId { get; set; }
     public long? SessionId { get; set; }
     public string EventName { get; set; } = "purchase";

--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -99,6 +99,8 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
     public async Task SendPurchaseAsync(Ga4PurchaseRequest request, CancellationToken ct = default)
     {
+        ApplyConsent(request);
+
         var storeOptions = ResolveStore(request.StoreAlias);
         if (string.IsNullOrWhiteSpace(storeOptions?.MeasurementId) || string.IsNullOrWhiteSpace(storeOptions.ApiSecret))
         {
@@ -181,6 +183,24 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
     private TrackingStoreOptions? ResolveStore(string storeAlias)
         => _options.Value.Ga4.Stores.FirstOrDefault(x => x.Alias.Equals(storeAlias, StringComparison.OrdinalIgnoreCase));
+
+    private void ApplyConsent(Ga4PurchaseRequest request)
+    {
+        if (request.HasAnalyticsConsent)
+        {
+            return;
+        }
+
+        request.ClientId = GenerateClientId();
+        request.SessionId = null;
+        request.Source = null;
+        request.Medium = null;
+        request.Campaign = null;
+        request.Term = null;
+        request.Content = null;
+        request.Gclid = null;
+        request.Parameters.Clear();
+    }
 
     private static long? ParseLong(string? value)
         => long.TryParse(value, out var parsed) ? parsed : null;

--- a/Ekom/Ekom/Tracking/MetaPurchaseRequest.cs
+++ b/Ekom/Ekom/Tracking/MetaPurchaseRequest.cs
@@ -3,6 +3,7 @@ namespace Ekom.Tracking;
 public sealed class MetaPurchaseRequest
 {
     public string StoreAlias { get; set; } = string.Empty;
+    public bool HasMarketingConsent { get; set; }
     public string EventName { get; set; } = "Purchase";
     public long? EventTimeUnix { get; set; }
     public string? EventId { get; set; }

--- a/Ekom/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom/Tracking/MetaTrackingService.cs
@@ -68,6 +68,8 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
     public async Task SendPurchaseAsync(MetaPurchaseRequest request, CancellationToken ct = default)
     {
+        ApplyConsent(request);
+
         var storeOptions = ResolveStore(request.StoreAlias);
         if (string.IsNullOrWhiteSpace(storeOptions?.PixelId) || string.IsNullOrWhiteSpace(storeOptions.AccessToken))
         {
@@ -165,6 +167,30 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
     private TrackingStoreOptions? ResolveStore(string storeAlias)
         => _options.Value.Meta.Stores.FirstOrDefault(x => x.Alias.Equals(storeAlias, StringComparison.OrdinalIgnoreCase));
+
+    private static void ApplyConsent(MetaPurchaseRequest request)
+    {
+        if (request.HasMarketingConsent)
+        {
+            return;
+        }
+
+        request.EventSourceUrl = null;
+        request.Email = null;
+        request.Phone = null;
+        request.FirstName = null;
+        request.LastName = null;
+        request.Fbp = null;
+        request.Fbc = null;
+        request.Source = null;
+        request.Medium = null;
+        request.Campaign = null;
+        request.Term = null;
+        request.Content = null;
+        request.Gclid = null;
+        request.UserData.Clear();
+        request.CustomData.Clear();
+    }
 
     private string? ResolveTestEventCode(TrackingStoreOptions? storeOptions, string storeAlias)
     {


### PR DESCRIPTION
## Summary
- allow GA4 and Meta purchase events to be created even when the order has no captured tracking data
- carry consent state into each purchase request and strip session, attribution, browser, and user identifiers when consent is missing
- preserve anonymous purchase payloads so conversion data can still be sent without linking the event to prior session data

## Test Plan
- run `dotnet build "Ekom Build.sln"`
- complete a checkout with no stored tracking data and verify GA4 and Meta still receive purchase events
- complete a checkout without analytics or marketing consent and verify the outbound purchase payloads omit session and identifying tracking fields