### PR TITLE
fix(manager): show order action refresh feedback

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -347,7 +347,7 @@
           return readBlobText(error.data)
             .then(function (text) {
               var message = tryParseMessage(text) || getErrorMessage(error, "Order action failed.");
-              window.alert(message);
+              notificationsService.error("Error", message);
             });
         })
         .finally(function () {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -347,7 +347,7 @@
           return readBlobText(error.data)
             .then(function (text) {
               var message = tryParseMessage(text) || getErrorMessage(error, "Order action failed.");
-              window.alert(message);
+              notificationsService.error("Error", message);
             });
         })
         .finally(function () {

--- a/Samples/U10/Ekom.Site/DemoOrderManagerActionProvider.cs
+++ b/Samples/U10/Ekom.Site/DemoOrderManagerActionProvider.cs
@@ -34,25 +34,48 @@ public sealed class DemoOrderManagerActionProvider : IOrderManagerActionProvider
         return Task.FromResult(actions);
     }
 
-    public Task<OrderManagerActionExecutionResult?> ExecuteAsync(IOrderInfo orderInfo, string actionKey, string? userName = null, CancellationToken ct = default)
+    private async Task RunTestFunction()
     {
-        OrderManagerActionExecutionResult? result = actionKey switch
+        
+    }
+    
+
+    public async Task<OrderManagerActionExecutionResult?> ExecuteAsync(IOrderInfo orderInfo, string actionKey, string? userName = null, CancellationToken ct = default)
+    {
+        if (actionKey == DemoRefreshActionKey)
         {
-            DemoRefreshActionKey => new OrderManagerActionSuccessResult
+            try
             {
-                Message = $"Demo refresh completed for order {orderInfo.ReferenceId}."
-            },
-            DemoPdfActionKey => new OrderManagerActionFileResult
+                await RunTestFunction().ConfigureAwait(false);
+
+                return new OrderManagerActionSuccessResult
+                {
+                    Message = $"Demo refresh completed for order {orderInfo.ReferenceId}."
+                };
+            }
+            catch (Exception ex)
+            {
+                return new OrderManagerActionBadRequestResult
+                {
+                    Message = string.IsNullOrWhiteSpace(ex.Message)
+                        ? $"Demo refresh failed for order {orderInfo.ReferenceId}."
+                        : ex.Message
+                };
+            }
+        }
+
+        if (actionKey == DemoPdfActionKey)
+        {
+            return new OrderManagerActionFileResult
             {
                 Content = CreateDemoPdf(orderInfo),
                 ContentType = "application/pdf",
                 FileName = $"ekom-demo-order-{orderInfo.ReferenceId}.pdf",
                 Message = "Demo PDF generated."
-            },
-            _ => null
-        };
+            };
+        }
 
-        return Task.FromResult(result);
+        return null;
     }
 
     private static byte[] CreateDemoPdf(IOrderInfo orderInfo)


### PR DESCRIPTION
## Summary
- run the demo refresh order action through `RunTestFunction` and return a success result or a bad-request result with the failure message
- show Umbraco error notifications for order action failures instead of using a browser alert
- keep the sample backoffice controller in sync with the packaged backoffice controller

## Test Plan
- trigger the Demo Refresh action and verify a success notification is shown when `RunTestFunction` completes
- trigger the Demo Refresh action with `RunTestFunction` throwing and verify an Umbraco error notification is shown
- confirm the Demo PDF action still opens the generated file as before