### PR TITLE
fix(manager): show order line metadata in order view

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -120,6 +120,43 @@
       return textArea.value;
     }
 
+    function formatOrderLinePropertyKey(key) {
+      var cleanedKey = (key || "").replace(/^orderline/i, "");
+      var spacedKey = cleanedKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+
+      if (!spacedKey) {
+        return "";
+      }
+
+      return spacedKey.charAt(0).toUpperCase() + spacedKey.slice(1);
+    }
+
+    function getOrderLineProperties(orderLine) {
+      var properties = orderLine && orderLine.orderLineInfo && orderLine.orderLineInfo.properties
+        ? orderLine.orderLineInfo.properties
+        : {};
+
+      return Object.entries(properties)
+        .filter(function (entry) {
+          return !!entry[1];
+        })
+        .map(function (entry) {
+          return {
+            key: formatOrderLinePropertyKey(entry[0]),
+            value: htmlDecode(entry[1])
+          };
+        })
+        .filter(function (entry) {
+          return !!entry.key;
+        });
+    }
+
+    var orderLines = ($scope.model.editModel.order && $scope.model.editModel.order.orderLines) || [];
+
+    orderLines.forEach(function (orderLine) {
+      orderLine.displayProperties = getOrderLineProperties(orderLine);
+    });
+
     var shippingProps = $scope.model.editModel.order.customerInformation.shipping.properties || {};
 
     $scope.extraShippingProperties = Object.entries(shippingProps)

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -187,6 +187,9 @@
           <small ng-if="orderLine.variant" style="font-style:italic; display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
             {{ orderLine.variant.title }} <span ng-if="orderLine.variant.sku">({{ orderLine.variant.sku }})</span>
           </small>
+          <small ng-repeat="property in orderLine.displayProperties track by $index" style="display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
+            <strong>{{ property.key }}</strong>: {{ property.value }}
+          </small>
         </div>
         <div class="umb-table-cell">{{ orderLine.quantity }}</div>
         <div class="umb-table-cell">{{orderLine.product.price.withVat.currencyString}}</div>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -120,6 +120,43 @@
       return textArea.value;
     }
 
+    function formatOrderLinePropertyKey(key) {
+      var cleanedKey = (key || "").replace(/^orderline/i, "");
+      var spacedKey = cleanedKey.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+
+      if (!spacedKey) {
+        return "";
+      }
+
+      return spacedKey.charAt(0).toUpperCase() + spacedKey.slice(1);
+    }
+
+    function getOrderLineProperties(orderLine) {
+      var properties = orderLine && orderLine.orderLineInfo && orderLine.orderLineInfo.properties
+        ? orderLine.orderLineInfo.properties
+        : {};
+
+      return Object.entries(properties)
+        .filter(function (entry) {
+          return !!entry[1];
+        })
+        .map(function (entry) {
+          return {
+            key: formatOrderLinePropertyKey(entry[0]),
+            value: htmlDecode(entry[1])
+          };
+        })
+        .filter(function (entry) {
+          return !!entry.key;
+        });
+    }
+
+    var orderLines = ($scope.model.editModel.order && $scope.model.editModel.order.orderLines) || [];
+
+    orderLines.forEach(function (orderLine) {
+      orderLine.displayProperties = getOrderLineProperties(orderLine);
+    });
+
     var shippingProps = $scope.model.editModel.order.customerInformation.shipping.properties || {};
 
     $scope.extraShippingProperties = Object.entries(shippingProps)

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -187,6 +187,9 @@
           <small ng-if="orderLine.variant" style="font-style:italic; display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
             {{ orderLine.variant.title }} <span ng-if="orderLine.variant.sku">({{ orderLine.variant.sku }})</span>
           </small>
+          <small ng-repeat="property in orderLine.displayProperties track by $index" style="display:block; margin-top:3px; text-overflow: unset !important; white-space:normal !important;">
+            <strong>{{ property.key }}</strong>: {{ property.value }}
+          </small>
         </div>
         <div class="umb-table-cell">{{ orderLine.quantity }}</div>
         <div class="umb-table-cell">{{orderLine.product.price.withVat.currencyString}}</div>


### PR DESCRIPTION
## Summary
- render non-empty `orderLineInfo.properties` under the product column in the manager order view
- strip the `orderline` prefix from labels and format them for display
- mirror the order view update in the sample U10 manager files

## Test Plan
- open an order in Ekom Manager that contains `orderLineInfo.properties`
- confirm the extra values appear under the product title/SKU
- verify empty values are hidden and `orderline` prefixes are removed from labels