### PR TITLE
fix: improve tracking error activity logs

### DIFF
--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -1,6 +1,7 @@
 using Ekom.API;
 using Ekom.Models;
 using Ekom.Repositories;
+using Ekom.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -141,12 +142,19 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         if (!response.IsSuccessStatusCode)
         {
-            await WriteActivityLogAsync(request.OrderUniqueId, $"GA4 purchase event failed ({(int)response.StatusCode})").ConfigureAwait(false);
+            await WriteActivityLogAsync(request.OrderUniqueId, $"GA4 purchase event failed ({(int)response.StatusCode})", OrderActivityLogType.Alert).ConfigureAwait(false);
             _logger.LogWarning("GA4 tracking failed for store {StoreAlias}. Status: {StatusCode}. Response: {Response}", request.StoreAlias, response.StatusCode, responseBody);
             return;
         }
 
-        await WriteActivityLogAsync(request.OrderUniqueId, "GA4 purchase event sent").ConfigureAwait(false);
+        if (_options.Value.Ga4.Testing && TryGetValidationError(responseBody, out string? validationError))
+        {
+            await WriteActivityLogAsync(request.OrderUniqueId, $"GA4 purchase event validation failed: {validationError}", OrderActivityLogType.Alert).ConfigureAwait(false);
+            _logger.LogWarning("GA4 debug validation failed for store {StoreAlias}: {ValidationError}. Response: {Response}", request.StoreAlias, validationError, responseBody);
+            return;
+        }
+
+        await WriteActivityLogAsync(request.OrderUniqueId, "GA4 purchase event sent", OrderActivityLogType.Success).ConfigureAwait(false);
 
         if (_options.Value.Ga4.Testing && !string.IsNullOrWhiteSpace(responseBody))
         {
@@ -181,7 +189,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
                 ["discount"] = item.Discount,
                 ["quantity"] = item.Quantity,
                 ["item_variant"] = item.ItemVariant
-            }).ToList()
+            }).Select(FilterNullValues).ToList()
         };
 
         if (request.SessionId.HasValue)
@@ -193,7 +201,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
         foreach (var item in request.Parameters)
             parameters[item.Key] = item.Value;
 
-        return parameters;
+        return FilterNullValues(parameters);
     }
 
     private TrackingStoreOptions? ResolveStore(string storeAlias)
@@ -214,17 +222,64 @@ public sealed class Ga4TrackingService : IGa4TrackingService
     private static long? ParseLong(string? value)
         => long.TryParse(value, out var parsed) ? parsed : null;
 
-    private async Task WriteActivityLogAsync(Guid orderUniqueId, string message)
+    private async Task WriteActivityLogAsync(Guid orderUniqueId, string message, OrderActivityLogType logType)
     {
         try
         {
             using var scope = _scopeFactory.CreateScope();
             var activityLogRepository = scope.ServiceProvider.GetRequiredService<ActivityLogRepository>();
-            await activityLogRepository.InsertAsync(orderUniqueId, message, "System").ConfigureAwait(false);
+            await activityLogRepository.InsertAsync(
+                new[]
+                {
+                    new OrderActivityLogWrite(orderUniqueId, message, "System", DateTime.Now, logType),
+                })
+                .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to write GA4 activity log for order {OrderUniqueId}.", orderUniqueId);
+        }
+    }
+
+    private static Dictionary<string, object?> FilterNullValues(Dictionary<string, object?> source)
+        => source
+            .Where(x => x.Value != null)
+            .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+
+    private static bool TryGetValidationError(string? responseBody, out string? validationError)
+    {
+        validationError = null;
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return false;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(responseBody);
+            if (!document.RootElement.TryGetProperty("validationMessages", out JsonElement validationMessages) || validationMessages.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            JsonElement.ArrayEnumerator enumerator = validationMessages.EnumerateArray();
+            if (!enumerator.MoveNext())
+            {
+                return false;
+            }
+
+            JsonElement first = enumerator.Current;
+            string? fieldPath = first.TryGetProperty("fieldPath", out JsonElement fieldPathElement) ? fieldPathElement.GetString() : null;
+            string? description = first.TryGetProperty("description", out JsonElement descriptionElement) ? descriptionElement.GetString() : null;
+            validationError = string.IsNullOrWhiteSpace(fieldPath)
+                ? description
+                : $"{fieldPath}: {description}";
+
+            return !string.IsNullOrWhiteSpace(validationError);
+        }
+        catch (JsonException)
+        {
+            return false;
         }
     }
 

--- a/Ekom/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom/Tracking/MetaTrackingService.cs
@@ -1,5 +1,6 @@
 using Ekom.Models;
 using Ekom.Repositories;
+using Ekom.Services;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -75,6 +76,13 @@ public sealed class MetaTrackingService : IMetaTrackingService
     {
         ApplyConsent(request);
 
+        if (!HasMatchableUserData(request))
+        {
+            await WriteActivityLogAsync(request.OrderUniqueId, "Meta purchase event skipped: insufficient customer information for matching", OrderActivityLogType.Alert).ConfigureAwait(false);
+            _logger.LogWarning("Meta tracking skipped for store {StoreAlias} because no matchable customer information is available.", request.StoreAlias);
+            return;
+        }
+
         var storeOptions = ResolveStore(request.StoreAlias);
         if (string.IsNullOrWhiteSpace(storeOptions?.PixelId) || string.IsNullOrWhiteSpace(storeOptions.AccessToken))
         {
@@ -101,12 +109,16 @@ public sealed class MetaTrackingService : IMetaTrackingService
         if (!response.IsSuccessStatusCode)
         {
             var responseBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            await WriteActivityLogAsync(request.OrderUniqueId, $"Meta purchase event failed ({(int)response.StatusCode})").ConfigureAwait(false);
+            var errorMessage = TryGetErrorMessage(responseBody, out string? parsedError)
+                ? parsedError
+                : $"Meta purchase event failed ({(int)response.StatusCode})";
+
+            await WriteActivityLogAsync(request.OrderUniqueId, errorMessage, OrderActivityLogType.Alert).ConfigureAwait(false);
             _logger.LogWarning("Meta tracking failed for store {StoreAlias}. Status: {StatusCode}. Response: {Response}", request.StoreAlias, response.StatusCode, responseBody);
             return;
         }
 
-        await WriteActivityLogAsync(request.OrderUniqueId, "Meta purchase event sent").ConfigureAwait(false);
+        await WriteActivityLogAsync(request.OrderUniqueId, "Meta purchase event sent", OrderActivityLogType.Success).ConfigureAwait(false);
     }
 
     private object BuildEvent(MetaPurchaseRequest request)
@@ -200,6 +212,15 @@ public sealed class MetaTrackingService : IMetaTrackingService
         request.CustomData.Clear();
     }
 
+    private static bool HasMatchableUserData(MetaPurchaseRequest request)
+        => HasValue(request.Email)
+            || HasValue(request.Phone)
+            || HasValue(request.FirstName)
+            || HasValue(request.LastName)
+            || HasValue(request.Fbp)
+            || HasValue(request.Fbc)
+            || request.UserData.Any(x => HasValue(x.Value));
+
     private string? ResolveTestEventCode(TrackingStoreOptions? storeOptions, string storeAlias)
     {
         if (!_options.Value.Meta.Testing)
@@ -259,17 +280,67 @@ public sealed class MetaTrackingService : IMetaTrackingService
         return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
     }
 
-    private async Task WriteActivityLogAsync(Guid orderUniqueId, string message)
+    private async Task WriteActivityLogAsync(Guid orderUniqueId, string message, OrderActivityLogType logType)
     {
         try
         {
             using var scope = _scopeFactory.CreateScope();
             var activityLogRepository = scope.ServiceProvider.GetRequiredService<ActivityLogRepository>();
-            await activityLogRepository.InsertAsync(orderUniqueId, message, "System").ConfigureAwait(false);
+            await activityLogRepository.InsertAsync(
+                    new[]
+                    {
+                        new OrderActivityLogWrite(orderUniqueId, message, "System", DateTime.Now, logType),
+                    })
+                .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to write Meta activity log for order {OrderUniqueId}.", orderUniqueId);
         }
     }
+
+    private static bool TryGetErrorMessage(string? responseBody, out string? errorMessage)
+    {
+        errorMessage = null;
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return false;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(responseBody);
+            if (!document.RootElement.TryGetProperty("error", out JsonElement error) || error.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            string? message = error.TryGetProperty("message", out JsonElement messageElement) ? messageElement.GetString() : null;
+            string? userMessage = error.TryGetProperty("error_user_msg", out JsonElement userMessageElement) ? userMessageElement.GetString() : null;
+
+            errorMessage = string.IsNullOrWhiteSpace(userMessage)
+                ? message
+                : $"{message} - {userMessage}";
+
+            if (!string.IsNullOrWhiteSpace(errorMessage))
+            {
+                errorMessage = $"Meta purchase event failed: {errorMessage}";
+            }
+
+            return !string.IsNullOrWhiteSpace(errorMessage);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasValue(object? value)
+        => value switch
+        {
+            null => false,
+            string text => !string.IsNullOrWhiteSpace(text),
+            JsonElement element => element.ValueKind != JsonValueKind.Null && element.ValueKind != JsonValueKind.Undefined,
+            _ => true,
+        };
 }


### PR DESCRIPTION
## Summary
- treat GA4 debug validation messages as tracking failures and avoid writing success activity logs when debug validation fails
- filter null GA4 parameters before send and write success or alert activity log entries with the correct log type
- skip Meta purchase sends when no matchable customer data is available and include detailed Meta API error messages in activity log alerts

## Test Plan
- run `dotnet build "Ekom Build.sln"`
- trigger a GA4 purchase in testing mode with invalid payload data and verify the order activity log shows an alert instead of a success message
- trigger a Meta purchase without matchable customer data and verify the order activity log shows a skip or detailed alert message