### PR TITLE
fix: improve order tracking capture and manager view

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -15,6 +15,7 @@
     $scope.activityLogsLoading = false;
     $scope.activityLogsError = false;
     $scope.activityLogExpandedStates = {};
+    $scope.isTrackingExpanded = false;
 
     var tracking = ($scope.model.editModel.order && $scope.model.editModel.order.tracking) || null;
     $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
@@ -248,6 +249,10 @@
         (orderTracking.ga4 && (orderTracking.ga4.clientId || orderTracking.ga4.sessionId || $scope.ga4TrackingData.length > 0)) ||
         (orderTracking.meta && (orderTracking.meta.fbp || orderTracking.meta.fbc || $scope.metaTrackingData.length > 0))
       );
+    };
+
+    $scope.toggleTracking = function () {
+      $scope.isTrackingExpanded = !$scope.isTrackingExpanded;
     };
 
     $scope.toggleActivityLog = function (index) {

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
@@ -117,7 +117,30 @@
 }
 
 .ekmOrderTracking {
+    border: 1px solid #d8d7d9;
+    margin-top: 30px;
     margin-bottom: 30px;
+    padding: 14px 16px;
+}
+
+.ekmOrderTracking__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.ekmOrderTracking__header--spaced {
+    margin-bottom: 12px;
+}
+
+.ekmOrderTracking__header h4 {
+    margin: 0;
+}
+
+.ekmOrderTracking__toggle {
+    color: #2152a3;
+    font-weight: 600;
 }
 
 .ekmOrderTracking__provider {

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -167,49 +167,6 @@
     </div>
   </div>
 
-  <div class="ekmOrderTracking">
-    <h4>Tracking</h4>
-
-    <p ng-if="!hasTrackingData()">No tracking data was captured for this order.</p>
-
-    <div class="ekmSplit" ng-if="hasTrackingData()">
-      <div class="ekmSplit__column">
-        <p ng-if="model.editModel.order.tracking.capturedAtUtc">Captured: {{ model.editModel.order.tracking.capturedAtUtc | date:'dd. MMMM yyyy HH:mm' }}</p>
-        <p ng-if="model.editModel.order.tracking.captureMethod">Capture method: {{ model.editModel.order.tracking.captureMethod }}</p>
-        <p ng-if="model.editModel.order.tracking.hasCookieSupport !== null && model.editModel.order.tracking.hasCookieSupport !== undefined">Cookie support: {{ model.editModel.order.tracking.hasCookieSupport ? 'Yes' : 'No' }}</p>
-        <p ng-if="model.editModel.order.tracking.source">Source: {{ model.editModel.order.tracking.source }}</p>
-        <p ng-if="model.editModel.order.tracking.medium">Medium: {{ model.editModel.order.tracking.medium }}</p>
-        <p ng-if="model.editModel.order.tracking.campaign">Campaign: {{ model.editModel.order.tracking.campaign }}</p>
-        <p ng-if="model.editModel.order.tracking.term">Term: {{ model.editModel.order.tracking.term }}</p>
-        <p ng-if="model.editModel.order.tracking.content">Content: {{ model.editModel.order.tracking.content }}</p>
-        <p ng-if="model.editModel.order.tracking.clickId">Click ID: {{ model.editModel.order.tracking.clickId }}</p>
-        <p ng-if="model.editModel.order.tracking.clickIdType">Click ID Type: {{ model.editModel.order.tracking.clickIdType }}</p>
-        <p ng-if="model.editModel.order.tracking.landingUrl" class="ekmOrderTracking__wrap">Landing URL: {{ model.editModel.order.tracking.landingUrl }}</p>
-        <p ng-if="model.editModel.order.tracking.referrer" class="ekmOrderTracking__wrap">Referrer: {{ model.editModel.order.tracking.referrer }}</p>
-      </div>
-
-      <div class="ekmSplit__column">
-        <div ng-if="model.editModel.order.tracking.ga4.clientId || model.editModel.order.tracking.ga4.sessionId || ga4TrackingData.length > 0">
-          <h5>GA4</h5>
-          <p ng-if="model.editModel.order.tracking.ga4.clientId" class="ekmOrderTracking__wrap">Client ID: {{ model.editModel.order.tracking.ga4.clientId }}</p>
-          <p ng-if="model.editModel.order.tracking.ga4.sessionId">Session ID: {{ model.editModel.order.tracking.ga4.sessionId }}</p>
-          <ul ng-if="ga4TrackingData.length > 0" class="ekmOrderTracking__list">
-            <li ng-repeat="pair in ga4TrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
-          </ul>
-        </div>
-
-        <div ng-if="model.editModel.order.tracking.meta.fbp || model.editModel.order.tracking.meta.fbc || metaTrackingData.length > 0" class="ekmOrderTracking__provider">
-          <h5>Meta</h5>
-          <p ng-if="model.editModel.order.tracking.meta.fbp" class="ekmOrderTracking__wrap">FBP: {{ model.editModel.order.tracking.meta.fbp }}</p>
-          <p ng-if="model.editModel.order.tracking.meta.fbc" class="ekmOrderTracking__wrap">FBC: {{ model.editModel.order.tracking.meta.fbc }}</p>
-          <ul ng-if="metaTrackingData.length > 0" class="ekmOrderTracking__list">
-            <li ng-repeat="pair in metaTrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <h4>Order Details</h4>
 
   <div class="umb-table" style="width:100%;">
@@ -277,6 +234,54 @@
         <div class="umb-table-cell"></div>
         <div class="umb-table-cell">Total</div>
         <div class="umb-table-cell" style="text-align: right;"><strong>{{ model.editModel.order.chargedAmount.currencyString }}</strong></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="ekmOrderTracking">
+    <div class="ekmOrderTracking__header" ng-class="{ 'ekmOrderTracking__header--spaced': isTrackingExpanded || !hasTrackingData() }">
+      <h4>Tracking</h4>
+      <button type="button" class="btn-reset ekmOrderTracking__toggle" ng-if="hasTrackingData()" ng-click="toggleTracking()">{{ isTrackingExpanded ? 'Hide' : 'Show' }}</button>
+    </div>
+
+    <p ng-if="!hasTrackingData()">No tracking data was captured for this order.</p>
+
+    <div ng-if="isTrackingExpanded && hasTrackingData()">
+      <div class="ekmSplit">
+        <div class="ekmSplit__column">
+          <p ng-if="model.editModel.order.tracking.capturedAtUtc">Captured: {{ model.editModel.order.tracking.capturedAtUtc | date:'dd. MMMM yyyy HH:mm' }}</p>
+          <p ng-if="model.editModel.order.tracking.captureMethod">Capture method: {{ model.editModel.order.tracking.captureMethod }}</p>
+          <p ng-if="model.editModel.order.tracking.hasCookieSupport !== null && model.editModel.order.tracking.hasCookieSupport !== undefined">Cookie support: {{ model.editModel.order.tracking.hasCookieSupport ? 'Yes' : 'No' }}</p>
+          <p ng-if="model.editModel.order.tracking.source">Source: {{ model.editModel.order.tracking.source }}</p>
+          <p ng-if="model.editModel.order.tracking.medium">Medium: {{ model.editModel.order.tracking.medium }}</p>
+          <p ng-if="model.editModel.order.tracking.campaign">Campaign: {{ model.editModel.order.tracking.campaign }}</p>
+          <p ng-if="model.editModel.order.tracking.term">Term: {{ model.editModel.order.tracking.term }}</p>
+          <p ng-if="model.editModel.order.tracking.content">Content: {{ model.editModel.order.tracking.content }}</p>
+          <p ng-if="model.editModel.order.tracking.clickId">Click ID: {{ model.editModel.order.tracking.clickId }}</p>
+          <p ng-if="model.editModel.order.tracking.clickIdType">Click ID Type: {{ model.editModel.order.tracking.clickIdType }}</p>
+          <p ng-if="model.editModel.order.tracking.landingUrl" class="ekmOrderTracking__wrap">Landing URL: {{ model.editModel.order.tracking.landingUrl }}</p>
+          <p ng-if="model.editModel.order.tracking.referrer" class="ekmOrderTracking__wrap">Referrer: {{ model.editModel.order.tracking.referrer }}</p>
+        </div>
+
+        <div class="ekmSplit__column">
+          <div ng-if="model.editModel.order.tracking.ga4.clientId || model.editModel.order.tracking.ga4.sessionId || ga4TrackingData.length > 0">
+            <h5>GA4</h5>
+            <p ng-if="model.editModel.order.tracking.ga4.clientId" class="ekmOrderTracking__wrap">Client ID: {{ model.editModel.order.tracking.ga4.clientId }}</p>
+            <p ng-if="model.editModel.order.tracking.ga4.sessionId">Session ID: {{ model.editModel.order.tracking.ga4.sessionId }}</p>
+            <ul ng-if="ga4TrackingData.length > 0" class="ekmOrderTracking__list">
+              <li ng-repeat="pair in ga4TrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
+            </ul>
+          </div>
+
+          <div ng-if="model.editModel.order.tracking.meta.fbp || model.editModel.order.tracking.meta.fbc || metaTrackingData.length > 0" class="ekmOrderTracking__provider">
+            <h5>Meta</h5>
+            <p ng-if="model.editModel.order.tracking.meta.fbp" class="ekmOrderTracking__wrap">FBP: {{ model.editModel.order.tracking.meta.fbp }}</p>
+            <p ng-if="model.editModel.order.tracking.meta.fbc" class="ekmOrderTracking__wrap">FBC: {{ model.editModel.order.tracking.meta.fbc }}</p>
+            <ul ng-if="metaTrackingData.length > 0" class="ekmOrderTracking__list">
+              <li ng-repeat="pair in metaTrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -1300,6 +1300,11 @@ partial class OrderService
 
             orderInfo.CustomerInformation.CustomerIpAddress = _ekmRequest?.IPAddress ?? "";
 
+            if (orderInfo.Consent == null || orderInfo.Tracking?.HasData() != true)
+            {
+                ApplyConsentAndTracking(orderInfo, null, null, replaceExisting: false);
+            }
+
             string serializedOrderInfo = JsonConvert.SerializeObject(orderInfo, EkomJsonDotNet.Settings);
 
             OrderData orderData = await _orderRepository.GetOrderAsync(orderInfo.UniqueId, ct)

--- a/Ekom/Ekom/Tracking/EkomTrackingMiddleware.cs
+++ b/Ekom/Ekom/Tracking/EkomTrackingMiddleware.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using System.IO;
 
 namespace Ekom.Tracking;
 
@@ -21,17 +22,48 @@ public sealed class EkomTrackingMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        if (_options.Value.Enabled && _options.Value.CaptureEnabled)
+        Models.OrderTracking? captured = null;
+
+        if (_options.Value.Enabled && _options.Value.CaptureEnabled && IsEligibleRequest(context.Request))
         {
-            var captured = _trackingCookieService.CaptureFromRequest(context);
-            if (captured is not null)
-            {
-                var existing = _trackingCookieService.ReadCookie(context);
-                _trackingCookieService.WriteCookie(context, Merge(existing, captured));
-            }
+            captured = _trackingCookieService.CaptureFromRequest(context);
         }
 
         await _next(context).ConfigureAwait(false);
+
+        if (captured is not null && ShouldPersistTracking(context))
+        {
+            var existing = _trackingCookieService.ReadCookie(context);
+            _trackingCookieService.WriteCookie(context, Merge(existing, captured));
+        }
+    }
+
+    private static bool IsEligibleRequest(HttpRequest request)
+    {
+        if (!HttpMethods.IsGet(request.Method) && !HttpMethods.IsHead(request.Method))
+        {
+            return false;
+        }
+
+        if (request.Path.StartsWithSegments("/umbraco", StringComparison.OrdinalIgnoreCase)
+            || request.Path.StartsWithSegments("/ekom", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !Path.HasExtension(request.Path.Value);
+    }
+
+    private static bool ShouldPersistTracking(HttpContext context)
+    {
+        if (context.Response.HasStarted)
+        {
+            return false;
+        }
+
+        var contentType = context.Response.ContentType;
+        return !string.IsNullOrWhiteSpace(contentType)
+            && contentType.StartsWith("text/html", StringComparison.OrdinalIgnoreCase);
     }
 
     private static Models.OrderTracking Merge(Models.OrderTracking? existing, Models.OrderTracking incoming)

--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -154,12 +154,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
             return;
         }
 
-        await WriteActivityLogAsync(request.OrderUniqueId, "GA4 purchase event sent", OrderActivityLogType.Success).ConfigureAwait(false);
-
-        if (_options.Value.Ga4.Testing && !string.IsNullOrWhiteSpace(responseBody))
-        {
-            _logger.LogInformation("GA4 debug response for store {StoreAlias}: {Response}", request.StoreAlias, responseBody);
-        }
+        await WriteActivityLogAsync(request.OrderUniqueId, "GA4 purchase event successfully sent", OrderActivityLogType.Success).ConfigureAwait(false);
     }
 
     private object BuildParameters(Ga4PurchaseRequest request)

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -15,6 +15,11 @@
     $scope.activityLogsLoading = false;
     $scope.activityLogsError = false;
     $scope.activityLogExpandedStates = {};
+    $scope.isTrackingExpanded = false;
+
+    var tracking = ($scope.model.editModel.order && $scope.model.editModel.order.tracking) || null;
+    $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
+    $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -219,6 +224,35 @@
         shipping.zipCode ||
         shipping.phone
       );
+    };
+
+    $scope.hasTrackingData = function () {
+      var orderTracking = $scope.model.editModel.order && $scope.model.editModel.order.tracking;
+
+      if (!orderTracking) {
+        return false;
+      }
+
+      return !!(
+        orderTracking.source ||
+        orderTracking.medium ||
+        orderTracking.campaign ||
+        orderTracking.term ||
+        orderTracking.content ||
+        orderTracking.clickId ||
+        orderTracking.clickIdType ||
+        orderTracking.landingUrl ||
+        orderTracking.referrer ||
+        orderTracking.captureMethod ||
+        orderTracking.capturedAtUtc ||
+        orderTracking.hasCookieSupport !== null && orderTracking.hasCookieSupport !== undefined ||
+        (orderTracking.ga4 && (orderTracking.ga4.clientId || orderTracking.ga4.sessionId || $scope.ga4TrackingData.length > 0)) ||
+        (orderTracking.meta && (orderTracking.meta.fbp || orderTracking.meta.fbc || $scope.metaTrackingData.length > 0))
+      );
+    };
+
+    $scope.toggleTracking = function () {
+      $scope.isTrackingExpanded = !$scope.isTrackingExpanded;
     };
 
     $scope.toggleActivityLog = function (index) {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/styles/ekmManagerStyles.css
@@ -116,6 +116,47 @@
     margin-top: 30px;
 }
 
+.ekmOrderTracking {
+    border: 1px solid #d8d7d9;
+    margin-top: 30px;
+    margin-bottom: 30px;
+    padding: 14px 16px;
+}
+
+.ekmOrderTracking__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.ekmOrderTracking__header--spaced {
+    margin-bottom: 12px;
+}
+
+.ekmOrderTracking__header h4 {
+    margin: 0;
+}
+
+.ekmOrderTracking__toggle {
+    color: #2152a3;
+    font-weight: 600;
+}
+
+.ekmOrderTracking__provider {
+    margin-top: 20px;
+}
+
+.ekmOrderTracking__list {
+    margin: 10px 0 0;
+    padding-left: 18px;
+}
+
+.ekmOrderTracking__wrap {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .ekmOrderActivityLog__list {
     border-top: 1px solid #eee;
 }

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -238,6 +238,54 @@
     </div>
   </div>
 
+  <div class="ekmOrderTracking">
+    <div class="ekmOrderTracking__header" ng-class="{ 'ekmOrderTracking__header--spaced': isTrackingExpanded || !hasTrackingData() }">
+      <h4>Tracking</h4>
+      <button type="button" class="btn-reset ekmOrderTracking__toggle" ng-if="hasTrackingData()" ng-click="toggleTracking()">{{ isTrackingExpanded ? 'Hide' : 'Show' }}</button>
+    </div>
+
+    <p ng-if="!hasTrackingData()">No tracking data was captured for this order.</p>
+
+    <div ng-if="isTrackingExpanded && hasTrackingData()">
+      <div class="ekmSplit">
+        <div class="ekmSplit__column">
+          <p ng-if="model.editModel.order.tracking.capturedAtUtc">Captured: {{ model.editModel.order.tracking.capturedAtUtc | date:'dd. MMMM yyyy HH:mm' }}</p>
+          <p ng-if="model.editModel.order.tracking.captureMethod">Capture method: {{ model.editModel.order.tracking.captureMethod }}</p>
+          <p ng-if="model.editModel.order.tracking.hasCookieSupport !== null && model.editModel.order.tracking.hasCookieSupport !== undefined">Cookie support: {{ model.editModel.order.tracking.hasCookieSupport ? 'Yes' : 'No' }}</p>
+          <p ng-if="model.editModel.order.tracking.source">Source: {{ model.editModel.order.tracking.source }}</p>
+          <p ng-if="model.editModel.order.tracking.medium">Medium: {{ model.editModel.order.tracking.medium }}</p>
+          <p ng-if="model.editModel.order.tracking.campaign">Campaign: {{ model.editModel.order.tracking.campaign }}</p>
+          <p ng-if="model.editModel.order.tracking.term">Term: {{ model.editModel.order.tracking.term }}</p>
+          <p ng-if="model.editModel.order.tracking.content">Content: {{ model.editModel.order.tracking.content }}</p>
+          <p ng-if="model.editModel.order.tracking.clickId">Click ID: {{ model.editModel.order.tracking.clickId }}</p>
+          <p ng-if="model.editModel.order.tracking.clickIdType">Click ID Type: {{ model.editModel.order.tracking.clickIdType }}</p>
+          <p ng-if="model.editModel.order.tracking.landingUrl" class="ekmOrderTracking__wrap">Landing URL: {{ model.editModel.order.tracking.landingUrl }}</p>
+          <p ng-if="model.editModel.order.tracking.referrer" class="ekmOrderTracking__wrap">Referrer: {{ model.editModel.order.tracking.referrer }}</p>
+        </div>
+
+        <div class="ekmSplit__column">
+          <div ng-if="model.editModel.order.tracking.ga4.clientId || model.editModel.order.tracking.ga4.sessionId || ga4TrackingData.length > 0">
+            <h5>GA4</h5>
+            <p ng-if="model.editModel.order.tracking.ga4.clientId" class="ekmOrderTracking__wrap">Client ID: {{ model.editModel.order.tracking.ga4.clientId }}</p>
+            <p ng-if="model.editModel.order.tracking.ga4.sessionId">Session ID: {{ model.editModel.order.tracking.ga4.sessionId }}</p>
+            <ul ng-if="ga4TrackingData.length > 0" class="ekmOrderTracking__list">
+              <li ng-repeat="pair in ga4TrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
+            </ul>
+          </div>
+
+          <div ng-if="model.editModel.order.tracking.meta.fbp || model.editModel.order.tracking.meta.fbc || metaTrackingData.length > 0" class="ekmOrderTracking__provider">
+            <h5>Meta</h5>
+            <p ng-if="model.editModel.order.tracking.meta.fbp" class="ekmOrderTracking__wrap">FBP: {{ model.editModel.order.tracking.meta.fbp }}</p>
+            <p ng-if="model.editModel.order.tracking.meta.fbc" class="ekmOrderTracking__wrap">FBC: {{ model.editModel.order.tracking.meta.fbc }}</p>
+            <ul ng-if="metaTrackingData.length > 0" class="ekmOrderTracking__list">
+              <li ng-repeat="pair in metaTrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="ekmOrderActivityLog">
     <h4>Activity log</h4>
 

--- a/Samples/U10/Ekom.Site/Controllers/TrackingSimulationController.cs
+++ b/Samples/U10/Ekom.Site/Controllers/TrackingSimulationController.cs
@@ -1,0 +1,138 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Net;
+using System.Text.Json;
+
+namespace Ekom.Site.Controllers;
+
+[ApiController]
+[Route("dev/tracking-simulation")]
+public sealed class TrackingSimulationController : ControllerBase
+{
+    private const string CookieHubCookieName = "cookiehub";
+    private const string GaCookieName = "_ga";
+    private const string GaSessionCookieName = "_ga_SIMULATED";
+    private const string MetaBrowserCookieName = "_fbp";
+    private const string MetaClickCookieName = "_fbc";
+
+    [HttpGet("")]
+    public IActionResult Simulate([FromQuery] string? provider = null, [FromQuery] string? redirectPath = null)
+    {
+        if (!IsLocalRequest())
+        {
+            return NotFound();
+        }
+
+        var targetProvider = string.IsNullOrWhiteSpace(provider)
+            ? "both"
+            : provider.Trim().ToUpperInvariant() switch
+            {
+                "GA4" => "ga4",
+                "META" => "meta",
+                _ => "both"
+            };
+
+        var now = DateTimeOffset.UtcNow;
+        var gclid = "test-gclid-123";
+        var fbclid = "test-fbclid-123";
+
+        WriteCookie(CookieHubCookieName, BuildCookieHubCookie(now));
+
+        if (targetProvider is "ga4" or "both")
+        {
+            WriteCookie(GaCookieName, "GA1.1.123456789.1710000000");
+            WriteCookie(GaSessionCookieName, "GS1.1.1710000000.1.1.1710000001.0.0.0");
+        }
+
+        if (targetProvider is "meta" or "both")
+        {
+            WriteCookie(MetaBrowserCookieName, $"fb.1.{now.ToUnixTimeMilliseconds()}.1234567890");
+            WriteCookie(MetaClickCookieName, $"fb.1.{now.ToUnixTimeMilliseconds()}.{fbclid}");
+        }
+
+        var finalRedirectPath = NormalizeRedirectPath(redirectPath);
+
+        var url = QueryHelpers.AddQueryString(finalRedirectPath, new Dictionary<string, string?>
+        {
+            ["utm_source"] = targetProvider == "meta" ? "facebook" : "google",
+            ["utm_medium"] = targetProvider == "meta" ? "paid-social" : "cpc",
+            ["utm_campaign"] = "tracking_simulation",
+            ["utm_term"] = "ekom-demo",
+            ["utm_content"] = targetProvider == "meta" ? "meta_ad_a" : "ga4_ad_a",
+            ["gclid"] = targetProvider is "ga4" or "both" ? gclid : null,
+            ["fbclid"] = targetProvider is "meta" or "both" ? fbclid : null,
+        });
+
+        return Redirect(url);
+    }
+
+    [HttpGet("clear")]
+    public IActionResult Clear([FromQuery] string? redirectPath = null)
+    {
+        if (!IsLocalRequest())
+        {
+            return NotFound();
+        }
+
+        DeleteCookie(CookieHubCookieName);
+        DeleteCookie(GaCookieName);
+        DeleteCookie(GaSessionCookieName);
+        DeleteCookie(MetaBrowserCookieName);
+        DeleteCookie(MetaClickCookieName);
+
+        return Redirect(NormalizeRedirectPath(redirectPath));
+    }
+
+    private bool IsLocalRequest()
+    {
+        var remoteIp = HttpContext.Connection.RemoteIpAddress;
+        if (remoteIp == null)
+        {
+            return false;
+        }
+
+        if (IPAddress.IsLoopback(remoteIp))
+        {
+            return true;
+        }
+
+        var localIp = HttpContext.Connection.LocalIpAddress;
+        return localIp != null && remoteIp.Equals(localIp);
+    }
+
+    private static string NormalizeRedirectPath(string? redirectPath)
+        => !string.IsNullOrWhiteSpace(redirectPath) && redirectPath.StartsWith("/", StringComparison.Ordinal)
+            ? redirectPath
+            : "/";
+
+    private void WriteCookie(string name, string value)
+        => Response.Cookies.Append(name, value, CreateCookieOptions());
+
+    private void DeleteCookie(string name)
+        => Response.Cookies.Delete(name, CreateCookieOptions());
+
+    private CookieOptions CreateCookieOptions()
+        => new()
+        {
+            Path = "/",
+            HttpOnly = false,
+            SameSite = SameSiteMode.Lax,
+            Secure = Request.IsHttps,
+            Expires = DateTimeOffset.UtcNow.AddDays(30)
+        };
+
+    private static string BuildCookieHubCookie(DateTimeOffset now)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            categories = new
+            {
+                analytics = true,
+                marketing = true
+            },
+            timestamp = now.UtcDateTime.ToString("O")
+        });
+
+        return Uri.EscapeDataString(payload);
+    }
+}


### PR DESCRIPTION
## Summary
- backfill missing consent and tracking data during normal order saves and limit tracking cookie capture to real page views
- improve the manager order view with a bordered, collapsible Tracking section and mirror those manager assets to the sample site
- add a local-only tracking simulation endpoint in the sample site to help test consent and purchase tracking flows without external services

## Test Plan
- run `dotnet build "Ekom Build.sln"`
- verify tracking cookies are only persisted on normal HTML page views and missing tracking is filled in on later order saves
- open an order in the manager and confirm the Tracking section appears below order details, is collapsed by default when data exists, and shows the empty message without an expand button when no tracking was captured
- use `/dev/tracking-simulation` locally in the sample site and verify tracking data is captured and displayed on the resulting order