### PR TITLE
fix(tracking): support CookieHub category consent

### DIFF
--- a/Ekom/Ekom.Tests/Tests/CookieHubTrackingConsentResolverTests.cs
+++ b/Ekom/Ekom.Tests/Tests/CookieHubTrackingConsentResolverTests.cs
@@ -1,5 +1,6 @@
 using Ekom.Tracking;
 using Microsoft.AspNetCore.Http;
+using System.Text;
 using Xunit;
 
 namespace Ekom.Tests.Tests;
@@ -43,6 +44,34 @@ public class CookieHubTrackingConsentResolverTests
         Assert.Null(result);
     }
 
+    [Fact]
+    public void Resolve_Returns_Consent_From_CookieHub_Category_Array()
+    {
+        var sut = new CookieHubTrackingConsentResolver();
+        var payload = "{\"answered\":true,\"allAllowed\":false,\"categories\":[1,2,3],\"timestamp\":\"2026-04-20T14:06:20.128Z\"}";
+        var httpContext = CreateHttpContext(ToBase64Url(payload));
+
+        var result = sut.Resolve(httpContext, "Store", CreateOptions("cookiehub", "cookiehub"));
+
+        Assert.NotNull(result);
+        Assert.True(result!.Analytics);
+        Assert.False(result.Marketing);
+    }
+
+    [Fact]
+    public void Resolve_Returns_Full_Consent_When_AllAllowed_Is_True()
+    {
+        var sut = new CookieHubTrackingConsentResolver();
+        var payload = "{\"answered\":true,\"allAllowed\":true,\"categories\":[],\"timestamp\":\"2026-04-20T14:06:20.128Z\"}";
+        var httpContext = CreateHttpContext(ToBase64Url(payload));
+
+        var result = sut.Resolve(httpContext, "Store", CreateOptions("cookiehub", "cookiehub"));
+
+        Assert.NotNull(result);
+        Assert.True(result!.Analytics);
+        Assert.True(result.Marketing);
+    }
+
     private static DefaultHttpContext CreateHttpContext(string cookieValue)
     {
         var httpContext = new DefaultHttpContext();
@@ -56,4 +85,10 @@ public class CookieHubTrackingConsentResolverTests
             AnalyticsCookieName = analyticsCookieName,
             MarketingCookieName = marketingCookieName
         };
+
+    private static string ToBase64Url(string value)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
 }

--- a/Ekom/Ekom/Tracking/Resolvers/CookieHubTrackingConsentResolver.cs
+++ b/Ekom/Ekom/Tracking/Resolvers/CookieHubTrackingConsentResolver.cs
@@ -1,5 +1,6 @@
 using Ekom.Models;
 using Microsoft.AspNetCore.Http;
+using System.Text;
 using System.Text.Json;
 
 namespace Ekom.Tracking;
@@ -23,22 +24,21 @@ public sealed class CookieHubTrackingConsentResolver : ITrackingConsentResolver
 
         try
         {
-            var decoded = Uri.UnescapeDataString(rawCookie);
-            using var document = JsonDocument.Parse(decoded);
-            if (!document.RootElement.TryGetProperty("categories", out var categories))
-            {
-                return null;
-            }
+            using var document = JsonDocument.Parse(DecodePayload(rawCookie));
 
-            return new OrderConsent
+            var consent = new OrderConsent
             {
-                Analytics = ReadCategory(categories, "analytics"),
-                Marketing = ReadCategory(categories, "marketing"),
+                Analytics = ReadAnalyticsConsent(document.RootElement),
+                Marketing = ReadMarketingConsent(document.RootElement),
                 ResolvedAtUtc = ReadTimestamp(document.RootElement),
                 Source = "cookiehub"
             };
+
+            return consent.Analytics.HasValue || consent.Marketing.HasValue
+                ? consent
+                : null;
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException || ex is FormatException || ex is ArgumentException)
         {
             return null;
         }
@@ -48,7 +48,91 @@ public sealed class CookieHubTrackingConsentResolver : ITrackingConsentResolver
         => string.Equals(options.AnalyticsCookieName, "cookiehub", StringComparison.OrdinalIgnoreCase)
         || string.Equals(options.MarketingCookieName, "cookiehub", StringComparison.OrdinalIgnoreCase);
 
-    private static bool? ReadCategory(JsonElement categories, string propertyName)
+    private static string DecodePayload(string rawCookie)
+    {
+        var decoded = Uri.UnescapeDataString(rawCookie);
+        if (LooksLikeJson(decoded))
+        {
+            return decoded;
+        }
+
+        return Encoding.UTF8.GetString(DecodeBase64(decoded));
+    }
+
+    private static byte[] DecodeBase64(string value)
+    {
+        try
+        {
+            return Convert.FromBase64String(value);
+        }
+        catch (FormatException)
+        {
+            var normalized = value.Replace('-', '+').Replace('_', '/');
+            var padding = normalized.Length % 4;
+            if (padding > 0)
+            {
+                normalized = normalized.PadRight(normalized.Length + (4 - padding), '=');
+            }
+
+            return Convert.FromBase64String(normalized);
+        }
+    }
+
+    private static bool LooksLikeJson(string value)
+    {
+        var trimmed = value.TrimStart();
+        return trimmed.StartsWith("{", StringComparison.Ordinal)
+            || trimmed.StartsWith("[", StringComparison.Ordinal);
+    }
+
+    private static bool? ReadAnalyticsConsent(JsonElement root)
+        => ReadCategoryConsent(root, "analytics", 3);
+
+    private static bool? ReadMarketingConsent(JsonElement root)
+        => ReadCategoryConsent(root, "marketing", 4);
+
+    private static bool? ReadCategoryConsent(JsonElement root, string propertyName, int categoryId)
+    {
+        if (TryReadAllAllowed(root, out var allAllowed) && allAllowed)
+        {
+            return true;
+        }
+
+        if (!root.TryGetProperty("categories", out var categories))
+        {
+            return null;
+        }
+
+        return categories.ValueKind switch
+        {
+            JsonValueKind.Object => ReadNamedCategory(categories, propertyName),
+            JsonValueKind.Array => ReadCategoryId(categories, categoryId),
+            _ => null
+        };
+    }
+
+    private static bool TryReadAllAllowed(JsonElement root, out bool allAllowed)
+    {
+        if (root.TryGetProperty("allAllowed", out var property))
+        {
+            if (property.ValueKind == JsonValueKind.True)
+            {
+                allAllowed = true;
+                return true;
+            }
+
+            if (property.ValueKind == JsonValueKind.False)
+            {
+                allAllowed = false;
+                return true;
+            }
+        }
+
+        allAllowed = false;
+        return false;
+    }
+
+    private static bool? ReadNamedCategory(JsonElement categories, string propertyName)
     {
         if (!categories.TryGetProperty(propertyName, out var property))
         {
@@ -60,6 +144,19 @@ public sealed class CookieHubTrackingConsentResolver : ITrackingConsentResolver
             : property.ValueKind == JsonValueKind.False
                 ? false
                 : null;
+    }
+
+    private static bool ReadCategoryId(JsonElement categories, int categoryId)
+    {
+        foreach (var item in categories.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.Number && item.TryGetInt32(out var value) && value == categoryId)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static DateTime? ReadTimestamp(JsonElement root)


### PR DESCRIPTION
## Summary
- add CookieHub consent parsing support for base64 and base64url cookie payloads as well as url-decoded JSON payloads
- interpret CookieHub category arrays so category `3` enables analytics consent and category `4` enables marketing consent, while `allAllowed` still enables both
- extend resolver coverage with focused tests for category-array and allAllowed CookieHub payloads

## Test Plan
- Run `dotnet test \"Ekom/Ekom.Tests/Ekom.Tests.csproj\" --filter \"FullyQualifiedName~CookieHubTrackingConsentResolverTests\"`