### PR TITLE
fix(algolia): support explicit metafield indexing

### DIFF
--- a/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -200,6 +200,105 @@ public class AlgoliaProductIndexMapperTests
         Assert.Equal(["/media/product.jpg"], record.ImageUrls);
     }
 
+    [Fact]
+    public void Maps_Scalar_Metafield_When_Explicitly_Configured()
+    {
+        var mapper = CreateMapper(productProperties: ["metafield:material"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("material", [CreateMetafieldValue((string.Empty, "Cotton"))])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal("Cotton", Assert.IsType<string>(record!.Data["material"]));
+    }
+
+    [Fact]
+    public void Maps_Localized_Metafield_When_Explicitly_Configured()
+    {
+        var mapper = CreateMapper(productProperties: ["metafield:color"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("color", [CreateMetafieldValue(("en-US", "Red"), ("is-IS", "Rauður"))])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(locale: "is-IS"), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal("Rauður", Assert.IsType<string>(record!.Data["color"]));
+    }
+
+    [Fact]
+    public void Maps_Multi_Value_Metafield_As_Array_When_Configured()
+    {
+        var mapper = CreateMapper(productProperties: ["metafield:channels|array"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("channels",
+            [
+                CreateMetafieldValue((string.Empty, "Web")),
+                CreateMetafieldValue((string.Empty, "Store")),
+                CreateMetafieldValue((string.Empty, "Web"))
+            ])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(["Web", "Store"], Assert.IsAssignableFrom<IReadOnlyList<string>>(record!.Data["channels"]));
+    }
+
+    [Fact]
+    public void Skips_Multi_Value_Metafield_Without_Array_Modifier()
+    {
+        var mapper = CreateMapper(productProperties: ["metafield:channels"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("channels",
+            [
+                CreateMetafieldValue((string.Empty, "Web")),
+                CreateMetafieldValue((string.Empty, "Store"))
+            ])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.DoesNotContain("channels", record!.Data.Keys);
+    }
+
+    [Fact]
+    public void Skips_Invalid_Int_Metafield_Value()
+    {
+        var mapper = CreateMapper(productProperties: ["metafield:stockLevel|int"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("stockLevel", [CreateMetafieldValue((string.Empty, "abc"))])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.DoesNotContain("stockLevel", record!.Data.Keys);
+    }
+
+    [Fact]
+    public void Plain_Property_Alias_Does_Not_Read_Metafield_Value()
+    {
+        var mapper = CreateMapper(productProperties: ["material"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("material", [CreateMetafieldValue((string.Empty, "Cotton"))])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.DoesNotContain("material", record!.Data.Keys);
+    }
+
     private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null)
     {
         var options = Options.Create(new AlgoliaOptions
@@ -234,6 +333,7 @@ public class AlgoliaProductIndexMapperTests
 
     private static Mock<Ekom.Models.IProduct> CreateProduct(
         IReadOnlyList<Mock<Ekom.Models.ICategory>>? categories = null,
+        IReadOnlyList<Ekom.Models.MetavalueSlim>? metafields = null,
         IReadOnlyDictionary<string, string>? properties = null,
         string sku = "sku",
         string summary = "Summary",
@@ -261,6 +361,7 @@ public class AlgoliaProductIndexMapperTests
         product.SetupGet(x => x.Price).Returns(price.Object);
         product.SetupGet(x => x.Prices).Returns([price.Object]);
         product.SetupGet(x => x.Categories).Returns((categories ?? []).Select(x => x.Object));
+        product.SetupGet(x => x.Metafields).Returns(metafields?.ToList() ?? []);
         product.SetupGet(x => x.CreateDate).Returns(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         product.SetupGet(x => x.UpdateDate).Returns(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc));
         product.Setup(x => x.GetValue(It.IsAny<string>(), It.IsAny<string?>(), true)).Returns(string.Empty);
@@ -269,4 +370,19 @@ public class AlgoliaProductIndexMapperTests
 
         return product;
     }
+
+    private static Ekom.Models.MetavalueSlim CreateMetafield(string alias, IReadOnlyList<Dictionary<string, string>> values)
+        => new()
+        {
+            Field = new Ekom.Models.MetafieldSlim
+            {
+                Alias = alias,
+                Name = alias,
+                Description = string.Empty
+            },
+            Values = values.ToList()
+        };
+
+    private static Dictionary<string, string> CreateMetafieldValue(params (string Key, string Value)[] values)
+        => values.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
 }

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -102,11 +102,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             var alias = kvp.Key;
             var configuredField = kvp.Value;
 
-            var raw = GetLocalizedValue(product, alias, product.GetValue(alias, store.Alias), locale);
-            if (string.IsNullOrWhiteSpace(raw))
-                continue;
-
-            object? converted = NormalizePropertyValue(raw, configuredField.ValueType);
+            object? converted = ResolveConfiguredValue(product, store, configuredField);
             var ctx = new AlgoliaProductFieldContext(product, store, alias, baseIndexName);
             converted = ConvertProperty(ctx, converted);
 
@@ -162,6 +158,66 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         }
 
         return value;
+    }
+
+    private static object? ResolveConfiguredValue(IProduct product, AlgoliaResolvedStore store, ConfiguredField configuredField)
+    {
+        return configuredField.Source switch
+        {
+            AlgoliaFieldSource.Metafield => ResolveMetafieldValue(product, configuredField.Alias, store.Locale, configuredField.ValueType),
+            _ => ResolveProductPropertyValue(product, store, configuredField)
+        };
+    }
+
+    private static object? ResolveProductPropertyValue(IProduct product, AlgoliaResolvedStore store, ConfiguredField configuredField)
+    {
+        var raw = GetLocalizedValue(product, configuredField.Alias, product.GetValue(configuredField.Alias, store.Alias), store.Locale);
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        return NormalizePropertyValue(raw, configuredField.ValueType);
+    }
+
+    private static object? ResolveMetafieldValue(IProduct product, string alias, string? locale, AlgoliaFieldValueType valueType)
+    {
+        var metafield = product.Metafields
+            .FirstOrDefault(x => x.Field.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+
+        if (metafield is null || metafield.Values.Count == 0)
+            return null;
+
+        var values = metafield.Values
+            .Select(value => ResolveMetafieldText(value, locale))
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (values.Count == 0)
+            return null;
+
+        if (valueType == AlgoliaFieldValueType.Array)
+            return values;
+
+        if (values.Count != 1)
+            return null;
+
+        return NormalizePropertyValue(values[0], valueType);
+    }
+
+    private static string? ResolveMetafieldText(IReadOnlyDictionary<string, string> values, string? locale)
+    {
+        if (!string.IsNullOrWhiteSpace(locale) &&
+            values.TryGetValue(locale, out var localizedValue) &&
+            !string.IsNullOrWhiteSpace(localizedValue))
+        {
+            return localizedValue;
+        }
+
+        if (values.TryGetValue(string.Empty, out var rawValue) && !string.IsNullOrWhiteSpace(rawValue))
+            return rawValue;
+
+        return values.Values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
     }
 
     private static string GetLocalizedValue(INodeEntity node, string propertyAlias, string fallbackValue, string? locale)
@@ -401,30 +457,46 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         return dto.ToUnixTimeSeconds();
     }
 
-    internal readonly record struct ConfiguredField(string Alias, AlgoliaFieldValueType ValueType, AlgoliaFieldTransform Transform)
+    internal readonly record struct ConfiguredField(string Alias, AlgoliaFieldSource Source, AlgoliaFieldValueType ValueType, AlgoliaFieldTransform Transform)
     {
         public static ConfiguredField Parse(string raw)
         {
             if (string.IsNullOrWhiteSpace(raw))
-                return new ConfiguredField(string.Empty, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None);
+                return new ConfiguredField(string.Empty, AlgoliaFieldSource.Property, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None);
 
             var parts = raw.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var alias = parts[0];
+            var (alias, source) = ParseSource(parts[0]);
 
             if (parts.Length < 2)
-                return new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None);
+                return new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None);
 
             return parts[1].ToLowerInvariant() switch
             {
-                "int" => new ConfiguredField(alias, AlgoliaFieldValueType.Int, AlgoliaFieldTransform.None),
-                "decimal" => new ConfiguredField(alias, AlgoliaFieldValueType.Decimal, AlgoliaFieldTransform.None),
-                "array" => new ConfiguredField(alias, AlgoliaFieldValueType.Array, AlgoliaFieldTransform.None),
-                "unix" => new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixSeconds),
-                "unixms" => new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixMilliseconds),
-                _ => new ConfiguredField(alias, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None)
+                "int" => new ConfiguredField(alias, source, AlgoliaFieldValueType.Int, AlgoliaFieldTransform.None),
+                "decimal" => new ConfiguredField(alias, source, AlgoliaFieldValueType.Decimal, AlgoliaFieldTransform.None),
+                "array" => new ConfiguredField(alias, source, AlgoliaFieldValueType.Array, AlgoliaFieldTransform.None),
+                "unix" => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixSeconds),
+                "unixms" => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixMilliseconds),
+                _ => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None)
             };
         }
+
+        private static (string Alias, AlgoliaFieldSource Source) ParseSource(string rawAlias)
+        {
+            const string metafieldPrefix = "metafield:";
+
+            if (rawAlias.StartsWith(metafieldPrefix, StringComparison.OrdinalIgnoreCase))
+                return (rawAlias[metafieldPrefix.Length..], AlgoliaFieldSource.Metafield);
+
+            return (rawAlias, AlgoliaFieldSource.Property);
+        }
     }
+}
+
+internal enum AlgoliaFieldSource
+{
+    Property,
+    Metafield
 }
 
 internal enum AlgoliaFieldValueType

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -144,6 +144,8 @@ public sealed class ProductSearchController
 - `Title` is always indexed as a top-level field, and `NodeName` contains the Umbraco node name.
 - Variants are not indexed by default.
 - `Indexing.ProductProperties` supports one optional modifier per property: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
+- Metafields can be indexed explicitly with `metafield:<alias>`, for example `metafield:material`, `metafield:color|array`, or `metafield:releaseDate|unix`.
+- Multi-value metafields are skipped unless `|array` is configured.
 - `|array` parses JSON arrays such as checkbox-list values like `["Web","Store"]` into Algolia string arrays.
 - `|decimal` accepts either comma or dot decimal separators, so values like `0,1` and `0.0` are indexed as decimals.
 - Invalid `|array`, `|int`, and `|decimal` values are skipped instead of being indexed as strings.

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -415,6 +415,44 @@
         "resolved": "2.5.192",
         "contentHash": "jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg=="
       },
+      "Microsoft.AspNetCore.Authentication.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "ve6uvLwKNRkfnO/QeN9M8eUJ49lCnWv/6/9p6iTEuiI6Rtsz+myaBAjdMzLuTViQY032xbTF5AdZF5BJzJJyXQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Core": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "gnLnKGawBjqBnU9fEuel3VcYAARkjyONAliaGDfMc8o8HBtfh+HrOPEoR8Xx4b2RnMb7uxdBDOvEAC7sul79ig==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Http": "2.3.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authorization": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "2/aBgLqBXva/+w8pzRNY8ET43Gi+dr1gv/7ySfbsh23lTK6IAgID5MGUEa1hreNIF+0XpW4tX7QwVe70+YvaPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Authorization.Policy": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "vn31uQ1dA1MIV2WNNDOOOm88V5KgR9esfi0LyQ6eVaGq2h0Yw+R29f5A6qUNJt+RccS3qkYayylAy9tP1wV+7Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Authorization": "2.3.0"
+        }
+      },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
         "resolved": "8.0.22",
@@ -449,54 +487,61 @@
       },
       "Microsoft.AspNetCore.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.0.2",
-        "contentHash": "CSVd9h1TdWDT2lt62C4FcgaF285J4O3MaOqTVvc7xP+3bFiwXcdp6qEd+u1CQrdJ+xJuslR+tvDW7vWQ/OH5Qw==",
+        "resolved": "2.3.0",
+        "contentHash": "4ivq53W2k6Nj4eez9wc81ytfGj6HR1NaZJCpOrvghJo9zHuQF57PLhPoQH5ItyCpHXnrN/y7yJDUm+TGYzrx0w==",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "1.0.2",
-          "Microsoft.AspNetCore.Http.Abstractions": "1.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "1.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.2",
-          "Microsoft.Extensions.FileProviders.Abstractions": "1.0.1",
-          "Microsoft.Extensions.Logging.Abstractions": "1.0.2"
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1"
         }
       },
       "Microsoft.AspNetCore.Hosting.Server.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.0.2",
-        "contentHash": "6ZtFh0huTlrUl72u9Vic0icCVIQiEx7ULFDx3P7BpOI97wjb0GAXf8B4m9uSpSGf0vqLEKFlkPbvXF0MXXEzhw==",
+        "resolved": "2.3.0",
+        "contentHash": "F5iHx7odAbFKBV1DNPDkFFcVmD5Tk7rk+tYm3LMQxHEFFdjlg5QcYb5XhHAefl5YaaPeG6ad+/ck8kSG3/D6kw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "1.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "1.0.2"
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "I9azEG2tZ4DDHAFgv+N38e6Yhttvf+QjE2j2UYyCACE7Swm5/0uoihCMWZ87oOZYeqiEFSxbsfpT71OYHe2tpw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.WebUtilities": "2.3.0",
+          "Microsoft.Extensions.ObjectPool": "8.0.11",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Net.Http.Headers": "2.3.0"
         }
       },
       "Microsoft.AspNetCore.Http.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.0.2",
-        "contentHash": "peJqc7BgYwhTzOIfFHX3/esV6iOXf17Afekh6mCYuUD3aWyaBwQuWYaKLR+RnjBEWaSzpCDgfCMMp5Y3LUXsiA==",
+        "resolved": "2.3.0",
+        "contentHash": "39r9PPrjA6s0blyFv5qarckjNkaHRA5B+3b53ybuGGNTXEj1/DStQJ4NWjFL6QTRQpL9zt7nDyKxZdJOlcnq+Q==",
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Features": "1.0.2",
-          "System.Globalization.Extensions": "4.0.1",
-          "System.Linq.Expressions": "4.1.1",
-          "System.Reflection.TypeExtensions": "4.1.0",
-          "System.Runtime.InteropServices": "4.1.0",
-          "System.Text.Encodings.Web": "4.0.0"
+          "Microsoft.AspNetCore.Http.Features": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Extensions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "EY2u/wFF5jsYwGXXswfQWrSsFPmiXsniAlUWo3rv/MGYf99ZFsENDnZcQP6W3c/+xQmQXq0NauzQ7jyy+o1LDQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Net.Http.Headers": "2.3.0",
+          "System.Buffers": "4.6.0"
         }
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Transitive",
-        "resolved": "1.0.2",
-        "contentHash": "9l/Y/CO3q8tET3w+dDiByREH8lRtpd14cMevwMV5nw2a/avJ5qcE3VVIE5U5hesec2phTT6udQEgwjHmdRRbig==",
+        "resolved": "2.3.0",
+        "contentHash": "f10WUgcsKqrkmnz6gt8HeZ7kyKjYN30PO7cSic1lPtH7paPtnQqXPOveul/SIPI43PhRD4trttg4ywnrEmmJpA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "1.0.1",
-          "System.Collections": "4.0.11",
-          "System.ComponentModel": "4.0.1",
-          "System.Linq": "4.1.0",
-          "System.Net.Primitives": "4.0.11",
-          "System.Net.WebSockets": "4.0.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Security.Claims": "4.0.1",
-          "System.Security.Cryptography.X509Certificates": "4.1.0",
-          "System.Security.Principal": "4.0.1"
+          "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
       "Microsoft.AspNetCore.JsonPatch": {
@@ -506,6 +551,36 @@
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "xrF8Fh10hEAS6Qp967IgPqNw2iz3/3Q8FQo+Jowbytaj1JJN86p0z851hSH4XP/sFnI5gFu7mGdkplirAJMWPw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
+          "Microsoft.Net.Http.Headers": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.Mvc.Core": {
+        "type": "Transitive",
+        "resolved": "2.3.9",
+        "contentHash": "lir+8KX+kFjaUYFDw6R1kJAxBPOAjSKrLEji/rW+h8ePqloVZ5xnzlPttGUPbOkvMXIQKW3mCvtUfVlqCagX5Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Core": "2.3.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.3.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Http": "2.3.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.DependencyModel": "2.1.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "Microsoft.AspNetCore.Mvc.NewtonsoftJson": {
@@ -541,6 +616,43 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "yCtBr1GSGzJrrp1NJUb4ltwFYMKHw/tJLnIDvg9g/FnkGIEzmE19tbCQqXARIJv5kdtBgsoVIdGLL+zmjxvM/A=="
+      },
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "VTqhxnUiawKS22fss5fr/NMJ4MVQHFUgqyWOIaJ9pUY+jmYGCAa+VYfB5DLJYmsD4AhdKnlO6I9lML5tUbDNNA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.Routing": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "no5/VC0CAQuT4PK4rp2K5fqwuSfzr2mdB6m1XNfWVhHnwzpRQzKAu9flChiT/JTLKwVI0Vq2MSmSW2OFMDCNXg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.ObjectPool": "8.0.11",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Microsoft.AspNetCore.Routing.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "ZkFpUrSmp6TocxZLBEX3IBv5dPMbQuMs6L/BPl0WRfn32UVOtNYJQ0bLdh3cL9LMV0rmTW/5R0w8CBYxr0AOUw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.3.0"
+        }
+      },
+      "Microsoft.AspNetCore.WebUtilities": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "trbXdWzoAEUVd0PE2yTopkz4kjZaAIA7xUWekd5uBw+7xE8Do/YOVTeb9d9koPTlbtZT539aESJjSLSqD8eYrQ==",
+        "dependencies": {
+          "Microsoft.Net.Http.Headers": "2.3.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -1035,6 +1147,11 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "8.0.11",
+        "contentHash": "6ApKcHNJigXBfZa6XlDQ8feJpq7SG1ogZXg6M4FiNzgd6irs3LUAzo0Pfn4F2ZI9liGnH1XIBR/OtSbZmJAV5w=="
+      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1123,6 +1240,15 @@
         "contentHash": "fQ0VVCba75lknUHGldi3iTKAYUQqbzp1Un8+d9cm9nON0Gs8NAkXddNg8iaUB0qi/ybtAmNWizTR4avdkCJ9pQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "7.7.1"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "2.3.0",
+        "contentHash": "/M0wVg6tJUOHutWD3BMOUVZAioJVXe0tCpFiovzv0T9T12TBf4MnaHP0efO8TCr1a6O9RZgQeZ9Gdark8L9XdA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0",
+          "System.Buffers": "4.6.0"
         }
       },
       "Microsoft.NET.StringTools": {
@@ -1838,15 +1964,8 @@
       },
       "System.Buffers": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ratu44uTIHgeBeI0dE8DWvmXVBSo4u7ozRZZHOMmK/JPpYyo0dAfgSiHlpiObMQ5lEtEyIXA40sKRYg5J6A8uQ==",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "4.6.0",
+        "contentHash": "lN6tZi7Q46zFzAbRYXTIvfXcyvQQgxnY7Xm6C6xQ9784dEL1amjM6S6Iw4ZpsvesAKnRVsM4scrDQaDqSClkjA=="
       },
       "System.ClientModel": {
         "type": "Transitive",
@@ -2307,17 +2426,6 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Net.WebSockets": {
-        "type": "Transitive",
-        "resolved": "4.0.0",
-        "contentHash": "2KJo8hir6Edi9jnMDAMhiJoI691xRBmKcbNpwjrvpIMOCTYOtBpSsSEGBxBDV7PKbasJNaFp1+PZz1D7xS41Hg==",
-        "dependencies": {
-          "Microsoft.Win32.Primitives": "4.0.1",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Threading.Tasks": "4.0.11"
-        }
-      },
       "System.ObjectModel": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2517,20 +2625,6 @@
           "System.Runtime": "4.3.0"
         }
       },
-      "System.Security.Claims": {
-        "type": "Transitive",
-        "resolved": "4.0.1",
-        "contentHash": "4Jlp0OgJLS/Voj1kyFP6MJlIYp3crgfH8kNQk2p7+4JYfc1aAmh9PZyAMMbDhuoolGNtux9HqSOazsioRiDvCw==",
-        "dependencies": {
-          "System.Collections": "4.0.11",
-          "System.Globalization": "4.0.11",
-          "System.IO": "4.1.0",
-          "System.Resources.ResourceManager": "4.0.1",
-          "System.Runtime": "4.1.0",
-          "System.Runtime.Extensions": "4.1.0",
-          "System.Security.Principal": "4.0.1"
-        }
-      },
       "System.Security.Cryptography.Algorithms": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2701,14 +2795,6 @@
           "System.Windows.Extensions": "8.0.0"
         }
       },
-      "System.Security.Principal": {
-        "type": "Transitive",
-        "resolved": "4.0.1",
-        "contentHash": "On+SKhXY5rzxh/S8wlH1Rm0ogBlu7zyHNxeNBiXauNrhHRXAe9EuX8Yl5IOzLPGU5Z4kLWHMvORDOCG8iu9hww==",
-        "dependencies": {
-          "System.Runtime": "4.1.0"
-        }
-      },
       "System.Text.Encoding": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2788,13 +2874,8 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
+        "resolved": "4.6.0",
+        "contentHash": "I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg=="
       },
       "System.Threading.Tasks.Parallel": {
         "type": "Transitive",
@@ -3008,7 +3089,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.125, )"
+          "Ekom.Core": "[0.2.126, )"
         }
       },
       "ekom.common": {
@@ -3023,12 +3104,17 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.125, )",
+          "Ekom.Common": "[0.2.126, )",
           "Ekom.Payments.Core": "[0.2.59, )",
           "Hangfire": "[1.8.18, )",
+          "Microsoft.AspNetCore.Http.Extensions": "[2.3.0, )",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "[2.3.0, )",
+          "Microsoft.AspNetCore.Mvc.Core": "[2.3.9, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
           "Microsoft.Data.Sqlite": "[8.0.11, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
+          "Microsoft.Extensions.Configuration": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.2, )",
           "Newtonsoft.Json": "[13.0.4, )",
@@ -3039,7 +3125,7 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.125, )",
+          "Ekom.AspNetCore": "[0.2.126, )",
           "Ekom.Payments.U10": "[0.2.59, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",


### PR DESCRIPTION
## Summary
- add explicit `metafield:<alias>` support to Algolia product property indexing so dynamic product metafields can be indexed without changing normal property behavior
- resolve metafield values directly from `product.Metafields`, including locale-aware values, and skip multi-value metafields unless `|array` is configured
- add mapper tests and README guidance for explicit metafield indexing syntax and behavior

## Test Plan
- dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj"
- dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~Algolia"