### PR TITLE
feat(manager): add order actions and consent panel

### DIFF
--- a/Ekom/Ekom.AspNetCore/Registrations.cs
+++ b/Ekom/Ekom.AspNetCore/Registrations.cs
@@ -101,6 +101,7 @@ static class Registrations
         services.AddSingleton<IOrderActivityLogDispatcher>(sp => sp.GetRequiredService<OrderActivityLogDispatcher>());
         services.AddHostedService(sp => sp.GetRequiredService<OrderActivityLogDispatcher>());
         services.AddTransient<IOrderActivityLogService, OrderActivityLogService>();
+        services.AddTransient<IOrderManagerActionService, OrderManagerActionService>();
         services.AddTransient<IProductFilterService, ProductFilterService>();
 
         services.AddSingleton<IObjectFactory<IStore>, StoreFactory>();

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -120,6 +120,43 @@
       return textArea.value;
     }
 
+    function formatOrderLinePropertyKey(key) {
+      var cleanedKey = (key || "").replace(/^orderline/i, "");
+      var spacedKey = cleanedKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+
+      if (!spacedKey) {
+        return "";
+      }
+
+      return spacedKey.charAt(0).toUpperCase() + spacedKey.slice(1);
+    }
+
+    function getOrderLineProperties(orderLine) {
+      var properties = orderLine && orderLine.orderLineInfo && orderLine.orderLineInfo.properties
+        ? orderLine.orderLineInfo.properties
+        : {};
+
+      return Object.entries(properties)
+        .filter(function (entry) {
+          return !!entry[1];
+        })
+        .map(function (entry) {
+          return {
+            key: formatOrderLinePropertyKey(entry[0]),
+            value: htmlDecode(entry[1])
+          };
+        })
+        .filter(function (entry) {
+          return !!entry.key;
+        });
+    }
+
+    var orderLines = ($scope.model.editModel.order && $scope.model.editModel.order.orderLines) || [];
+
+    orderLines.forEach(function (orderLine) {
+      orderLine.displayProperties = getOrderLineProperties(orderLine);
+    });
+
     var shippingProps = $scope.model.editModel.order.customerInformation.shipping.properties || {};
 
     $scope.extraShippingProperties = Object.entries(shippingProps)

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -7,6 +7,7 @@
     var activityLogTypeInfo = 0;
     var activityLogTypeSuccess = 1;
     var activityLogTypeAlert = 2;
+    var orderId = $scope.model && $scope.model.editModel && $scope.model.editModel.order && $scope.model.editModel.order.uniqueId;
 
     $scope.visibleDropdowns = {};
     $scope.labelDropdowns = {};
@@ -16,10 +17,12 @@
     $scope.activityLogsError = false;
     $scope.activityLogExpandedStates = {};
     $scope.isTrackingExpanded = false;
-
-    var tracking = ($scope.model.editModel.order && $scope.model.editModel.order.tracking) || null;
-    $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
-    $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
+    $scope.isConsentExpanded = false;
+    $scope.orderActions = [];
+    $scope.orderActionsLoading = false;
+    $scope.executingOrderActionKey = null;
+    $scope.ga4TrackingData = [];
+    $scope.metaTrackingData = [];
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -120,6 +123,23 @@
       return textArea.value;
     }
 
+    function parseProperties(properties, predicate) {
+      return Object.entries(properties || {})
+        .filter(function (entry) {
+          var key = entry[0];
+          var value = entry[1];
+
+          if (!value) {
+            return false;
+          }
+
+          return predicate(key, value);
+        })
+        .map(function (entry) {
+          return [entry[0], htmlDecode(entry[1])];
+        });
+    }
+
     function formatOrderLinePropertyKey(key) {
       var cleanedKey = (key || "").replace(/^orderline/i, "");
       var spacedKey = cleanedKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
@@ -151,97 +171,198 @@
         });
     }
 
-    var orderLines = ($scope.model.editModel.order && $scope.model.editModel.order.orderLines) || [];
+    function applyOrderData(order) {
+      var tracking = (order && order.tracking) || null;
+      var orderLines = (order && order.orderLines) || [];
+      var shippingProps = order.customerInformation.shipping.properties || {};
+      var customerProps = order.customerInformation.customer.properties || {};
+      var customShippingProps = (order.shippingProvider && order.shippingProvider.customData) || {};
+      var customPaymentProps = (order.paymentProvider && order.paymentProvider.customData) || {};
 
-    orderLines.forEach(function (orderLine) {
-      orderLine.displayProperties = getOrderLineProperties(orderLine);
-    });
+      $scope.model.editModel.order = order;
+      $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
+      $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
 
-    var shippingProps = $scope.model.editModel.order.customerInformation.shipping.properties || {};
+      orderLines.forEach(function (orderLine) {
+        orderLine.displayProperties = getOrderLineProperties(orderLine);
+      });
 
-    $scope.extraShippingProperties = Object.entries(shippingProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraShippingProperties = parseProperties(shippingProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("shipping") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
 
-    var customerProps = $scope.model.editModel.order.customerInformation.customer.properties || {};
-
-    $scope.extraCustomerProperties = Object.entries(customerProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraCustomerProperties = parseProperties(customerProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("customer") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
 
-    var customShippingProps = ($scope.model.editModel.order.shippingProvider && $scope.model.editModel.order.shippingProvider.customData) || {};
-
-    $scope.extraCustomShippingProperties = Object.entries(customShippingProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraCustomShippingProperties = parseProperties(customShippingProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("customshipping") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
 
-    var customPaymentProps = ($scope.model.editModel.order.paymentProvider && $scope.model.editModel.order.paymentProvider.customData) || {};
-
-    $scope.extraCustomPaymentProperties = Object.entries(customPaymentProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraCustomPaymentProperties = parseProperties(customPaymentProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("custompayment") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
+    }
+
+    function loadOrder() {
+      if (!orderId) {
+        return Promise.resolve();
+      }
+
+      return resources.OrderInfo(orderId)
+        .then(function (result) {
+          applyOrderData(result.data);
+        }, function (error) {
+          window.alert(getErrorMessage(error, "Failed to reload order."));
+        });
+    }
+
+    function loadOrderActions() {
+      if (!orderId) {
+        return Promise.resolve();
+      }
+
+      $scope.orderActionsLoading = true;
+
+      return resources.OrderActions(orderId)
+        .then(function (result) {
+          $scope.orderActions = result.data || [];
+        }, function (error) {
+          $scope.orderActions = [];
+          window.alert(getErrorMessage(error, "Failed to load order actions."));
+        })
+        .finally(function () {
+          $scope.orderActionsLoading = false;
+        });
+    }
+
+    function readBlobText(blob) {
+      if (!blob) {
+        return Promise.resolve("");
+      }
+
+      if (typeof blob.text === "function") {
+        return blob.text();
+      }
+
+      return new Promise(function (resolve, reject) {
+        var reader = new FileReader();
+        reader.onload = function () {
+          resolve(reader.result || "");
+        };
+        reader.onerror = reject;
+        reader.readAsText(blob);
+      });
+    }
+
+    function tryParseMessage(text) {
+      if (!text) {
+        return "";
+      }
+
+      try {
+        var data = JSON.parse(text);
+        return data && data.message ? data.message : text;
+      } catch (error) {
+        return text;
+      }
+    }
+
+    function getErrorMessage(response, fallbackMessage) {
+      if (!response || !response.data) {
+        return fallbackMessage;
+      }
+
+      if (typeof response.data === "string") {
+        return response.data || fallbackMessage;
+      }
+
+      if (response.data && typeof response.data.message === "string") {
+        return response.data.message || fallbackMessage;
+      }
+
+      return fallbackMessage;
+    }
+
+    function isFileResponse(response) {
+      var contentDisposition = (response.headers("content-disposition") || "").toLowerCase();
+      var contentType = (response.headers("content-type") || "").toLowerCase();
+
+      return contentDisposition.indexOf("filename=") !== -1 ||
+        contentType.indexOf("application/pdf") === 0 ||
+        contentType.indexOf("application/octet-stream") === 0 ||
+        contentType.indexOf("image/") === 0;
+    }
+
+    function refreshOrderView() {
+      return loadOrder()
+        .then(function () {
+          loadActivityLogs();
+          return loadOrderActions();
+        });
+    }
+
+    $scope.getOrderActionButtonClass = function (action) {
+      if (action && action.look === "primary") {
+        return "btn-success";
+      }
+
+      return "btn-outline umb-outline";
+    };
+
+    $scope.executeOrderAction = function (action) {
+      if (!action || !action.key || $scope.executingOrderActionKey) {
+        return;
+      }
+
+      if (action.confirmMessage && !window.confirm(action.confirmMessage)) {
+        return;
+      }
+
+      $scope.executingOrderActionKey = action.key;
+
+      resources.ExecuteOrderAction(orderId, action.key)
+        .then(function (response) {
+          if (isFileResponse(response)) {
+            var fileUrl = window.URL.createObjectURL(response.data);
+            window.open(fileUrl, "_blank");
+            return;
+          }
+
+          return readBlobText(response.data)
+            .then(function (text) {
+              var message = tryParseMessage(text);
+
+              if (message) {
+                notificationsService.success("Success", message);
+              }
+
+              return refreshOrderView();
+            });
+        }, function (error) {
+          return readBlobText(error.data)
+            .then(function (text) {
+              var message = tryParseMessage(text) || getErrorMessage(error, "Order action failed.");
+              window.alert(message);
+            });
+        })
+        .finally(function () {
+          $scope.executingOrderActionKey = null;
+        });
+    };
+
+    applyOrderData($scope.model.editModel.order);
 
     $scope.$watch("model.editModel.order.customerInformation.customer.properties", function (props) {
       var liveCustomerProps = props || {};
 
-      $scope.extraCustomerProperties = Object.entries(liveCustomerProps)
-        .filter(function (entry) {
-          var key = entry[0];
-          var value = entry[1];
-
-          return value && key.toLowerCase().startsWith("customer") && !$scope.isDefaultKey(key);
-        })
-        .map(function (entry) {
-          return [entry[0], htmlDecode(entry[1])];
-        });
+      $scope.extraCustomerProperties = parseProperties(liveCustomerProps, function (key) {
+        return key.toLowerCase().startsWith("customer") && !$scope.isDefaultKey(key);
+      });
     });
 
     $scope.hasShippingInfo = function () {
@@ -290,6 +411,37 @@
 
     $scope.toggleTracking = function () {
       $scope.isTrackingExpanded = !$scope.isTrackingExpanded;
+    };
+
+    $scope.hasConsentData = function () {
+      var consent = $scope.model.editModel.order && $scope.model.editModel.order.consent;
+
+      if (!consent) {
+        return false;
+      }
+
+      return !!(
+        consent.resolvedAtUtc ||
+        consent.source ||
+        consent.analytics !== null && consent.analytics !== undefined ||
+        consent.marketing !== null && consent.marketing !== undefined
+      );
+    };
+
+    $scope.toggleConsent = function () {
+      $scope.isConsentExpanded = !$scope.isConsentExpanded;
+    };
+
+    $scope.getConsentValueLabel = function (value) {
+      if (value === true) {
+        return "Yes";
+      }
+
+      if (value === false) {
+        return "No";
+      }
+
+      return "Unknown";
     };
 
     $scope.toggleActivityLog = function (index) {
@@ -350,6 +502,7 @@
     }
 
     loadActivityLogs();
+    loadOrderActions();
 
     var printOrderButton = document.getElementById("printOrder");
 

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -58,6 +58,16 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       OrderLogs: function (orderId) {
         return get(backofficeBaseUrl + "OrderLogs/" + orderId);
       },
+      OrderActions: function (orderId) {
+        return get(backofficeBaseUrl + "OrderActions/" + orderId);
+      },
+      ExecuteOrderAction: function (orderId, actionKey) {
+        return $http({
+          method: "POST",
+          url: backofficeBaseUrl + "OrderActions/" + orderId + "/" + encodeURIComponent(actionKey),
+          responseType: "blob"
+        });
+      },
       Charts: function (query) {
         return get(backofficeBaseUrl + "Charts", query);
       },

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -187,6 +187,9 @@
           <small ng-if="orderLine.variant" style="font-style:italic; display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
             {{ orderLine.variant.title }} <span ng-if="orderLine.variant.sku">({{ orderLine.variant.sku }})</span>
           </small>
+          <small ng-repeat="property in orderLine.displayProperties track by $index" style="display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
+            <strong>{{ property.key }}</strong>: {{ property.value }}
+          </small>
         </div>
         <div class="umb-table-cell">{{ orderLine.quantity }}</div>
         <div class="umb-table-cell">{{orderLine.product.price.withVat.currencyString}}</div>

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -27,6 +27,22 @@
     <p>Store: {{ model.editModel.order.storeInfo.alias }}</p>
     <p>Payment: <strong>{{ model.editModel.order.chargedAmount.currencyString }}</strong></p>
 
+    <div ng-if="orderActions.length > 0 || orderActionsLoading" style="margin-top:15px;">
+      <h4 style="margin-bottom:10px;">Order Actions</h4>
+      <div style="display:flex; flex-wrap:wrap; gap:10px;">
+        <button
+          type="button"
+          class="btn umb-button__button"
+          ng-repeat="action in orderActions track by action.key"
+          ng-class="getOrderActionButtonClass(action)"
+          ng-click="executeOrderAction(action)"
+          ng-disabled="!action.enabled || executingOrderActionKey === action.key">
+          {{ action.label }}
+        </button>
+      </div>
+      <p ng-if="orderActionsLoading" style="margin-top:10px;">Loading actions...</p>
+    </div>
+
   </div>
 
   <div class="ekmSplit">
@@ -286,6 +302,22 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="ekmOrderTracking">
+    <div class="ekmOrderTracking__header" ng-class="{ 'ekmOrderTracking__header--spaced': isConsentExpanded || !hasConsentData() }">
+      <h4>Consent</h4>
+      <button type="button" class="btn-reset ekmOrderTracking__toggle" ng-if="hasConsentData()" ng-click="toggleConsent()">{{ isConsentExpanded ? 'Hide' : 'Show' }}</button>
+    </div>
+
+    <p ng-if="!hasConsentData()">No consent data was captured for this order.</p>
+
+    <div ng-if="isConsentExpanded && hasConsentData()">
+      <p ng-if="model.editModel.order.consent.resolvedAtUtc">Resolved: {{ model.editModel.order.consent.resolvedAtUtc | date:'dd. MMMM yyyy HH:mm' }}</p>
+      <p ng-if="model.editModel.order.consent.source">Source: {{ model.editModel.order.consent.source }}</p>
+      <p>Analytics: {{ getConsentValueLabel(model.editModel.order.consent.analytics) }}</p>
+      <p>Marketing: {{ getConsentValueLabel(model.editModel.order.consent.marketing) }}</p>
     </div>
   </div>
 

--- a/Ekom/Ekom/Controllers/EkomManagerController.cs
+++ b/Ekom/Ekom/Controllers/EkomManagerController.cs
@@ -19,13 +19,15 @@ public class EkomManagerController : ControllerBase
     readonly IManagerAccessService _managerAccessService;
     readonly INodeService _nodeService;
     readonly IOrderActivityLogService _orderActivityLogService;
+    readonly IOrderManagerActionService _orderManagerActionService;
     readonly ILogger<EkomManagerController> _logger;
-    public EkomManagerController(ManagerRepository repo, IManagerAccessService managerAccessService, INodeService nodeService, IOrderActivityLogService orderActivityLogService, ILogger<EkomManagerController> logger)
+    public EkomManagerController(ManagerRepository repo, IManagerAccessService managerAccessService, INodeService nodeService, IOrderActivityLogService orderActivityLogService, IOrderManagerActionService orderManagerActionService, ILogger<EkomManagerController> logger)
     {
         _repo = repo;
         _managerAccessService = managerAccessService;
         _nodeService = nodeService;
         _orderActivityLogService = orderActivityLogService;
+        _orderManagerActionService = orderManagerActionService;
         _logger = logger;
     }
 
@@ -97,6 +99,80 @@ public class EkomManagerController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to get order logs. {OrderId}", orderId);
+
+            return StatusCode(500, "An unexpected error occurred.");
+        }
+    }
+
+    [HttpGet]
+    [Route("OrderActions/{orderId}")]
+    [UmbracoUserAuthorize]
+    public async Task<IActionResult> GetOrderActionsAsync(Guid orderId, CancellationToken ct = default)
+    {
+        try
+        {
+            var orderData = await _repo.GetOrderAsync(orderId, ct);
+
+            if (!CanAccessStore(orderData.StoreAlias))
+            {
+                return ForbidStore(orderData.StoreAlias);
+            }
+
+            var order = await _repo.GetOrderInfoAsync(orderId, ct);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(await _orderManagerActionService.GetActionsAsync(order, ct).ConfigureAwait(false));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get order actions. {OrderId}", orderId);
+
+            return StatusCode(500, "An unexpected error occurred.");
+        }
+    }
+
+    [HttpPost]
+    [Route("OrderActions/{orderId}/{actionKey}")]
+    [UmbracoUserAuthorize]
+    public async Task<IActionResult> ExecuteOrderActionAsync(Guid orderId, string actionKey, CancellationToken ct = default)
+    {
+        try
+        {
+            var orderData = await _repo.GetOrderAsync(orderId, ct);
+
+            if (!CanAccessStore(orderData.StoreAlias))
+            {
+                return ForbidStore(orderData.StoreAlias);
+            }
+
+            var order = await _repo.GetOrderInfoAsync(orderId, ct);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            OrderManagerActionExecutionResult? result = await _orderManagerActionService.ExecuteAsync(order, actionKey, HttpContext?.User?.Identity?.Name, ct).ConfigureAwait(false);
+
+            if (result == null)
+            {
+                return BadRequest("Unknown order action.");
+            }
+
+            return result switch
+            {
+                OrderManagerActionFileResult fileResult => File(fileResult.Content, fileResult.ContentType, fileResult.FileName),
+                OrderManagerActionBadRequestResult badRequestResult => BadRequest(badRequestResult.Message ?? "Order action failed."),
+                _ => Ok(new OrderActionExecuteResponse { Message = result.Message })
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to execute order action {ActionKey}. {OrderId}", actionKey, orderId);
 
             return StatusCode(500, "An unexpected error occurred.");
         }
@@ -266,6 +342,11 @@ public class EkomManagerController : ControllerBase
 
         public string x { get; set; } = string.Empty;
         public decimal y { get; set; }
+    }
+
+    public sealed class OrderActionExecuteResponse
+    {
+        public string? Message { get; set; }
     }
 
 

--- a/Ekom/Ekom/Models/Manager/OrderManagerAction.cs
+++ b/Ekom/Ekom/Models/Manager/OrderManagerAction.cs
@@ -1,0 +1,16 @@
+namespace Ekom.Models.Manager;
+
+public sealed class OrderManagerAction
+{
+    public required string Key { get; init; }
+
+    public required string Label { get; init; }
+
+    public string Look { get; init; } = "outline";
+
+    public bool Enabled { get; init; } = true;
+
+    public string? ConfirmMessage { get; init; }
+
+    public int SortOrder { get; init; }
+}

--- a/Ekom/Ekom/Models/Manager/OrderManagerActionExecutionResult.cs
+++ b/Ekom/Ekom/Models/Manager/OrderManagerActionExecutionResult.cs
@@ -1,0 +1,23 @@
+namespace Ekom.Models.Manager;
+
+public abstract class OrderManagerActionExecutionResult
+{
+    public string? Message { get; init; }
+}
+
+public sealed class OrderManagerActionSuccessResult : OrderManagerActionExecutionResult
+{
+}
+
+public sealed class OrderManagerActionBadRequestResult : OrderManagerActionExecutionResult
+{
+}
+
+public sealed class OrderManagerActionFileResult : OrderManagerActionExecutionResult
+{
+    public required byte[] Content { get; init; }
+
+    public required string ContentType { get; init; }
+
+    public string? FileName { get; init; }
+}

--- a/Ekom/Ekom/Services/IOrderManagerActionProvider.cs
+++ b/Ekom/Ekom/Services/IOrderManagerActionProvider.cs
@@ -1,0 +1,11 @@
+using Ekom.Models;
+using Ekom.Models.Manager;
+
+namespace Ekom.Services;
+
+public interface IOrderManagerActionProvider
+{
+    Task<IReadOnlyCollection<OrderManagerAction>> GetActionsAsync(IOrderInfo orderInfo, CancellationToken ct = default);
+
+    Task<OrderManagerActionExecutionResult?> ExecuteAsync(IOrderInfo orderInfo, string actionKey, string? userName = null, CancellationToken ct = default);
+}

--- a/Ekom/Ekom/Services/IOrderManagerActionService.cs
+++ b/Ekom/Ekom/Services/IOrderManagerActionService.cs
@@ -1,0 +1,11 @@
+using Ekom.Models;
+using Ekom.Models.Manager;
+
+namespace Ekom.Services;
+
+public interface IOrderManagerActionService
+{
+    Task<IReadOnlyCollection<OrderManagerAction>> GetActionsAsync(IOrderInfo orderInfo, CancellationToken ct = default);
+
+    Task<OrderManagerActionExecutionResult?> ExecuteAsync(IOrderInfo orderInfo, string actionKey, string? userName = null, CancellationToken ct = default);
+}

--- a/Ekom/Ekom/Services/OrderManagerActionService.cs
+++ b/Ekom/Ekom/Services/OrderManagerActionService.cs
@@ -1,0 +1,66 @@
+using Ekom.Models;
+using Ekom.Models.Manager;
+using Microsoft.Extensions.Logging;
+
+namespace Ekom.Services;
+
+public sealed class OrderManagerActionService : IOrderManagerActionService
+{
+    private readonly IEnumerable<IOrderManagerActionProvider> _providers;
+    private readonly ILogger<OrderManagerActionService> _logger;
+
+    public OrderManagerActionService(
+        IEnumerable<IOrderManagerActionProvider> providers,
+        ILogger<OrderManagerActionService> logger)
+    {
+        _providers = providers;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyCollection<OrderManagerAction>> GetActionsAsync(IOrderInfo orderInfo, CancellationToken ct = default)
+    {
+        List<OrderManagerAction> actions = new();
+        HashSet<string> keys = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (IOrderManagerActionProvider provider in _providers)
+        {
+            IReadOnlyCollection<OrderManagerAction> providerActions = await provider.GetActionsAsync(orderInfo, ct).ConfigureAwait(false);
+
+            foreach (OrderManagerAction action in providerActions)
+            {
+                if (string.IsNullOrWhiteSpace(action.Key))
+                {
+                    continue;
+                }
+
+                if (!keys.Add(action.Key))
+                {
+                    _logger.LogWarning("Duplicate order manager action key {ActionKey} ignored for order {OrderId}", action.Key, orderInfo.UniqueId);
+                    continue;
+                }
+
+                actions.Add(action);
+            }
+        }
+
+        return actions
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.Label, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<OrderManagerActionExecutionResult?> ExecuteAsync(IOrderInfo orderInfo, string actionKey, string? userName = null, CancellationToken ct = default)
+    {
+        foreach (IOrderManagerActionProvider provider in _providers)
+        {
+            OrderManagerActionExecutionResult? result = await provider.ExecuteAsync(orderInfo, actionKey, userName, ct).ConfigureAwait(false);
+
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -120,6 +120,43 @@
       return textArea.value;
     }
 
+    function formatOrderLinePropertyKey(key) {
+      var cleanedKey = (key || "").replace(/^orderline/i, "");
+      var spacedKey = cleanedKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+
+      if (!spacedKey) {
+        return "";
+      }
+
+      return spacedKey.charAt(0).toUpperCase() + spacedKey.slice(1);
+    }
+
+    function getOrderLineProperties(orderLine) {
+      var properties = orderLine && orderLine.orderLineInfo && orderLine.orderLineInfo.properties
+        ? orderLine.orderLineInfo.properties
+        : {};
+
+      return Object.entries(properties)
+        .filter(function (entry) {
+          return !!entry[1];
+        })
+        .map(function (entry) {
+          return {
+            key: formatOrderLinePropertyKey(entry[0]),
+            value: htmlDecode(entry[1])
+          };
+        })
+        .filter(function (entry) {
+          return !!entry.key;
+        });
+    }
+
+    var orderLines = ($scope.model.editModel.order && $scope.model.editModel.order.orderLines) || [];
+
+    orderLines.forEach(function (orderLine) {
+      orderLine.displayProperties = getOrderLineProperties(orderLine);
+    });
+
     var shippingProps = $scope.model.editModel.order.customerInformation.shipping.properties || {};
 
     $scope.extraShippingProperties = Object.entries(shippingProps)

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -7,6 +7,7 @@
     var activityLogTypeInfo = 0;
     var activityLogTypeSuccess = 1;
     var activityLogTypeAlert = 2;
+    var orderId = $scope.model && $scope.model.editModel && $scope.model.editModel.order && $scope.model.editModel.order.uniqueId;
 
     $scope.visibleDropdowns = {};
     $scope.labelDropdowns = {};
@@ -16,10 +17,12 @@
     $scope.activityLogsError = false;
     $scope.activityLogExpandedStates = {};
     $scope.isTrackingExpanded = false;
-
-    var tracking = ($scope.model.editModel.order && $scope.model.editModel.order.tracking) || null;
-    $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
-    $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
+    $scope.isConsentExpanded = false;
+    $scope.orderActions = [];
+    $scope.orderActionsLoading = false;
+    $scope.executingOrderActionKey = null;
+    $scope.ga4TrackingData = [];
+    $scope.metaTrackingData = [];
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -120,6 +123,23 @@
       return textArea.value;
     }
 
+    function parseProperties(properties, predicate) {
+      return Object.entries(properties || {})
+        .filter(function (entry) {
+          var key = entry[0];
+          var value = entry[1];
+
+          if (!value) {
+            return false;
+          }
+
+          return predicate(key, value);
+        })
+        .map(function (entry) {
+          return [entry[0], htmlDecode(entry[1])];
+        });
+    }
+
     function formatOrderLinePropertyKey(key) {
       var cleanedKey = (key || "").replace(/^orderline/i, "");
       var spacedKey = cleanedKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
@@ -151,97 +171,198 @@
         });
     }
 
-    var orderLines = ($scope.model.editModel.order && $scope.model.editModel.order.orderLines) || [];
+    function applyOrderData(order) {
+      var tracking = (order && order.tracking) || null;
+      var orderLines = (order && order.orderLines) || [];
+      var shippingProps = order.customerInformation.shipping.properties || {};
+      var customerProps = order.customerInformation.customer.properties || {};
+      var customShippingProps = (order.shippingProvider && order.shippingProvider.customData) || {};
+      var customPaymentProps = (order.paymentProvider && order.paymentProvider.customData) || {};
 
-    orderLines.forEach(function (orderLine) {
-      orderLine.displayProperties = getOrderLineProperties(orderLine);
-    });
+      $scope.model.editModel.order = order;
+      $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
+      $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
 
-    var shippingProps = $scope.model.editModel.order.customerInformation.shipping.properties || {};
+      orderLines.forEach(function (orderLine) {
+        orderLine.displayProperties = getOrderLineProperties(orderLine);
+      });
 
-    $scope.extraShippingProperties = Object.entries(shippingProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraShippingProperties = parseProperties(shippingProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("shipping") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
 
-    var customerProps = $scope.model.editModel.order.customerInformation.customer.properties || {};
-
-    $scope.extraCustomerProperties = Object.entries(customerProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraCustomerProperties = parseProperties(customerProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("customer") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
 
-    var customShippingProps = ($scope.model.editModel.order.shippingProvider && $scope.model.editModel.order.shippingProvider.customData) || {};
-
-    $scope.extraCustomShippingProperties = Object.entries(customShippingProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraCustomShippingProperties = parseProperties(customShippingProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("customshipping") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
 
-    var customPaymentProps = ($scope.model.editModel.order.paymentProvider && $scope.model.editModel.order.paymentProvider.customData) || {};
-
-    $scope.extraCustomPaymentProperties = Object.entries(customPaymentProps)
-      .filter(function (entry) {
-        var key = entry[0];
-        var value = entry[1];
-
-        if (!value) {
-          return false;
-        }
-
+      $scope.extraCustomPaymentProperties = parseProperties(customPaymentProps, function (key) {
         var normalisedKey = (key || "").toLowerCase();
         return normalisedKey.startsWith("custompayment") && !$scope.isDefaultKey(normalisedKey);
-      })
-      .map(function (entry) {
-        return [entry[0], htmlDecode(entry[1])];
       });
+    }
+
+    function loadOrder() {
+      if (!orderId) {
+        return Promise.resolve();
+      }
+
+      return resources.OrderInfo(orderId)
+        .then(function (result) {
+          applyOrderData(result.data);
+        }, function (error) {
+          window.alert(getErrorMessage(error, "Failed to reload order."));
+        });
+    }
+
+    function loadOrderActions() {
+      if (!orderId) {
+        return Promise.resolve();
+      }
+
+      $scope.orderActionsLoading = true;
+
+      return resources.OrderActions(orderId)
+        .then(function (result) {
+          $scope.orderActions = result.data || [];
+        }, function (error) {
+          $scope.orderActions = [];
+          window.alert(getErrorMessage(error, "Failed to load order actions."));
+        })
+        .finally(function () {
+          $scope.orderActionsLoading = false;
+        });
+    }
+
+    function readBlobText(blob) {
+      if (!blob) {
+        return Promise.resolve("");
+      }
+
+      if (typeof blob.text === "function") {
+        return blob.text();
+      }
+
+      return new Promise(function (resolve, reject) {
+        var reader = new FileReader();
+        reader.onload = function () {
+          resolve(reader.result || "");
+        };
+        reader.onerror = reject;
+        reader.readAsText(blob);
+      });
+    }
+
+    function tryParseMessage(text) {
+      if (!text) {
+        return "";
+      }
+
+      try {
+        var data = JSON.parse(text);
+        return data && data.message ? data.message : text;
+      } catch (error) {
+        return text;
+      }
+    }
+
+    function getErrorMessage(response, fallbackMessage) {
+      if (!response || !response.data) {
+        return fallbackMessage;
+      }
+
+      if (typeof response.data === "string") {
+        return response.data || fallbackMessage;
+      }
+
+      if (response.data && typeof response.data.message === "string") {
+        return response.data.message || fallbackMessage;
+      }
+
+      return fallbackMessage;
+    }
+
+    function isFileResponse(response) {
+      var contentDisposition = (response.headers("content-disposition") || "").toLowerCase();
+      var contentType = (response.headers("content-type") || "").toLowerCase();
+
+      return contentDisposition.indexOf("filename=") !== -1 ||
+        contentType.indexOf("application/pdf") === 0 ||
+        contentType.indexOf("application/octet-stream") === 0 ||
+        contentType.indexOf("image/") === 0;
+    }
+
+    function refreshOrderView() {
+      return loadOrder()
+        .then(function () {
+          loadActivityLogs();
+          return loadOrderActions();
+        });
+    }
+
+    $scope.getOrderActionButtonClass = function (action) {
+      if (action && action.look === "primary") {
+        return "btn-success";
+      }
+
+      return "btn-outline umb-outline";
+    };
+
+    $scope.executeOrderAction = function (action) {
+      if (!action || !action.key || $scope.executingOrderActionKey) {
+        return;
+      }
+
+      if (action.confirmMessage && !window.confirm(action.confirmMessage)) {
+        return;
+      }
+
+      $scope.executingOrderActionKey = action.key;
+
+      resources.ExecuteOrderAction(orderId, action.key)
+        .then(function (response) {
+          if (isFileResponse(response)) {
+            var fileUrl = window.URL.createObjectURL(response.data);
+            window.open(fileUrl, "_blank");
+            return;
+          }
+
+          return readBlobText(response.data)
+            .then(function (text) {
+              var message = tryParseMessage(text);
+
+              if (message) {
+                notificationsService.success("Success", message);
+              }
+
+              return refreshOrderView();
+            });
+        }, function (error) {
+          return readBlobText(error.data)
+            .then(function (text) {
+              var message = tryParseMessage(text) || getErrorMessage(error, "Order action failed.");
+              window.alert(message);
+            });
+        })
+        .finally(function () {
+          $scope.executingOrderActionKey = null;
+        });
+    };
+
+    applyOrderData($scope.model.editModel.order);
 
     $scope.$watch("model.editModel.order.customerInformation.customer.properties", function (props) {
       var liveCustomerProps = props || {};
 
-      $scope.extraCustomerProperties = Object.entries(liveCustomerProps)
-        .filter(function (entry) {
-          var key = entry[0];
-          var value = entry[1];
-
-          return value && key.toLowerCase().startsWith("customer") && !$scope.isDefaultKey(key);
-        })
-        .map(function (entry) {
-          return [entry[0], htmlDecode(entry[1])];
-        });
+      $scope.extraCustomerProperties = parseProperties(liveCustomerProps, function (key) {
+        return key.toLowerCase().startsWith("customer") && !$scope.isDefaultKey(key);
+      });
     });
 
     $scope.hasShippingInfo = function () {
@@ -290,6 +411,37 @@
 
     $scope.toggleTracking = function () {
       $scope.isTrackingExpanded = !$scope.isTrackingExpanded;
+    };
+
+    $scope.hasConsentData = function () {
+      var consent = $scope.model.editModel.order && $scope.model.editModel.order.consent;
+
+      if (!consent) {
+        return false;
+      }
+
+      return !!(
+        consent.resolvedAtUtc ||
+        consent.source ||
+        consent.analytics !== null && consent.analytics !== undefined ||
+        consent.marketing !== null && consent.marketing !== undefined
+      );
+    };
+
+    $scope.toggleConsent = function () {
+      $scope.isConsentExpanded = !$scope.isConsentExpanded;
+    };
+
+    $scope.getConsentValueLabel = function (value) {
+      if (value === true) {
+        return "Yes";
+      }
+
+      if (value === false) {
+        return "No";
+      }
+
+      return "Unknown";
     };
 
     $scope.toggleActivityLog = function (index) {
@@ -350,6 +502,7 @@
     }
 
     loadActivityLogs();
+    loadOrderActions();
 
     var printOrderButton = document.getElementById("printOrder");
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -58,6 +58,16 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       OrderLogs: function (orderId) {
         return get(backofficeBaseUrl + "OrderLogs/" + orderId);
       },
+      OrderActions: function (orderId) {
+        return get(backofficeBaseUrl + "OrderActions/" + orderId);
+      },
+      ExecuteOrderAction: function (orderId, actionKey) {
+        return $http({
+          method: "POST",
+          url: backofficeBaseUrl + "OrderActions/" + orderId + "/" + encodeURIComponent(actionKey),
+          responseType: "blob"
+        });
+      },
       Charts: function (query) {
         return get(backofficeBaseUrl + "Charts", query);
       },

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -187,6 +187,9 @@
           <small ng-if="orderLine.variant" style="font-style:italic; display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
             {{ orderLine.variant.title }} <span ng-if="orderLine.variant.sku">({{ orderLine.variant.sku }})</span>
           </small>
+          <small ng-repeat="property in orderLine.displayProperties track by $index" style="display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
+            <strong>{{ property.key }}</strong>: {{ property.value }}
+          </small>
         </div>
         <div class="umb-table-cell">{{ orderLine.quantity }}</div>
         <div class="umb-table-cell">{{orderLine.product.price.withVat.currencyString}}</div>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -27,6 +27,21 @@
     <p>Store: {{ model.editModel.order.storeInfo.alias }}</p>
     <p>Payment: <strong>{{ model.editModel.order.chargedAmount.currencyString }}</strong></p>
 
+    <div ng-if="orderActions.length > 0 || orderActionsLoading" style="margin-top:15px;">
+      <div style="display:flex; flex-wrap:wrap; gap:10px;">
+        <button
+          type="button"
+          class="btn umb-button__button"
+          ng-repeat="action in orderActions track by action.key"
+          ng-class="getOrderActionButtonClass(action)"
+          ng-click="executeOrderAction(action)"
+          ng-disabled="!action.enabled || executingOrderActionKey === action.key">
+          {{ action.label }}
+        </button>
+      </div>
+      <p ng-if="orderActionsLoading" style="margin-top:10px;">Loading actions...</p>
+    </div>
+
   </div>
 
   <div class="ekmSplit">
@@ -286,6 +301,22 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="ekmOrderTracking">
+    <div class="ekmOrderTracking__header" ng-class="{ 'ekmOrderTracking__header--spaced': isConsentExpanded || !hasConsentData() }">
+      <h4>Consent</h4>
+      <button type="button" class="btn-reset ekmOrderTracking__toggle" ng-if="hasConsentData()" ng-click="toggleConsent()">{{ isConsentExpanded ? 'Hide' : 'Show' }}</button>
+    </div>
+
+    <p ng-if="!hasConsentData()">No consent data was captured for this order.</p>
+
+    <div ng-if="isConsentExpanded && hasConsentData()">
+      <p ng-if="model.editModel.order.consent.resolvedAtUtc">Resolved: {{ model.editModel.order.consent.resolvedAtUtc | date:'dd. MMMM yyyy HH:mm' }}</p>
+      <p ng-if="model.editModel.order.consent.source">Source: {{ model.editModel.order.consent.source }}</p>
+      <p>Analytics: {{ getConsentValueLabel(model.editModel.order.consent.analytics) }}</p>
+      <p>Marketing: {{ getConsentValueLabel(model.editModel.order.consent.marketing) }}</p>
     </div>
   </div>
 

--- a/Samples/U10/Ekom.Site/DemoOrderManagerActionProvider.cs
+++ b/Samples/U10/Ekom.Site/DemoOrderManagerActionProvider.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using Ekom.Models;
+using Ekom.Models.Manager;
+using Ekom.Services;
+
+namespace Ekom.Site;
+
+public sealed class DemoOrderManagerActionProvider : IOrderManagerActionProvider
+{
+    private const string DemoRefreshActionKey = "demo-refresh-order";
+    private const string DemoPdfActionKey = "demo-open-pdf";
+
+    public Task<IReadOnlyCollection<OrderManagerAction>> GetActionsAsync(IOrderInfo orderInfo, CancellationToken ct = default)
+    {
+        IReadOnlyCollection<OrderManagerAction> actions = new[]
+        {
+            new OrderManagerAction
+            {
+                Key = DemoRefreshActionKey,
+                Label = "Demo Refresh",
+                Look = "primary",
+                ConfirmMessage = "Run the demo refresh action for this order?",
+                SortOrder = 10
+            },
+            new OrderManagerAction
+            {
+                Key = DemoPdfActionKey,
+                Label = "Demo PDF",
+                Look = "outline",
+                SortOrder = 20
+            }
+        };
+
+        return Task.FromResult(actions);
+    }
+
+    public Task<OrderManagerActionExecutionResult?> ExecuteAsync(IOrderInfo orderInfo, string actionKey, string? userName = null, CancellationToken ct = default)
+    {
+        OrderManagerActionExecutionResult? result = actionKey switch
+        {
+            DemoRefreshActionKey => new OrderManagerActionSuccessResult
+            {
+                Message = $"Demo refresh completed for order {orderInfo.ReferenceId}."
+            },
+            DemoPdfActionKey => new OrderManagerActionFileResult
+            {
+                Content = CreateDemoPdf(orderInfo),
+                ContentType = "application/pdf",
+                FileName = $"ekom-demo-order-{orderInfo.ReferenceId}.pdf",
+                Message = "Demo PDF generated."
+            },
+            _ => null
+        };
+
+        return Task.FromResult(result);
+    }
+
+    private static byte[] CreateDemoPdf(IOrderInfo orderInfo)
+    {
+        var title = EscapePdfText($"Ekom demo action for order {orderInfo.ReferenceId}");
+        var orderNumber = EscapePdfText($"Order number: {orderInfo.OrderNumber}");
+        var uniqueId = EscapePdfText($"Unique Id: {orderInfo.UniqueId}");
+        var streamContent = $"BT\n/F1 18 Tf\n50 780 Td\n({title}) Tj\n0 -28 Td\n/F1 12 Tf\n({orderNumber}) Tj\n0 -20 Td\n({uniqueId}) Tj\nET\n";
+        var streamLength = Encoding.ASCII.GetByteCount(streamContent);
+
+        var offsets = new List<int>();
+        var builder = new StringBuilder();
+
+        void AppendObject(string value)
+        {
+            offsets.Add(Encoding.ASCII.GetByteCount(builder.ToString()));
+            builder.Append(value);
+        }
+
+        AppendObject("%PDF-1.4\n");
+        AppendObject("1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n");
+        AppendObject("2 0 obj<< /Type /Pages /Count 1 /Kids [3 0 R] >>endobj\n");
+        AppendObject("3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>endobj\n");
+        AppendObject($"4 0 obj<< /Length {streamLength} >>stream\n{streamContent}endstream\nendobj\n");
+        AppendObject("5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n");
+
+        var xrefOffset = Encoding.ASCII.GetByteCount(builder.ToString());
+
+        builder.Append("xref\n0 6\n");
+        builder.Append("0000000000 65535 f \n");
+
+        foreach (var offset in offsets)
+        {
+            builder.Append(offset.ToString("D10"));
+            builder.Append(" 00000 n \n");
+        }
+
+        builder.Append("trailer<< /Size 6 /Root 1 0 R >>\n");
+        builder.Append("startxref\n");
+        builder.Append(xrefOffset);
+        builder.Append("\n%%EOF");
+
+        return Encoding.ASCII.GetBytes(builder.ToString());
+    }
+
+    private static string EscapePdfText(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("(", "\\(", StringComparison.Ordinal)
+            .Replace(")", "\\)", StringComparison.Ordinal);
+    }
+}

--- a/Samples/U10/Ekom.Site/Startup.cs
+++ b/Samples/U10/Ekom.Site/Startup.cs
@@ -63,6 +63,7 @@ public class Startup
         
         services.AddScoped<UmbracoService>();
         services.AddTransient<IProductFilterService, CustomProductFilterService>();
+        services.AddTransient<IOrderManagerActionProvider, DemoOrderManagerActionProvider>();
         //services.AddTransient<Service>();
         services.AddHsts(options =>
         {


### PR DESCRIPTION
## Summary
- add a backend-driven order action extension point with manager endpoints for listing and executing actions
- render generic order action buttons in the manager order view, handling file responses, success reloads, and error alerts
- add a consent panel below tracking and register two demo actions in the sample U10 site

## Test Plan
- open an order in Ekom Manager and verify the Order Actions section renders when actions are available
- execute the demo refresh action and confirm the order view reloads with a success message
- execute the demo PDF action and confirm the PDF opens in a new tab
- expand the Consent section and verify analytics, marketing, resolved time, and source render when consent data exists