### PR TITLE
fix(tracking): skip silent meta events without consent

### DIFF
--- a/Ekom/Ekom.Tests/Tests/MetaTrackingServiceTests.cs
+++ b/Ekom/Ekom.Tests/Tests/MetaTrackingServiceTests.cs
@@ -1,0 +1,57 @@
+using Ekom.Repositories;
+using Ekom.Tracking;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Net;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public sealed class MetaTrackingServiceTests
+{
+    [Fact]
+    public async Task SendPurchaseAsync_Does_Not_Send_Or_Clear_Data_When_Marketing_Consent_Is_Missing()
+    {
+        using var handler = new CountingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.facebook.com/v20.0/")
+        };
+        var request = new MetaPurchaseRequest
+        {
+            HasMarketingConsent = false,
+            StoreAlias = "store",
+            Email = "customer@example.com",
+            Value = 10,
+            Currency = "ISK"
+        };
+        var sut = new MetaTrackingService(
+            httpClient,
+            Options.Create(new TrackingOptions()),
+            new ThrowingServiceScopeFactory(),
+            NullLogger<MetaTrackingService>.Instance);
+
+        await sut.SendPurchaseAsync(request);
+
+        Assert.Equal(0, handler.CallCount);
+        Assert.Equal("customer@example.com", request.Email);
+    }
+
+    private sealed class CountingHttpMessageHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class ThrowingServiceScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope()
+            => throw new InvalidOperationException("Scope should not be created when consent is missing.");
+    }
+}

--- a/Ekom/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom/Tracking/Ga4TrackingService.cs
@@ -76,11 +76,6 @@ public sealed class Ga4TrackingService : IGa4TrackingService
             _logger.LogWarning("GA4 client_id missing for order {OrderNumber}. Generated fallback client_id for store {StoreAlias}.", orderInfo.OrderNumber, orderInfo.StoreInfo.Alias);
         }
 
-        if (generatedSessionId)
-        {
-            _logger.LogWarning("GA4 session_id missing for order {OrderNumber}. Generated fallback session_id for store {StoreAlias}.", orderInfo.OrderNumber, orderInfo.StoreInfo.Alias);
-        }
-
         foreach (var entry in tracking.Ga4.Data)
             request.Parameters[entry.Key] = entry.Value;
 

--- a/Ekom/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom/Tracking/MetaTrackingService.cs
@@ -74,7 +74,10 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
     public async Task SendPurchaseAsync(MetaPurchaseRequest request, CancellationToken ct = default)
     {
-        ApplyConsent(request);
+        if (!request.HasMarketingConsent)
+        {
+            return;
+        }
 
         if (!HasMatchableUserData(request))
         {
@@ -194,23 +197,6 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
     private TrackingStoreOptions? ResolveStore(string storeAlias)
         => _options.Value.Meta.Stores.FirstOrDefault(x => x.Alias.Equals(storeAlias, StringComparison.OrdinalIgnoreCase));
-
-    private static void ApplyConsent(MetaPurchaseRequest request)
-    {
-        if (request.HasMarketingConsent)
-        {
-            return;
-        }
-
-        request.Email = null;
-        request.Phone = null;
-        request.FirstName = null;
-        request.LastName = null;
-        request.Fbp = null;
-        request.Fbc = null;
-        request.UserData.Clear();
-        request.CustomData.Clear();
-    }
 
     private static bool HasMatchableUserData(MetaPurchaseRequest request)
         => HasValue(request.Email)


### PR DESCRIPTION
## Summary
- return early from Meta purchase dispatch when marketing consent is missing instead of clearing request data and emitting an insufficient matching warning
- remove the GA4 fallback session id warning while keeping fallback session generation intact
- add focused Meta tracking coverage to verify no request is sent and no customer data is cleared when consent is missing

## Test Plan
- Run `dotnet test \"Ekom/Ekom.Tests/Ekom.Tests.csproj\" --filter \"FullyQualifiedName~MetaTrackingServiceTests\"`
- Run `dotnet build \"Ekom/Ekom/Ekom.csproj\"`