### PR TITLE
fix(algolia): stop prefixing indexed urls

### DIFF
--- a/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -1,5 +1,6 @@
 using Ekom.Algolia;
 using Ekom.Algolia.Mappers;
+using Ekom.Models.Umbraco;
 using Microsoft.Extensions.Options;
 using Moq;
 using System.Text.Json;
@@ -179,6 +180,26 @@ public class AlgoliaProductIndexMapperTests
         Assert.Contains("\"featured\":false", json, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Keeps_Relative_Urls_And_Image_Urls_As_Is()
+    {
+        var mapper = CreateMapper();
+        var product = CreateProduct(url: "/product/fallback");
+        product.SetupGet(x => x.Images).Returns([
+            new Ekom.Models.Image { Url = "/media/product.jpg" }
+        ]);
+        product.SetupGet(x => x.UrlsWithContext).Returns([
+            new UmbracoUrl { Culture = "is-IS", Url = "/product/context" }
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(locale: "is-IS"), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal("/product/context", record!.Url);
+        Assert.Equal("/media/product.jpg", record.ImageUrl);
+        Assert.Equal(["/media/product.jpg"], record.ImageUrls);
+    }
+
     private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null)
     {
         var options = Options.Create(new AlgoliaOptions
@@ -195,9 +216,10 @@ public class AlgoliaProductIndexMapperTests
         return new ProductIndexMapper(options);
     }
 
-    private static AlgoliaResolvedStore CreateStore() => new()
+    private static AlgoliaResolvedStore CreateStore(string? locale = null) => new()
     {
-        Alias = "store"
+        Alias = "store",
+        Locale = locale
     };
 
     private static Mock<Ekom.Models.ICategory> CreateCategory(string title, IReadOnlyList<Mock<Ekom.Models.ICategory>>? ancestors = null)

--- a/Ekom/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -4,9 +4,7 @@ using Ekom.Algolia.Models.Search;
 using Ekom.Algolia.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Moq;
 using Xunit;
 
 namespace Ekom.Tests.Tests;
@@ -120,92 +118,5 @@ public class AlgoliaSearchTests
             "primary.store.products");
 
         Assert.NotEqual(first, second);
-    }
-
-    [Fact]
-    public void Store_Resolver_Returns_Absolute_Store_Domain()
-    {
-        using var loggerFactory = LoggerFactory.Create(_ => { });
-        var resolver = CreateStoreResolver("https://www.lyfja.is", loggerFactory);
-
-        var store = resolver.Resolve("Lyfja");
-
-        Assert.Equal("https://www.lyfja.is/", store.Domain);
-    }
-
-    [Fact]
-    public void Store_Resolver_Warns_When_Store_Domain_Is_Invalid()
-    {
-        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(new TestLoggerProvider()));
-        var resolver = CreateStoreResolver("www.lyfja.is", loggerFactory);
-
-        var store = resolver.Resolve("Lyfja");
-
-        Assert.Null(store.Domain);
-        Assert.Contains(
-            TestLoggerProvider.Entries,
-            x => x.LogLevel == LogLevel.Warning
-                && x.Message.Contains("Algolia store domain is invalid", StringComparison.Ordinal));
-    }
-
-    private static AlgoliaStoreResolver CreateStoreResolver(string? domain, ILoggerFactory loggerFactory)
-    {
-        var options = Options.Create(new AlgoliaOptions
-        {
-            ApplicationId = "app-id",
-            AdminApiKey = "admin-key",
-            SearchApiKey = "search-key",
-            Stores =
-            [
-                new AlgoliaStoreOptions
-                {
-                    Alias = "Lyfja",
-                    Domain = domain
-                }
-            ]
-        });
-
-        var serviceProvider = new Mock<IServiceProvider>();
-
-        return new AlgoliaStoreResolver(options, serviceProvider.Object, loggerFactory.CreateLogger<AlgoliaStoreResolver>());
-    }
-
-    private sealed record TestLogEntry(LogLevel LogLevel, string Message);
-
-    private sealed class TestLoggerProvider : ILoggerProvider
-    {
-        public static List<TestLogEntry> Entries { get; } = [];
-
-        public TestLoggerProvider()
-        {
-            Entries.Clear();
-        }
-
-        public ILogger CreateLogger(string categoryName) => new TestLogger();
-
-        public void Dispose()
-        {
-        }
-
-        private sealed class TestLogger : ILogger
-        {
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-
-            public bool IsEnabled(LogLevel logLevel) => true;
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            {
-                TestLoggerProvider.Entries.Add(new TestLogEntry(logLevel, formatter(state, exception)));
-            }
-        }
-
-        private sealed class NullScope : IDisposable
-        {
-            public static NullScope Instance { get; } = new();
-
-            public void Dispose()
-            {
-            }
-        }
     }
 }

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -83,14 +83,12 @@ public sealed class AlgoliaDispatcherOptions
 public sealed class AlgoliaStoreOptions
 {
     public required string Alias { get; set; }
-    public string? Domain { get; set; }
     public bool IncludeStock { get; set; }
 }
 
 public sealed class AlgoliaResolvedStore
 {
     public required string Alias { get; init; }
-    public string? Domain { get; init; }
     public string? Locale { get; init; }
     public string? Currency { get; init; }
     public bool IncludeStock { get; init; }
@@ -116,7 +114,6 @@ public sealed class AlgoliaResolvedStore
         => new()
         {
             Alias = Alias,
-            Domain = Domain,
             Locale = locale,
             Currency = currency,
             IncludeStock = IncludeStock,

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -42,7 +42,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         var images = product.Images
             .Select(i => i?.Url)
             .Where(u => !string.IsNullOrWhiteSpace(u))
-            .Select(u => ApplyDomain(u!, store.Domain))
+            .Select(u => u!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
@@ -50,7 +50,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             .Where(u => string.IsNullOrWhiteSpace(locale) || u.Culture.Equals(locale, StringComparison.OrdinalIgnoreCase))
             .Select(u => u.Url)
             .Where(u => !string.IsNullOrWhiteSpace(u))
-            .Select(u => ApplyDomain(u!, store.Domain))
+            .Select(u => u!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList()
             ?? [];
@@ -59,7 +59,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         {
             urls = product.Urls
                 ?.Where(u => !string.IsNullOrWhiteSpace(u))
-                .Select(u => ApplyDomain(u!, store.Domain))
+                .Select(u => u!)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList()
                 ?? [];
@@ -73,7 +73,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             Title = title,
             Summary = NullIfWhiteSpace(GetLocalizedValue(product, "summary", product.Summary, locale)),
             Description = NullIfWhiteSpace(GetLocalizedValue(product, "description", product.Description, locale)),
-            Url = NullIfWhiteSpace(urls.FirstOrDefault() ?? ApplyDomain(product.Url, store.Domain)),
+            Url = NullIfWhiteSpace(urls.FirstOrDefault() ?? product.Url),
             ImageUrl = NullIfWhiteSpace(images.FirstOrDefault()),
             ImageUrls = images.Count > 0 ? images : null,
             Price = price?.Value,
@@ -173,25 +173,6 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         return string.IsNullOrWhiteSpace(localized) ? fallbackValue : localized;
     }
 
-    private static string ApplyDomain(string? url, string? domain)
-    {
-        if (string.IsNullOrWhiteSpace(url))
-            return string.Empty;
-
-        if (string.IsNullOrWhiteSpace(domain))
-            return url;
-
-        if (Uri.TryCreate(url, UriKind.Absolute, out _))
-            return url;
-
-        if (!Uri.TryCreate(domain, UriKind.Absolute, out var baseUri))
-            return url;
-
-        if (!Uri.TryCreate(baseUri, url, out var absoluteUri))
-            return url;
-
-        return absoluteUri.ToString();
-    }
 
     private static IReadOnlyDictionary<string, IReadOnlyList<string>> BuildCategoryLevels(IProduct product, string? locale)
     {

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -123,8 +123,7 @@ public sealed class ProductSearchController
       },
       "Stores": [
         {
-          "Alias": "Store",
-          "Domain": "https://example.com"
+          "Alias": "Store"
         }
       ]
     }
@@ -140,8 +139,7 @@ public sealed class ProductSearchController
 - `IAlgoliaSearchService.SearchProductsAsync(...)` returns hits together with paging metadata, query text, processing time, and raw facets.
 - The plugin always resolves and sets the Algolia index name from Ekom store alias, locale, and currency; callers should not set `IndexName` themselves.
 - Search cache keys include the resolved index name and serialized Algolia query payload so all SDK options affect caching.
-- Store `Locale` and `Currency` now come from the Ekom store resolved by alias, so `appsettings.json` only needs the store alias and optional domain.
-- `Stores[].Domain` must be an absolute URL such as `https://example.com`; invalid values are ignored and logged as warnings during indexing.
+- Store `Locale` and `Currency` now come from the Ekom store resolved by alias, so `appsettings.json` only needs the store alias.
 - Request and order context decide which culture and currency suffix is used; background indexing falls back to the store's default culture/currency.
 - `Title` is always indexed as a top-level field, and `NodeName` contains the Umbraco node name.
 - Variants are not indexed by default.

--- a/Plugins/Ekom.Algolia/Services/AlgoliaStoreResolver.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaStoreResolver.cs
@@ -26,7 +26,6 @@ internal sealed class AlgoliaStoreResolver
     {
         var configuredStore = _options.Stores.FirstOrDefault(s => s.Alias.Equals(storeAlias, StringComparison.OrdinalIgnoreCase));
         var resolvedAlias = configuredStore?.Alias ?? storeAlias;
-        var domain = ResolveDomain(configuredStore?.Domain, resolvedAlias);
         var ekomStore = ResolveStore(resolvedAlias);
         var locales = ekomStore?.Cultures
             .Select(x => x.Name)
@@ -44,29 +43,12 @@ internal sealed class AlgoliaStoreResolver
         return new AlgoliaResolvedStore
         {
             Alias = resolvedAlias,
-            Domain = domain,
             Locale = ekomStore?.Culture?.Name,
             Currency = ekomStore?.Currency?.CurrencyValue,
             IncludeStock = configuredStore?.IncludeStock ?? false,
             Locales = locales,
             Currencies = currencies
         };
-    }
-
-    private string? ResolveDomain(string? domain, string storeAlias)
-    {
-        if (string.IsNullOrWhiteSpace(domain))
-            return null;
-
-        if (Uri.TryCreate(domain, UriKind.Absolute, out var absoluteUri))
-            return absoluteUri.ToString();
-
-        _logger.LogWarning(
-            "Algolia store domain is invalid for store {Store}. Domain={Domain}. Relative product and image URLs will not be converted to absolute URLs.",
-            storeAlias,
-            domain);
-
-        return null;
     }
 
     private IStore? ResolveStore(string storeAlias)

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -3008,7 +3008,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.121, )"
+          "Ekom.Core": "[0.2.125, )"
         }
       },
       "ekom.common": {
@@ -3023,7 +3023,7 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.121, )",
+          "Ekom.Common": "[0.2.125, )",
           "Ekom.Payments.Core": "[0.2.59, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
@@ -3039,7 +3039,7 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.121, )",
+          "Ekom.AspNetCore": "[0.2.125, )",
           "Ekom.Payments.U10": "[0.2.59, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -143,7 +143,6 @@
             "Stores": [
                 {
                     "Alias": "Store",
-                    "Domain": "https://localhost:44317",
                     "IncludeStock": false
                 }
             ]


### PR DESCRIPTION
## Summary
- remove the Algolia store domain option and the resolver logic that normalized it
- keep indexed product and image URLs exactly as provided by Ekom instead of prefixing a domain
- update tests, README, sample config, and the Algolia package lock file to match the new behavior

## Test Plan
- dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj"
- dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~Algolia"