### PR TITLE
fix(algolia): tighten indexed product property values

### DIFF
--- a/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -2,6 +2,7 @@ using Ekom.Algolia;
 using Ekom.Algolia.Mappers;
 using Microsoft.Extensions.Options;
 using Moq;
+using System.Text.Json;
 using Xunit;
 
 namespace Ekom.Tests.Tests;
@@ -22,8 +23,11 @@ public class AlgoliaProductIndexMapperTests
         var record = mapper.Map(product.Object, CreateStore(), "products");
 
         Assert.NotNull(record);
-        Assert.Equal(["Candy", "Organic"], Assert.IsAssignableFrom<IReadOnlyList<string>>(record!.Data["categories.lvl0"]));
-        Assert.Equal(["Candy > Chocolate"], Assert.IsAssignableFrom<IReadOnlyList<string>>(record.Data["categories.lvl1"]));
+        Assert.Equal(["Candy", "Organic"], Assert.IsAssignableFrom<IReadOnlyList<string>>(record!.Data["hierarchical_categories.lvl0"]));
+        Assert.Equal(["Candy > Chocolate"], Assert.IsAssignableFrom<IReadOnlyList<string>>(record.Data["hierarchical_categories.lvl1"]));
+        Assert.Equal(
+            ["Candy", "Candy > Chocolate", "Organic"],
+            Assert.IsAssignableFrom<IReadOnlyList<string>>(record.Data["category_paths"]));
     }
 
     [Theory]
@@ -41,6 +45,108 @@ public class AlgoliaProductIndexMapperTests
 
         Assert.NotNull(record);
         Assert.Equal(expected, Assert.IsType<bool>(record!.Data["featured"]));
+    }
+
+    [Fact]
+    public void Maps_Int_Product_Properties_From_Configured_Modifier()
+    {
+        var mapper = CreateMapper(productProperties: ["stockCount|int"]);
+        var product = CreateProduct(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["stockCount"] = "0"
+        });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(0, Assert.IsType<int>(record!.Data["stockCount"]));
+    }
+
+    [Theory]
+    [InlineData("0,1", 0.1)]
+    [InlineData("0.0", 0.0)]
+    public void Maps_Decimal_Product_Properties_From_Configured_Modifier(string rawValue, decimal expected)
+    {
+        var mapper = CreateMapper(productProperties: ["weight|decimal"]);
+        var product = CreateProduct(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["weight"] = rawValue
+        });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(expected, Assert.IsType<decimal>(record!.Data["weight"]));
+    }
+
+    [Fact]
+    public void Skips_Invalid_Int_Product_Properties_From_Configured_Modifier()
+    {
+        var mapper = CreateMapper(productProperties: ["stockCount|int"]);
+        var product = CreateProduct(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["stockCount"] = "abc"
+        });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.DoesNotContain("stockCount", record!.Data.Keys);
+    }
+
+    [Fact]
+    public void Skips_Invalid_Decimal_Product_Properties_From_Configured_Modifier()
+    {
+        var mapper = CreateMapper(productProperties: ["weight|decimal"]);
+        var product = CreateProduct(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["weight"] = "abc"
+        });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.DoesNotContain("weight", record!.Data.Keys);
+    }
+
+    [Fact]
+    public void Omits_Empty_And_Whitespace_Values_From_Indexed_Record()
+    {
+        var mapper = CreateMapper(productProperties: ["emptyProp", "blankProp", "featured"]);
+        var product = CreateProduct(
+            summary: "   ",
+            description: string.Empty,
+            sku: " ",
+            url: " ",
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["emptyProp"] = string.Empty,
+                ["blankProp"] = "   ",
+                ["featured"] = "0"
+            });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Null(record!.Sku);
+        Assert.Null(record.Summary);
+        Assert.Null(record.Description);
+        Assert.Null(record.Url);
+        Assert.Null(record.ImageUrl);
+        Assert.Null(record.ImageUrls);
+        Assert.DoesNotContain("emptyProp", record.Data.Keys);
+        Assert.DoesNotContain("blankProp", record.Data.Keys);
+        Assert.False(Assert.IsType<bool>(record.Data["featured"]));
+
+        var json = JsonSerializer.Serialize(record);
+
+        Assert.DoesNotContain("Summary", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("Description", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("image_url", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ImageUrls", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("emptyProp", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("blankProp", json, StringComparison.Ordinal);
+        Assert.Contains("\"featured\":false", json, StringComparison.Ordinal);
     }
 
     private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null)
@@ -76,7 +182,11 @@ public class AlgoliaProductIndexMapperTests
 
     private static Mock<Ekom.Models.IProduct> CreateProduct(
         IReadOnlyList<Mock<Ekom.Models.ICategory>>? categories = null,
-        IReadOnlyDictionary<string, string>? properties = null)
+        IReadOnlyDictionary<string, string>? properties = null,
+        string sku = "sku",
+        string summary = "Summary",
+        string description = "Description",
+        string url = "/product")
     {
         var price = new Mock<Ekom.Models.IPrice>();
         price.SetupGet(x => x.Value).Returns(100m);
@@ -86,11 +196,11 @@ public class AlgoliaProductIndexMapperTests
 
         var product = new Mock<Ekom.Models.IProduct>();
         product.SetupGet(x => x.Key).Returns(Guid.NewGuid());
-        product.SetupGet(x => x.SKU).Returns("sku");
+        product.SetupGet(x => x.SKU).Returns(sku);
         product.SetupGet(x => x.Title).Returns("Product");
-        product.SetupGet(x => x.Summary).Returns("Summary");
-        product.SetupGet(x => x.Description).Returns("Description");
-        product.SetupGet(x => x.Url).Returns("/product");
+        product.SetupGet(x => x.Summary).Returns(summary);
+        product.SetupGet(x => x.Description).Returns(description);
+        product.SetupGet(x => x.Url).Returns(url);
         product.SetupGet(x => x.Images).Returns([]);
         product.SetupGet(x => x.UrlsWithContext).Returns([]);
         product.SetupGet(x => x.Urls).Returns([]);

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -32,6 +32,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             return null;
 
         var allowedProps = BuildAllowedProperties(product, store);
+        var allowedTransforms = allowedProps.ToDictionary(x => x.Key, x => x.Value.Transform, StringComparer.OrdinalIgnoreCase);
         var price = ResolvePrice(product, store);
         var locale = store.Locale;
         var categoryLevels = BuildCategoryLevels(product, locale);
@@ -66,22 +67,22 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         var record = new AlgoliaProductRecord
         {
             ObjectId = product.Key.ToString(),
-            Sku = product.SKU,
-            NodeName = product.Title,
+            Sku = NullIfWhiteSpace(product.SKU),
+            NodeName = NullIfWhiteSpace(product.Title),
             Title = title,
-            Summary = GetLocalizedValue(product, "summary", product.Summary, locale),
-            Description = GetLocalizedValue(product, "description", product.Description, locale),
-            Url = urls.FirstOrDefault() ?? ApplyDomain(product.Url, store.Domain),
-            ImageUrl = images.FirstOrDefault(),
-            ImageUrls = images,
+            Summary = NullIfWhiteSpace(GetLocalizedValue(product, "summary", product.Summary, locale)),
+            Description = NullIfWhiteSpace(GetLocalizedValue(product, "description", product.Description, locale)),
+            Url = NullIfWhiteSpace(urls.FirstOrDefault() ?? ApplyDomain(product.Url, store.Domain)),
+            ImageUrl = NullIfWhiteSpace(images.FirstOrDefault()),
+            ImageUrls = images.Count > 0 ? images : null,
             Price = price?.Value,
             PriceWithVat = price?.WithVat.Value,
             PriceWithoutVat = price?.WithoutVat.Value,
-            Currency = price?.Currency.CurrencyValue ?? store.Currency,
+            Currency = NullIfWhiteSpace(price?.Currency.ISOCurrencySymbol ?? store.Currency),
             Available = product.Available,
             Stock = store.IncludeStock ? product.Stock : null,
-            StoreAlias = store.Alias,
-            Locale = store.Locale,
+            StoreAlias = NullIfWhiteSpace(store.Alias),
+            Locale = NullIfWhiteSpace(store.Locale),
             CreatedAt = ToUnixTimeSeconds(product.CreateDate),
             UpdatedAt = ToUnixTimeSeconds(product.UpdateDate),
             Data = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
@@ -90,16 +91,21 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         foreach (var categoryLevel in categoryLevels)
             record.Data[categoryLevel.Key] = categoryLevel.Value;
 
+        var categoryPaths = BuildCategoryPaths(product, locale);
+
+        if (categoryPaths.Count > 0)
+            record.Data["category_paths"] = categoryPaths;
+
         foreach (var kvp in allowedProps)
         {
             var alias = kvp.Key;
-            var transform = kvp.Value;
+            var configuredField = kvp.Value;
 
             var raw = GetLocalizedValue(product, alias, product.GetValue(alias, store.Alias), locale);
             if (string.IsNullOrWhiteSpace(raw))
                 continue;
 
-            object? converted = NormalizePropertyValue(raw);
+            object? converted = NormalizePropertyValue(raw, configuredField.ValueType);
             var ctx = new AlgoliaProductFieldContext(product, store, alias, baseIndexName);
             converted = ConvertProperty(ctx, converted);
 
@@ -108,9 +114,9 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
             record.Data[alias] = converted;
 
-            if (transform != AlgoliaFieldTransform.None)
+            if (configuredField.Transform != AlgoliaFieldTransform.None)
             {
-                var unixValue = transform switch
+                var unixValue = configuredField.Transform switch
                 {
                     AlgoliaFieldTransform.UnixSeconds => TryToUnix(converted, unixMilliseconds: false),
                     AlgoliaFieldTransform.UnixMilliseconds => TryToUnix(converted, unixMilliseconds: true),
@@ -124,24 +130,26 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
         if (_enrichers.Count > 0)
         {
-            var ctx = new AlgoliaProductEnrichmentContext(product, store, baseIndexName, allowedProps);
+            var ctx = new AlgoliaProductEnrichmentContext(product, store, baseIndexName, allowedTransforms);
             foreach (var enricher in _enrichers)
                 enricher.Enrich(record, ctx);
         }
 
+        RemoveEmptyValues(record.Data);
+
         return record;
     }
 
-    private Dictionary<string, AlgoliaFieldTransform> BuildAllowedProperties(IProduct product, AlgoliaResolvedStore store)
+    private Dictionary<string, ConfiguredField> BuildAllowedProperties(IProduct product, AlgoliaResolvedStore store)
     {
         if (_options.Indexing.ProductProperties.Count == 0)
-            return new Dictionary<string, AlgoliaFieldTransform>(StringComparer.OrdinalIgnoreCase);
+            return new Dictionary<string, ConfiguredField>(StringComparer.OrdinalIgnoreCase);
 
         return _options.Indexing.ProductProperties
             .Select(ConfiguredField.Parse)
             .Where(f => !string.IsNullOrWhiteSpace(f.Alias))
             .GroupBy(f => f.Alias, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.Last().Transform, StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
     }
 
     private object? ConvertProperty(AlgoliaProductFieldContext ctx, object? value)
@@ -201,7 +209,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
             for (var i = 0; i < segments.Count; i++)
             {
-                var key = $"categories.lvl{i}";
+                var key = $"hierarchical_categories.lvl{i}";
                 if (!categoryLevels.TryGetValue(key, out var values))
                 {
                     values = [];
@@ -221,8 +229,66 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             StringComparer.OrdinalIgnoreCase);
     }
 
-    private static object NormalizePropertyValue(string value)
+    private static IReadOnlyList<string> BuildCategoryPaths(IProduct product, string? locale)
     {
+        var categoryPaths = new List<string>();
+
+        foreach (var category in product.Categories)
+        {
+            var segments = category.Ancestors
+                .Select(ancestor => GetLocalizedValue(ancestor, "title", ancestor.Title, locale))
+                .Where(title => !string.IsNullOrWhiteSpace(title))
+                .ToList();
+
+            var categoryTitle = GetLocalizedValue(category, "title", category.Title, locale);
+            if (!string.IsNullOrWhiteSpace(categoryTitle))
+                segments.Add(categoryTitle);
+
+            for (var i = 0; i < segments.Count; i++)
+            {
+                var path = string.Join(" > ", segments.Take(i + 1));
+                if (!string.IsNullOrWhiteSpace(path) && !categoryPaths.Contains(path, StringComparer.OrdinalIgnoreCase))
+                    categoryPaths.Add(path);
+            }
+        }
+
+        return categoryPaths;
+    }
+
+    private static void RemoveEmptyValues(IDictionary<string, object?> values)
+    {
+        var keysToRemove = values
+            .Where(kvp => IsEmptyValue(kvp.Value))
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in keysToRemove)
+            values.Remove(key);
+    }
+
+    private static bool IsEmptyValue(object? value)
+    {
+        return value switch
+        {
+            null => true,
+            string s => string.IsNullOrWhiteSpace(s),
+            System.Collections.IDictionary dictionary => dictionary.Count == 0,
+            System.Collections.IEnumerable enumerable when value is not string => !enumerable.Cast<object?>().Any(),
+            _ => false
+        };
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static object? NormalizePropertyValue(string value, AlgoliaFieldValueType valueType)
+    {
+        if (valueType == AlgoliaFieldValueType.Int)
+            return TryParseInt(value);
+
+        if (valueType == AlgoliaFieldValueType.Decimal)
+            return TryParseDecimal(value);
+
         if (bool.TryParse(value, out var booleanValue))
             return booleanValue;
 
@@ -232,6 +298,29 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             "1" => true,
             _ => value
         };
+    }
+
+    private static int? TryParseInt(string value)
+    {
+        var trimmedValue = value.Trim();
+        if (int.TryParse(trimmedValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
+            return intValue;
+
+        return int.TryParse(trimmedValue, NumberStyles.Integer, CultureInfo.CurrentCulture, out intValue)
+            ? intValue
+            : null;
+    }
+
+    private static decimal? TryParseDecimal(string value)
+    {
+        var trimmedValue = value.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedValue))
+            return null;
+
+        var normalizedValue = trimmedValue.Replace(',', '.');
+        return decimal.TryParse(normalizedValue, NumberStyles.Number, CultureInfo.InvariantCulture, out var decimalValue)
+            ? decimalValue
+            : null;
     }
 
     private static IPrice? ResolvePrice(IProduct product, AlgoliaResolvedStore store)
@@ -292,25 +381,34 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         return dto.ToUnixTimeSeconds();
     }
 
-    internal readonly record struct ConfiguredField(string Alias, AlgoliaFieldTransform Transform)
+    internal readonly record struct ConfiguredField(string Alias, AlgoliaFieldValueType ValueType, AlgoliaFieldTransform Transform)
     {
         public static ConfiguredField Parse(string raw)
         {
             if (string.IsNullOrWhiteSpace(raw))
-                return new ConfiguredField(string.Empty, AlgoliaFieldTransform.None);
+                return new ConfiguredField(string.Empty, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None);
 
             var parts = raw.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var alias = parts[0];
 
             if (parts.Length < 2)
-                return new ConfiguredField(alias, AlgoliaFieldTransform.None);
+                return new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None);
 
             return parts[1].ToLowerInvariant() switch
             {
-                "unix" => new ConfiguredField(alias, AlgoliaFieldTransform.UnixSeconds),
-                "unixms" => new ConfiguredField(alias, AlgoliaFieldTransform.UnixMilliseconds),
-                _ => new ConfiguredField(alias, AlgoliaFieldTransform.None)
+                "int" => new ConfiguredField(alias, AlgoliaFieldValueType.Int, AlgoliaFieldTransform.None),
+                "decimal" => new ConfiguredField(alias, AlgoliaFieldValueType.Decimal, AlgoliaFieldTransform.None),
+                "unix" => new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixSeconds),
+                "unixms" => new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixMilliseconds),
+                _ => new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None)
             };
         }
     }
+}
+
+internal enum AlgoliaFieldValueType
+{
+    None,
+    Int,
+    Decimal
 }

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
@@ -7,21 +7,40 @@ public sealed class AlgoliaProductRecord
     [JsonPropertyName("objectID")]
     public required string ObjectId { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Sku { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? NodeName { get; init; }
+
     public required string Title { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Summary { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Url { get; init; }
 
     [JsonPropertyName("image_url")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ImageUrl { get; init; }
 
-    public IReadOnlyList<string> ImageUrls { get; init; } = [];
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? ImageUrls { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public decimal? Price { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public decimal? PriceWithVat { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public decimal? PriceWithoutVat { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Currency { get; init; }
 
     public bool Available { get; init; }
@@ -29,10 +48,16 @@ public sealed class AlgoliaProductRecord
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public decimal? Stock { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? StoreAlias { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Locale { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? CreatedAt { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? UpdatedAt { get; init; }
 
     [JsonExtensionData]

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -81,7 +81,10 @@ public sealed class ProductSearchController
         "ProductProperties": [
           "title",
           "summary",
-          "description"
+          "description",
+          "stockCount|int",
+          "weight|decimal",
+          "publishedAt|unix"
         ],
         "Dispatching": {
           "MaxBatchSize": 100,
@@ -141,5 +144,8 @@ public sealed class ProductSearchController
 - Request and order context decide which culture and currency suffix is used; background indexing falls back to the store's default culture/currency.
 - `Title` is always indexed as a top-level field, and `NodeName` contains the Umbraco node name.
 - Variants are not indexed by default.
+- `Indexing.ProductProperties` supports one optional modifier per property: `|int`, `|decimal`, `|unix`, or `|unixms`.
+- `|decimal` accepts either comma or dot decimal separators, so values like `0,1` and `0.0` are indexed as decimals.
+- Invalid `|int` and `|decimal` values are skipped instead of being indexed as strings.
 - Manual reindex all endpoint: `GET` or `POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildIndexesAsync`.
 - Manual reindex store endpoint: `GET` or `POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildStoreIndexesAsync?storeAlias=Store`.


### PR DESCRIPTION
## Summary
- rename indexed category hierarchy fields to `hierarchical_categories.*` and add `category_paths` in branch traversal order for Algolia category navigation
- prune empty strings, whitespace values, nulls, and empty arrays from indexed product records to reduce Algolia payload size
- add typed `ProductProperties` modifiers for `|int` and `|decimal`, skipping invalid typed values and documenting the new configuration

## Test Plan
- run `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaProductIndexMapperTests"`
- verify product records omit empty optional fields and still keep meaningful `false` and numeric values
- verify configured `ProductProperties` parse `|int` and `|decimal` values such as `0`, `0,1`, and `0.0`