### PR TITLE
fix: show order tracking details in manager

### DIFF
--- a/Ekom/Ekom.U10/EkomStartup.cs
+++ b/Ekom/Ekom.U10/EkomStartup.cs
@@ -36,8 +36,8 @@ class StartupFilter : IStartupFilter
         app.UseEkomMalformedFormGuard();
         app.UseAuthentication();
         app.UseAuthorization();
-        app.UseEkomTrackingMiddleware();
         app.UseEkomMiddleware();
+        app.UseEkomTrackingMiddleware();
         next(app);
     };
 }

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -16,6 +16,10 @@
     $scope.activityLogsError = false;
     $scope.activityLogExpandedStates = {};
 
+    var tracking = ($scope.model.editModel.order && $scope.model.editModel.order.tracking) || null;
+    $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
+    $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
+
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
     };
@@ -218,6 +222,31 @@
         shipping.country ||
         shipping.zipCode ||
         shipping.phone
+      );
+    };
+
+    $scope.hasTrackingData = function () {
+      var orderTracking = $scope.model.editModel.order && $scope.model.editModel.order.tracking;
+
+      if (!orderTracking) {
+        return false;
+      }
+
+      return !!(
+        orderTracking.source ||
+        orderTracking.medium ||
+        orderTracking.campaign ||
+        orderTracking.term ||
+        orderTracking.content ||
+        orderTracking.clickId ||
+        orderTracking.clickIdType ||
+        orderTracking.landingUrl ||
+        orderTracking.referrer ||
+        orderTracking.captureMethod ||
+        orderTracking.capturedAtUtc ||
+        orderTracking.hasCookieSupport !== null && orderTracking.hasCookieSupport !== undefined ||
+        (orderTracking.ga4 && (orderTracking.ga4.clientId || orderTracking.ga4.sessionId || $scope.ga4TrackingData.length > 0)) ||
+        (orderTracking.meta && (orderTracking.meta.fbp || orderTracking.meta.fbc || $scope.metaTrackingData.length > 0))
       );
     };
 

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
@@ -116,6 +116,24 @@
     margin-top: 30px;
 }
 
+.ekmOrderTracking {
+    margin-bottom: 30px;
+}
+
+.ekmOrderTracking__provider {
+    margin-top: 20px;
+}
+
+.ekmOrderTracking__list {
+    margin: 10px 0 0;
+    padding-left: 18px;
+}
+
+.ekmOrderTracking__wrap {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .ekmOrderActivityLog__list {
     border-top: 1px solid #eee;
 }

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -167,6 +167,49 @@
     </div>
   </div>
 
+  <div class="ekmOrderTracking">
+    <h4>Tracking</h4>
+
+    <p ng-if="!hasTrackingData()">No tracking data was captured for this order.</p>
+
+    <div class="ekmSplit" ng-if="hasTrackingData()">
+      <div class="ekmSplit__column">
+        <p ng-if="model.editModel.order.tracking.capturedAtUtc">Captured: {{ model.editModel.order.tracking.capturedAtUtc | date:'dd. MMMM yyyy HH:mm' }}</p>
+        <p ng-if="model.editModel.order.tracking.captureMethod">Capture method: {{ model.editModel.order.tracking.captureMethod }}</p>
+        <p ng-if="model.editModel.order.tracking.hasCookieSupport !== null && model.editModel.order.tracking.hasCookieSupport !== undefined">Cookie support: {{ model.editModel.order.tracking.hasCookieSupport ? 'Yes' : 'No' }}</p>
+        <p ng-if="model.editModel.order.tracking.source">Source: {{ model.editModel.order.tracking.source }}</p>
+        <p ng-if="model.editModel.order.tracking.medium">Medium: {{ model.editModel.order.tracking.medium }}</p>
+        <p ng-if="model.editModel.order.tracking.campaign">Campaign: {{ model.editModel.order.tracking.campaign }}</p>
+        <p ng-if="model.editModel.order.tracking.term">Term: {{ model.editModel.order.tracking.term }}</p>
+        <p ng-if="model.editModel.order.tracking.content">Content: {{ model.editModel.order.tracking.content }}</p>
+        <p ng-if="model.editModel.order.tracking.clickId">Click ID: {{ model.editModel.order.tracking.clickId }}</p>
+        <p ng-if="model.editModel.order.tracking.clickIdType">Click ID Type: {{ model.editModel.order.tracking.clickIdType }}</p>
+        <p ng-if="model.editModel.order.tracking.landingUrl" class="ekmOrderTracking__wrap">Landing URL: {{ model.editModel.order.tracking.landingUrl }}</p>
+        <p ng-if="model.editModel.order.tracking.referrer" class="ekmOrderTracking__wrap">Referrer: {{ model.editModel.order.tracking.referrer }}</p>
+      </div>
+
+      <div class="ekmSplit__column">
+        <div ng-if="model.editModel.order.tracking.ga4.clientId || model.editModel.order.tracking.ga4.sessionId || ga4TrackingData.length > 0">
+          <h5>GA4</h5>
+          <p ng-if="model.editModel.order.tracking.ga4.clientId" class="ekmOrderTracking__wrap">Client ID: {{ model.editModel.order.tracking.ga4.clientId }}</p>
+          <p ng-if="model.editModel.order.tracking.ga4.sessionId">Session ID: {{ model.editModel.order.tracking.ga4.sessionId }}</p>
+          <ul ng-if="ga4TrackingData.length > 0" class="ekmOrderTracking__list">
+            <li ng-repeat="pair in ga4TrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
+          </ul>
+        </div>
+
+        <div ng-if="model.editModel.order.tracking.meta.fbp || model.editModel.order.tracking.meta.fbc || metaTrackingData.length > 0" class="ekmOrderTracking__provider">
+          <h5>Meta</h5>
+          <p ng-if="model.editModel.order.tracking.meta.fbp" class="ekmOrderTracking__wrap">FBP: {{ model.editModel.order.tracking.meta.fbp }}</p>
+          <p ng-if="model.editModel.order.tracking.meta.fbc" class="ekmOrderTracking__wrap">FBC: {{ model.editModel.order.tracking.meta.fbc }}</p>
+          <ul ng-if="metaTrackingData.length > 0" class="ekmOrderTracking__list">
+            <li ng-repeat="pair in metaTrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <h4>Order Details</h4>
 
   <div class="umb-table" style="width:100%;">


### PR DESCRIPTION
## Summary
- move Ekom middleware ahead of tracking middleware so store-specific consent resolution is available before tracking capture
- add a Tracking section to the manager order view above order lines
- show a simple fallback message when no tracking data was captured for the order

## Test Plan
- run `dotnet build "Ekom Build.sln"`
- place an order with tracking data and verify the manager order view shows the tracking section above order lines
- place an order without tracking data and verify the manager order view shows the empty tracking message