### PR TITLE
fix(algolia): use highest category ranking

### DIFF
--- a/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -329,14 +329,15 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Fact]
-    public void Maps_Product_And_Primary_Category_Ranking()
+    public void Maps_Product_And_Highest_Category_Ranking()
     {
         var mapper = CreateMapper();
         var product = CreateProduct(
             categories:
             [
                 CreateCategory("Primary", algoliaRank: "5"),
-                CreateCategory("Secondary", algoliaRank: "9")
+                CreateCategory("Secondary", algoliaRank: "9"),
+                CreateCategory("Third", algoliaRank: "2")
             ],
             properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -347,7 +348,29 @@ public class AlgoliaProductIndexMapperTests
 
         Assert.NotNull(record);
         Assert.Equal(12, record!.ProductRanking);
-        Assert.Equal(5, record.CategoryRanking);
+        Assert.Equal(9, record.CategoryRanking);
+    }
+
+    [Fact]
+    public void Allows_Negative_Product_And_Category_Ranking()
+    {
+        var mapper = CreateMapper();
+        var product = CreateProduct(
+            categories:
+            [
+                CreateCategory("Primary", algoliaRank: "-10"),
+                CreateCategory("Secondary")
+            ],
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ekmAlgoliaRank"] = "-4"
+            });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(-4, record!.ProductRanking);
+        Assert.Equal(-10, record.CategoryRanking);
     }
 
     [Fact]

--- a/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -47,6 +47,20 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Theory]
+    [InlineData(true, 1)]
+    [InlineData(false, 0)]
+    public void Maps_Availability_As_Numeric_Ranking_Value(bool available, int expected)
+    {
+        var mapper = CreateMapper();
+        var product = CreateProduct(available: available);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(expected, record!.Available);
+    }
+
+    [Theory]
     [InlineData("0", false)]
     [InlineData("1", true)]
     public void Maps_Boolean_Product_Properties_From_Umbraco_Flags(string rawValue, bool expected)
@@ -314,6 +328,46 @@ public class AlgoliaProductIndexMapperTests
         Assert.DoesNotContain("material", record!.Data.Keys);
     }
 
+    [Fact]
+    public void Maps_Product_And_Primary_Category_Ranking()
+    {
+        var mapper = CreateMapper();
+        var product = CreateProduct(
+            categories:
+            [
+                CreateCategory("Primary", algoliaRank: "5"),
+                CreateCategory("Secondary", algoliaRank: "9")
+            ],
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ekmAlgoliaRank"] = "12"
+            });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(12, record!.ProductRanking);
+        Assert.Equal(5, record.CategoryRanking);
+    }
+
+    [Fact]
+    public void Defaults_Product_And_Category_Ranking_To_Zero_When_Missing_Or_Invalid()
+    {
+        var mapper = CreateMapper();
+        var product = CreateProduct(
+            categories: [CreateCategory("Primary", algoliaRank: "invalid")],
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["ekmAlgoliaRank"] = "invalid"
+            });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(0, record!.ProductRanking);
+        Assert.Equal(0, record.CategoryRanking);
+    }
+
     private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null)
     {
         var options = Options.Create(new AlgoliaOptions
@@ -336,12 +390,16 @@ public class AlgoliaProductIndexMapperTests
         Locale = locale
     };
 
-    private static Mock<Ekom.Models.ICategory> CreateCategory(string title, IReadOnlyList<Mock<Ekom.Models.ICategory>>? ancestors = null)
+    private static Mock<Ekom.Models.ICategory> CreateCategory(
+        string title,
+        IReadOnlyList<Mock<Ekom.Models.ICategory>>? ancestors = null,
+        string? algoliaRank = null)
     {
         var category = new Mock<Ekom.Models.ICategory>();
         category.SetupGet(x => x.Title).Returns(title);
         category.SetupGet(x => x.Ancestors).Returns((ancestors ?? []).Select(x => x.Object));
         category.Setup(x => x.GetValue("title", It.IsAny<string?>(), true)).Returns(string.Empty);
+        category.Setup(x => x.GetValue("ekmAlgoliaRank", It.IsAny<string?>(), false)).Returns(algoliaRank ?? string.Empty);
 
         return category;
     }
@@ -355,7 +413,8 @@ public class AlgoliaProductIndexMapperTests
         string sku = "sku",
         string summary = "Summary",
         string description = "Description",
-        string url = "/product")
+        string url = "/product",
+        bool available = true)
     {
         var price = new Mock<Ekom.Models.IPrice>();
         price.SetupGet(x => x.Value).Returns(100m);
@@ -373,7 +432,7 @@ public class AlgoliaProductIndexMapperTests
         product.SetupGet(x => x.Images).Returns([]);
         product.SetupGet(x => x.UrlsWithContext).Returns([]);
         product.SetupGet(x => x.Urls).Returns([]);
-        product.SetupGet(x => x.Available).Returns(true);
+        product.SetupGet(x => x.Available).Returns(available);
         product.SetupGet(x => x.Stock).Returns(10m);
         product.SetupGet(x => x.Price).Returns(price.Object);
         product.SetupGet(x => x.Prices).Returns([price.Object]);

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -81,7 +81,9 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             PriceWithVat = price?.WithVat.Value,
             PriceWithoutVat = price?.WithoutVat.Value,
             Currency = NullIfWhiteSpace(price?.Currency.ISOCurrencySymbol ?? store.Currency),
-            Available = product.Available,
+            Available = product.Available ? 1 : 0,
+            ProductRanking = ResolveRank(product, store.Alias),
+            CategoryRanking = ResolveCategoryRank(product, store.Alias),
             Stock = store.IncludeStock ? product.Stock : null,
             StoreAlias = NullIfWhiteSpace(store.Alias),
             Locale = NullIfWhiteSpace(store.Locale),
@@ -177,6 +179,23 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             return null;
 
         return NormalizePropertyValue(raw, configuredField.ValueType);
+    }
+
+    private static int ResolveCategoryRank(IProduct product, string? storeAlias)
+    {
+        var primaryCategory = product.Categories.FirstOrDefault();
+        return primaryCategory is null ? 0 : ResolveRank(primaryCategory, storeAlias);
+    }
+
+    private static int ResolveRank(INodeEntity node, string? storeAlias)
+    {
+        var raw = node.GetValue("ekmAlgoliaRank", storeAlias);
+        if (string.IsNullOrWhiteSpace(raw))
+            return 0;
+
+        return int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var rank)
+            ? rank
+            : 0;
     }
 
     private static object? ResolveMetafieldValue(IProduct product, string alias, string? locale, AlgoliaFieldValueType valueType)

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -183,19 +183,26 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
     private static int ResolveCategoryRank(IProduct product, string? storeAlias)
     {
-        var primaryCategory = product.Categories.FirstOrDefault();
-        return primaryCategory is null ? 0 : ResolveRank(primaryCategory, storeAlias);
+        var rank = product.Categories
+            .Select(category => TryResolveRank(category, storeAlias))
+            .Where(value => value.HasValue)
+            .Max();
+
+        return rank ?? 0;
     }
 
     private static int ResolveRank(INodeEntity node, string? storeAlias)
+        => TryResolveRank(node, storeAlias) ?? 0;
+
+    private static int? TryResolveRank(INodeEntity node, string? storeAlias)
     {
         var raw = node.GetValue("ekmAlgoliaRank", storeAlias);
         if (string.IsNullOrWhiteSpace(raw))
-            return 0;
+            return null;
 
         return int.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var rank)
             ? rank
-            : 0;
+            : null;
     }
 
     private static object? ResolveMetafieldValue(IProduct product, string alias, string? locale, AlgoliaFieldValueType valueType)

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
@@ -43,7 +43,11 @@ public sealed class AlgoliaProductRecord
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Currency { get; init; }
 
-    public bool Available { get; init; }
+    public int Available { get; init; }
+
+    public int ProductRanking { get; init; }
+
+    public int CategoryRanking { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public decimal? Stock { get; init; }

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -52,7 +52,7 @@ public sealed class ProductSearchController
                 {
                     Query = "shoe",
                     HitsPerPage = 20,
-                    Filters = "available:true"
+                    Filters = "Available:1"
                 }
             },
             ct).ConfigureAwait(false);
@@ -200,6 +200,8 @@ public sealed class ProductSearchController
 - Store `Locale` and `Currency` now come from the Ekom store resolved by alias, so `appsettings.json` only needs the store alias.
 - Request and order context decide which culture and currency suffix is used; background indexing falls back to the store's default culture/currency.
 - `Title` is always indexed as a top-level field, and `NodeName` contains the Umbraco node name.
+- `Available` is indexed as `1` for available products and `0` for unavailable products, so it can be used for numeric ranking.
+- Product records always include top-level `ProductRanking` and `CategoryRanking` integer fields. Both default to `0`. `ProductRanking` reads the product `ekmAlgoliaRank` property, and `CategoryRanking` reads `ekmAlgoliaRank` from the product's primary category.
 - Variants are not indexed by default.
 - `Indexing.ProductProperties` supports one optional modifier per property: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
 - Metafields can be indexed explicitly with `metafield:<alias>`, for example `metafield:material`, `metafield:color|array`, or `metafield:releaseDate|unix`.

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -201,7 +201,7 @@ public sealed class ProductSearchController
 - Request and order context decide which culture and currency suffix is used; background indexing falls back to the store's default culture/currency.
 - `Title` is always indexed as a top-level field, and `NodeName` contains the Umbraco node name.
 - `Available` is indexed as `1` for available products and `0` for unavailable products, so it can be used for numeric ranking.
-- Product records always include top-level `ProductRanking` and `CategoryRanking` integer fields. Both default to `0`. `ProductRanking` reads the product `ekmAlgoliaRank` property, and `CategoryRanking` reads `ekmAlgoliaRank` from the product's primary category.
+- Product records always include top-level `ProductRanking` and `CategoryRanking` integer fields. Both support negative values. `ProductRanking` reads the product `ekmAlgoliaRank` property and defaults to `0` when missing or invalid. `CategoryRanking` uses the highest valid `ekmAlgoliaRank` value across the product's categories and defaults to `0` when no category has a valid rank.
 - Variants are not indexed by default.
 - `Indexing.ProductProperties` supports one optional modifier per property: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
 - Metafields can be indexed explicitly with `metafield:<alias>`, for example `metafield:material`, `metafield:color|array`, or `metafield:releaseDate|unix`.


### PR DESCRIPTION
## Summary
- Use the highest valid `ekmAlgoliaRank` across product categories for `CategoryRanking`.
- Allow negative product and category ranking values, defaulting to `0` only when no valid value is set.
- Update product mapper tests and README documentation for the ranking behavior.

## Test Plan
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --no-restore --filter "FullyQualifiedName~AlgoliaProductIndexMapperTests"`