### PR TITLE
feat(search): normalize Examine catalog search

### DIFF
--- a/Ekom/Ekom.U10/EkomStartup.cs
+++ b/Ekom/Ekom.U10/EkomStartup.cs
@@ -69,6 +69,7 @@ public class EkomComposer : IComposer
             // Can't use umbraco npoco for this since we use linq2db in core
             .Append<EnsureTablesExist>()
             .Append<EnsureNodesExist>()
+            .Append<Ekom.Umb.Services.ExamineSearchIndexComponent>()
             .Append<EkomStartup>()
             ;
 

--- a/Ekom/Ekom.U10/Services/CatalogSearchService.cs
+++ b/Ekom/Ekom.U10/Services/CatalogSearchService.cs
@@ -125,57 +125,23 @@ public class CatalogSearchService : ICatalogSearchService
 
             var searcher = index.Searcher ?? throw new Exception("Searcher not found. " + examineIndex);
 
-            // Build terms: stopwords -> diacritics -> tokenize -> escape
+            // Build terms: stopwords -> tokenize. Normalized terms target *_normalized fields.
             var withoutStopWords = req.SearchQuery.RemoveStopWords();
             var baseQuery = string.IsNullOrWhiteSpace(withoutStopWords) ? req.SearchQuery : withoutStopWords;
-            var cleanQuery = SearchHelper.RemoveDiacritics(baseQuery);
-
-            var searchTerms = cleanQuery
-                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(t => t.Trim())
-                .Where(t => !string.IsNullOrWhiteSpace(t))
-                .Select(QueryParser.Escape)
-                .ToList();
+            var searchTerms = ExamineSearchTextNormalizer.Tokenize(baseQuery, normalize: false);
+            var normalizedSearchTerms = ExamineSearchTextNormalizer.Tokenize(baseQuery, normalize: true);
 
             // No usable tokens => no results (prevents empty query / weird parse)
-            if (searchTerms.Count == 0)
+            if (searchTerms.Count == 0 && normalizedSearchTerms.Count == 0)
                 return Array.Empty<SearchResultEntity>();
 
             ct.ThrowIfCancellationRequested();
 
-            // Each term is required (+) and must match at least one of the fields (OR across fields)
-            for (var i = 0; i < searchTerms.Count; i++)
-            {
-                var term = searchTerms[i];
+            var normalizedFieldNames = GetNormalizedFieldNames();
+            luceneQuery.Append(BuildLuceneQuery(req.SearchFields, searchTerms, normalizedSearchTerms, normalizedFieldNames));
 
-                if (i > 0)
-                    luceneQuery.Append(" AND ");
-
-                // Require each term-group
-                luceneQuery.Append("+(");
-
-                var wroteAnyFieldClause = false;
-
-                foreach (var field in req.SearchFields)
-                {
-                    var clause = BuildFieldClause(field, term);
-                    if (string.IsNullOrWhiteSpace(clause))
-                        continue;
-
-                    // OR across fields within a term-group
-                    if (wroteAnyFieldClause)
-                        luceneQuery.Append(" OR ");
-
-                    luceneQuery.Append(clause);
-                    wroteAnyFieldClause = true;
-                }
-
-                luceneQuery.Append(")");
-
-                // Safety: never allow "+()" to escape
-                if (!wroteAnyFieldClause)
-                    return Array.Empty<SearchResultEntity>();
-            }
+            if (luceneQuery.Length == 0)
+                return Array.Empty<SearchResultEntity>();
 
             ct.ThrowIfCancellationRequested();
 
@@ -243,34 +209,6 @@ public class CatalogSearchService : ICatalogSearchService
             total = 0;
             return Array.Empty<SearchResultEntity>();
         }
-
-        static string BuildFieldClause(EkomSearchField field, string term)
-        {
-            // Lucene classic syntax: field:value (no space after ':')
-            // Wrap term-values with parentheses only where needed; keep it simple and valid.
-
-            var booster = string.IsNullOrWhiteSpace(field.Booster) ? "" : field.Booster;
-
-            return field.SearchType switch
-            {
-                EkomSearchType.Wildcard =>
-                    $"{field.Name}:*{term}*{booster}",
-
-                EkomSearchType.Fuzzy =>
-                    $"{field.Name}:{term}~{field.FuzzyConfiguration}{booster}",
-
-                EkomSearchType.FuzzyAndWilcard =>
-                    // (wild OR fuzzy) inside a single field-clause
-                    $"({field.Name}:*{term}* OR {field.Name}:{term}~{field.FuzzyConfiguration}){booster}",
-
-                EkomSearchType.Exact =>
-                    $"{field.Name}:{term}{booster}",
-
-                _ =>
-                    // Default to exact if unknown
-                    $"{field.Name}:{term}{booster}"
-            };
-        }
     }
 
     private IEnumerable<SearchResultEntity> InternalQueryCore(SearchRequest req, out long total, CancellationToken ct)
@@ -313,45 +251,20 @@ public class CatalogSearchService : ICatalogSearchService
             var searcher = index.Searcher ?? throw new Exception("Searcher not found. " + examineIndex);
 
             var queryWithOutStopWords = req.SearchQuery.RemoveStopWords();
-            var cleanQuery = SearchHelper.RemoveDiacritics(string.IsNullOrEmpty(queryWithOutStopWords) ? req.SearchQuery : queryWithOutStopWords);
+            var baseQuery = string.IsNullOrEmpty(queryWithOutStopWords) ? req.SearchQuery : queryWithOutStopWords;
+            var searchTerms = ExamineSearchTextNormalizer.Tokenize(baseQuery, normalize: false);
+            var normalizedSearchTerms = ExamineSearchTextNormalizer.Tokenize(baseQuery, normalize: true);
 
-            var searchTerms = cleanQuery
-                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(QueryParser.Escape)
-                .ToList();
+            if (searchTerms.Count == 0 && normalizedSearchTerms.Count == 0)
+                return Array.Empty<SearchResultEntity>();
 
             ct.ThrowIfCancellationRequested();
 
-            for (var i = 0; i < searchTerms.Count; i++)
-            {
-                var term = searchTerms[i];
+            var normalizedFieldNames = GetNormalizedFieldNames();
+            luceneQuery.Append(BuildLuceneQuery(req.SearchFields, searchTerms, normalizedSearchTerms, normalizedFieldNames));
 
-                if (i != 0)
-                    luceneQuery.Append(" AND ");
-
-                if (i == 0)
-                    luceneQuery.Append("+");
-
-                luceneQuery.Append(" (");
-
-                foreach (var field in req.SearchFields)
-                {
-                    luceneQuery.Append(" (");
-
-                    if (field.SearchType == EkomSearchType.Wildcard || field.SearchType == EkomSearchType.FuzzyAndWilcard)
-                        luceneQuery.Append("(" + field.Name + ": " + "*" + term + "*" + ")" + (string.IsNullOrEmpty(field.Booster) ? "" : field.Booster));
-
-                    if (field.SearchType == EkomSearchType.Fuzzy || field.SearchType == EkomSearchType.FuzzyAndWilcard)
-                        luceneQuery.Append(" (" + field.Name + ": " + term + "~" + field.FuzzyConfiguration + ")" + (string.IsNullOrEmpty(field.Booster) ? "" : field.Booster));
-
-                    if (field.SearchType == EkomSearchType.Exact)
-                        luceneQuery.Append(" (" + field.Name + ": " + term + ") " + (string.IsNullOrEmpty(field.Booster) ? "" : field.Booster));
-
-                    luceneQuery.Append(")");
-                }
-
-                luceneQuery.Append(")");
-            }
+            if (luceneQuery.Length == 0)
+                return Array.Empty<SearchResultEntity>();
 
             ct.ThrowIfCancellationRequested();
 
@@ -386,5 +299,110 @@ public class CatalogSearchService : ICatalogSearchService
             _logger.LogInformation(luceneQuery.ToString());
             return new List<SearchResultEntity>();
         }
+    }
+
+    private HashSet<string> GetNormalizedFieldNames()
+    {
+        return _config.ExamineSearchNormalizedFields
+            .Where(field => !string.IsNullOrWhiteSpace(field))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string BuildLuceneQuery(
+        IReadOnlyCollection<EkomSearchField> fields,
+        IReadOnlyList<string> searchTerms,
+        IReadOnlyList<string> normalizedSearchTerms,
+        HashSet<string> normalizedFieldNames)
+    {
+        var query = new StringBuilder();
+        var termCount = Math.Max(searchTerms.Count, normalizedSearchTerms.Count);
+
+        for (var i = 0; i < termCount; i++)
+        {
+            var term = i < searchTerms.Count ? QueryParser.Escape(searchTerms[i]) : string.Empty;
+            var normalizedTerm = i < normalizedSearchTerms.Count ? QueryParser.Escape(normalizedSearchTerms[i]) : string.Empty;
+
+            if (string.IsNullOrWhiteSpace(term) && string.IsNullOrWhiteSpace(normalizedTerm))
+                continue;
+
+            if (query.Length > 0)
+                query.Append(" AND ");
+
+            query.Append("+(");
+
+            var wroteAnyFieldClause = false;
+            foreach (var field in fields)
+            {
+                if (string.IsNullOrWhiteSpace(field.Name))
+                    continue;
+
+                if (!string.IsNullOrWhiteSpace(term))
+                    wroteAnyFieldClause = AppendFieldClause(query, field, term, wroteAnyFieldClause);
+
+                if (!string.IsNullOrWhiteSpace(normalizedTerm) && normalizedFieldNames.Contains(field.Name))
+                {
+                    var normalizedField = new EkomSearchField
+                    {
+                        Name = ExamineSearchTextNormalizer.NormalizedFieldName(field.Name),
+                        SearchType = field.SearchType,
+                        FuzzyConfiguration = field.FuzzyConfiguration,
+                        Booster = field.Booster
+                    };
+
+                    wroteAnyFieldClause = AppendFieldClause(query, normalizedField, normalizedTerm, wroteAnyFieldClause);
+                }
+            }
+
+            query.Append(')');
+
+            if (!wroteAnyFieldClause)
+                return string.Empty;
+        }
+
+        return query.ToString();
+    }
+
+    private static bool AppendFieldClause(StringBuilder query, EkomSearchField field, string term, bool wroteAnyFieldClause)
+    {
+        var clause = BuildFieldClause(field, term);
+        if (string.IsNullOrWhiteSpace(clause))
+            return wroteAnyFieldClause;
+
+        if (wroteAnyFieldClause)
+            query.Append(" OR ");
+
+        query.Append(clause);
+        return true;
+    }
+
+    private static string BuildFieldClause(EkomSearchField field, string term)
+    {
+        // Lucene classic syntax: field:value (no space after ':')
+        // Wrap term-values with parentheses only where needed; keep it simple and valid.
+
+        if (string.IsNullOrWhiteSpace(field.Name))
+            return string.Empty;
+
+        var booster = string.IsNullOrWhiteSpace(field.Booster) ? "" : field.Booster;
+
+        return field.SearchType switch
+        {
+            EkomSearchType.Wildcard =>
+                $"{field.Name}:*{term}*{booster}",
+
+            EkomSearchType.Fuzzy =>
+                $"{field.Name}:{term}~{field.FuzzyConfiguration}{booster}",
+
+            EkomSearchType.FuzzyAndWilcard =>
+                // (wild OR fuzzy) inside a single field-clause
+                $"({field.Name}:*{term}* OR {field.Name}:{term}~{field.FuzzyConfiguration}){booster}",
+
+            EkomSearchType.Exact =>
+                $"{field.Name}:{term}{booster}",
+
+            _ =>
+                // Default to exact if unknown
+                $"{field.Name}:{term}{booster}"
+        };
     }
 }

--- a/Ekom/Ekom.U10/Services/ExamineSearchIndexComponent.cs
+++ b/Ekom/Ekom.U10/Services/ExamineSearchIndexComponent.cs
@@ -1,0 +1,144 @@
+using Ekom;
+using Examine;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+using Umbraco.Cms.Core.Composing;
+
+namespace Ekom.Umb.Services;
+
+internal sealed class ExamineSearchIndexComponent : IComponent
+{
+    private readonly IExamineManager _examineManager;
+    private readonly Configuration _config;
+    private readonly ILogger<ExamineSearchIndexComponent> _logger;
+    private readonly List<BaseIndexProvider> _indexes = new();
+
+    public ExamineSearchIndexComponent(
+        IExamineManager examineManager,
+        Configuration config,
+        ILogger<ExamineSearchIndexComponent> logger)
+    {
+        _examineManager = examineManager;
+        _config = config;
+        _logger = logger;
+    }
+
+    public void Initialize()
+    {
+        foreach (var indexName in GetIndexNames())
+        {
+            if (!_examineManager.TryGetIndex(indexName, out var index) || index is not BaseIndexProvider baseIndex)
+            {
+                _logger.LogWarning("Could not attach Ekom search normalizer to Examine index {IndexName}.", indexName);
+                continue;
+            }
+
+            _indexes.Add(baseIndex);
+            baseIndex.TransformingIndexValues += TransformingIndexValues;
+        }
+    }
+
+    public void Terminate()
+    {
+        foreach (var index in _indexes)
+        {
+            index.TransformingIndexValues -= TransformingIndexValues;
+        }
+
+        _indexes.Clear();
+    }
+
+    private IEnumerable<string> GetIndexNames()
+    {
+        return new[]
+            {
+                _config.ExamineSearchIndex,
+                "ExternalIndex",
+                "InternalIndex"
+            }
+            .Where(indexName => !string.IsNullOrWhiteSpace(indexName))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private void TransformingIndexValues(object? sender, IndexingItemEventArgs e)
+    {
+        var normalizedFields = _config.ExamineSearchNormalizedFields
+            .Where(field => !string.IsNullOrWhiteSpace(field))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (normalizedFields.Count == 0)
+            return;
+
+        var values = e.ValueSet.Values.ToDictionary(
+            kvp => kvp.Key,
+            kvp => (IEnumerable<object>)kvp.Value,
+            StringComparer.OrdinalIgnoreCase);
+
+        var wroteValues = false;
+
+        foreach (var field in normalizedFields)
+        {
+            var fieldValues = GetFieldValues(e.ValueSet.Values, field).ToList();
+            if (fieldValues.Count == 0)
+                continue;
+
+            var normalizedValue = string.Join(
+                ' ',
+                fieldValues
+                    .Select(value => ExamineSearchTextNormalizer.Normalize(value?.ToString() ?? string.Empty))
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Distinct(StringComparer.OrdinalIgnoreCase));
+
+            if (string.IsNullOrWhiteSpace(normalizedValue))
+                continue;
+
+            values[ExamineSearchTextNormalizer.NormalizedFieldName(field)] = [normalizedValue];
+            wroteValues = true;
+        }
+
+        if (!wroteValues)
+            return;
+
+        e.SetValues(values);
+    }
+
+    private static IEnumerable<object> GetFieldValues(
+        IReadOnlyDictionary<string, IReadOnlyList<object>> values,
+        string fieldName)
+    {
+        foreach (var value in values)
+        {
+            if (!IsFieldOrCultureVariant(value.Key, fieldName))
+                continue;
+
+            foreach (var fieldValue in value.Value)
+            {
+                yield return fieldValue;
+            }
+        }
+    }
+
+    private static bool IsFieldOrCultureVariant(string valueFieldName, string fieldName)
+    {
+        if (valueFieldName.Equals(fieldName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!valueFieldName.StartsWith(fieldName + "_", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var suffix = valueFieldName[(fieldName.Length + 1)..];
+        if (string.IsNullOrWhiteSpace(suffix))
+            return false;
+
+        try
+        {
+            _ = CultureInfo.GetCultureInfo(suffix);
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+    }
+}

--- a/Ekom/Ekom.U10/Services/ExamineSearchTextNormalizer.cs
+++ b/Ekom/Ekom.U10/Services/ExamineSearchTextNormalizer.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using System.Text;
+
+namespace Ekom.Umb.Services;
+
+internal static class ExamineSearchTextNormalizer
+{
+    public const string NormalizedFieldSuffix = "_normalized";
+
+    public static string NormalizedFieldName(string fieldName)
+        => fieldName.EndsWith(NormalizedFieldSuffix, StringComparison.OrdinalIgnoreCase)
+            ? fieldName
+            : fieldName + NormalizedFieldSuffix;
+
+    public static string Normalize(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var normalized = value.Normalize(NormalizationForm.FormD);
+        var builder = new StringBuilder(normalized.Length);
+        var previousWasSeparator = true;
+
+        foreach (var c in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.NonSpacingMark)
+                continue;
+
+            AppendNormalizedCharacter(char.ToLowerInvariant(c), builder, ref previousWasSeparator);
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    public static IReadOnlyList<string> Tokenize(string value, bool normalize)
+    {
+        var searchValue = normalize ? Normalize(value) : NormalizeSeparators(value);
+        if (string.IsNullOrWhiteSpace(searchValue))
+            return [];
+
+        return searchValue
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string NormalizeSeparators(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var builder = new StringBuilder(value.Length);
+        var previousWasSeparator = true;
+
+        foreach (var c in value)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                builder.Append(c);
+                previousWasSeparator = false;
+                continue;
+            }
+
+            AppendSeparator(builder, ref previousWasSeparator);
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static void AppendNormalizedCharacter(char c, StringBuilder builder, ref bool previousWasSeparator)
+    {
+        switch (c)
+        {
+            case 'æ':
+                builder.Append("ae");
+                previousWasSeparator = false;
+                return;
+            case 'ð':
+                builder.Append('d');
+                previousWasSeparator = false;
+                return;
+            case 'þ':
+                builder.Append("th");
+                previousWasSeparator = false;
+                return;
+        }
+
+        if (char.IsLetterOrDigit(c))
+        {
+            builder.Append(c);
+            previousWasSeparator = false;
+            return;
+        }
+
+        AppendSeparator(builder, ref previousWasSeparator);
+    }
+
+    private static void AppendSeparator(StringBuilder builder, ref bool previousWasSeparator)
+    {
+        if (previousWasSeparator)
+            return;
+
+        builder.Append(' ');
+        previousWasSeparator = true;
+    }
+}

--- a/Ekom/Ekom/Configuration.cs
+++ b/Ekom/Ekom/Configuration.cs
@@ -61,6 +61,19 @@ public class Configuration
     }
 
     /// <summary>
+    /// Ekom:ExamineSearchNormalizedFields
+    /// Fields that should be duplicated into normalized Examine fields for more forgiving search.
+    /// </summary>
+    public virtual IReadOnlyList<string> ExamineSearchNormalizedFields
+    {
+        get
+        {
+            return _configuration.GetSection("Ekom:ExamineSearchNormalizedFields").Get<string[]>()
+                ?? ["nodeName", "title", "pageTitle", "sku", "searchTags", "summary", "description"];
+        }
+    }
+
+    /// <summary>
     /// Umbraco:CMS:RequestHandler:CharCollection
     /// Gets the Umbraco CharCollection
     /// </summary>

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ All Ekom settings live under the `Ekom` section in `appsettings.json`.
 
 - `PerStoreStock` (bool, default `false`): Use per-store stock cache instead of product/variant stock.
 - `ExamineSearchIndex` (string, default `ExternalIndex`): Examine index name used for search.
+- `ExamineSearchNormalizedFields` (list, default `nodeName`, `title`, `pageTitle`, `sku`, `searchTags`, `summary`, `description`): Examine fields duplicated into `*_normalized` fields so catalog search can match diacritics and symbol-separated terms more reliably.
 - `ShareBasket` (bool, default `false`): Share baskets between stores; requires same currencies across stores.
 - `BasketCookieLifetime` (number, days, default `1`): Order cookie lifespan in days.
 - `CustomImage` (string, default `images`): Media folder alias for product images.
@@ -124,6 +125,73 @@ All Ekom settings live under the `Ekom` section in `appsettings.json`.
 - `Headless:ReValidateApis` (list): Items with `Store`, `Url`, `Secret` for headless revalidation.
 - `OrderDiscountCalculation:ApiKey` (string, required to enable): `POST /ekom/order-discounts/calculate` requires this value in the `X-Ekom-Api-Key` header. When missing or empty, the endpoint always returns unauthorized.
 - `Payments` (object): Provider-specific configuration used by payment providers.
+
+### Catalog search overrides
+
+Ekom resolves catalog search through `ICatalogSearchService`. The default Umbraco implementation is `CatalogSearchService`, registered as scoped by `AddEkom(...)`.
+
+`ICatalogSearchService` exposes three async override points:
+
+- `ProductQueryAsync(...)`: product search used by product listings and `Catalog.ProductSearchAsync(...)`. Override this when an external product search provider should return matching Ekom product IDs.
+- `PublicQueryAsync(...)`: public-facing search returning `SearchResultEntity` records. Override this for autocomplete, site search, or mixed product/category result cards.
+- `InternalQueryAsync(...)`: backoffice/internal search, including the Umbraco searchable tree. Override this when internal CMS search should use a custom provider/index.
+
+To replace search completely, register your implementation after `AddEkom(...)`:
+
+```csharp
+services.AddEkom(configuration);
+services.AddScoped<ICatalogSearchService, CustomCatalogSearchService>();
+```
+
+Example implementation using the default `CatalogSearchService` as a base class:
+
+```csharp
+using Ekom;
+using Ekom.Models;
+using Ekom.Services;
+using Ekom.Umb.Services;
+using Examine;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+
+public sealed class CustomCatalogSearchService : CatalogSearchService
+{
+    public CustomCatalogSearchService(
+        IPublishedContentQuery query,
+        ILogger<CatalogSearchService> logger,
+        IExamineManager examineManager,
+        Configuration config)
+        : base(query, logger, examineManager, config)
+    {
+    }
+
+    public override async Task<(IEnumerable<int> Ids, long Total)> ProductQueryAsync(
+        SearchRequest req,
+        CancellationToken ct = default)
+    {
+        var ids = await SearchProductsInExternalIndexAsync(req, ct);
+        return (ids, ids.Count());
+    }
+
+    public override async Task<(IEnumerable<SearchResultEntity> Results, long Total)> PublicQueryAsync(
+        SearchRequest req,
+        CancellationToken ct = default)
+    {
+        var results = await SearchPublicContentAsync(req, ct);
+        return (results, results.Count());
+    }
+
+    public override async Task<(IEnumerable<SearchResultEntity> Results, long Total)> InternalQueryAsync(
+        SearchRequest req,
+        CancellationToken ct = default)
+    {
+        var results = await SearchBackofficeContentAsync(req, ct);
+        return (results, results.Count());
+    }
+}
+```
+
+If you only need to customize one path, override only that async method and let the base `CatalogSearchService` handle the rest. Register the derived type for `ICatalogSearchService` after `AddEkom(...)`.
 
 ### Order discount calculation API
 


### PR DESCRIPTION
## Summary
- Add configurable normalized Examine search fields with defaults for product/content search fields.
- Index normalized field values across ExternalIndex, InternalIndex, and the configured search index, including culture-variant fields.
- Query both original and normalized fields so Icelandic letters, diacritics, and symbol-separated terms match more reliably.

## Test Plan
- Ran `git diff --check`.
- Ran `dotnet build "Ekom/Ekom.U10/Ekom.U10.csproj"`.