### PR TITLE
feat(klaviyo): add generic event service

### DIFF
--- a/Plugins/Ekom.Klaviyo/Clients/KlaviyoEventsClient.cs
+++ b/Plugins/Ekom.Klaviyo/Clients/KlaviyoEventsClient.cs
@@ -1,0 +1,61 @@
+using Ekom.Klaviyo.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Ekom.Klaviyo.Clients;
+
+internal interface IKlaviyoEventsClient
+{
+    Task SendEventAsync(object requestPayload, string storeAlias, CancellationToken ct = default);
+}
+
+internal sealed class KlaviyoEventsClient : IKlaviyoEventsClient
+{
+    private readonly KlaviyoHttpClient _http;
+    private readonly KlaviyoOptions _opt;
+    private readonly ILogger<KlaviyoEventsClient> _logger;
+
+    public KlaviyoEventsClient(
+        KlaviyoHttpClient http,
+        IOptions<KlaviyoOptions> options,
+        ILogger<KlaviyoEventsClient> logger)
+    {
+        _http = http;
+        _opt = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendEventAsync(
+        object requestPayload,
+        string storeAlias,
+        CancellationToken ct = default)
+    {
+        if (!_opt.Enabled || requestPayload is null)
+            return;
+
+        try
+        {
+            _logger.LogDebug(
+                "Klaviyo: sending event for store {StoreAlias}",
+                storeAlias);
+
+            await _http.PostAsync("/api/events", requestPayload, storeAlias, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            _logger.LogDebug(
+                "Klaviyo: event send cancelled for store {StoreAlias}",
+                storeAlias);
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Klaviyo: failed to send event for store {StoreAlias}. PayloadType={PayloadType}",
+                storeAlias,
+                requestPayload.GetType().Name);
+        }
+    }
+}

--- a/Plugins/Ekom.Klaviyo/KlaviyoServiceCollectionExtensions.cs
+++ b/Plugins/Ekom.Klaviyo/KlaviyoServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ public static class KlaviyoServiceCollectionExtensions
         services.AddSingleton<IKlaviyoOrdersClient, KlaviyoOrdersClient>();
         services.AddSingleton<IKlaviyoProfilesClient, KlaviyoProfilesClient>();
         services.AddSingleton<IKlaviyoTrackingClient, KlaviyoTrackingClient>();
+        services.AddSingleton<IKlaviyoEventsClient, KlaviyoEventsClient>();
 
         // Dispatchers (singleton hosted services)
         services.AddSingleton<KlaviyoCatalogDispatcher>();
@@ -74,6 +75,7 @@ public static class KlaviyoServiceCollectionExtensions
         services.AddScoped<IKlaviyoOrderService, KlaviyoOrderService>();
         services.AddScoped<IKlaviyoProfilesService, KlaviyoProfilesService>();
         services.AddScoped<IKlaviyoTrackingService, KlaviyoTrackingService>();
+        services.AddScoped<IKlaviyoEventService, KlaviyoEventService>();
 
         // Enrichers
         services.AddSingleton<KlaviyoProductEnrichmentPipeline>();

--- a/Plugins/Ekom.Klaviyo/Mappers/EventMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/EventMapper.cs
@@ -1,0 +1,137 @@
+using Ekom.Klaviyo.Models.Events;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Ekom.Klaviyo.Mappers;
+
+internal static class EventMapper
+{
+    internal static object ToCustomEventRequest(this KlaviyoCustomEvent e, KlaviyoOptions opt)
+    {
+        var occurredAt = e.OccurredAt == default
+            ? DateTimeOffset.UtcNow
+            : e.OccurredAt;
+
+        var metricName = e.EventName + (opt.Testing ? " Test" : "");
+        var uniqueId = BuildUniqueId(e.StoreAlias, e.EventName, e.UniqueId, opt.Testing);
+
+        return new JsonObject
+        {
+            ["data"] = new JsonObject
+            {
+                ["type"] = "event",
+                ["attributes"] = new JsonObject
+                {
+                    ["unique_id"] = uniqueId,
+                    ["metric"] = new JsonObject
+                    {
+                        ["data"] = new JsonObject
+                        {
+                            ["type"] = "metric",
+                            ["attributes"] = new JsonObject
+                            {
+                                ["name"] = metricName
+                            }
+                        }
+                    },
+                    ["profile"] = new JsonObject
+                    {
+                        ["data"] = new JsonObject
+                        {
+                            ["type"] = "profile",
+                            ["attributes"] = e.Profile.ToProfileAttributes()
+                        }
+                    },
+                    ["time"] = occurredAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
+                    ["properties"] = ToPropertiesObject(e.Properties)
+                }
+            }
+        };
+    }
+
+    private static JsonObject ToPropertiesObject(object? properties)
+    {
+        if (properties is null)
+            return [];
+
+        if (properties is JsonObject jsonObject)
+            return jsonObject.DeepClone().AsObject();
+
+        var node = JsonSerializer.SerializeToNode(properties);
+        return node is JsonObject serializedObject
+            ? serializedObject
+            : [];
+    }
+
+    private static string BuildUniqueId(string storeAlias, string eventName, string? uniqueId, bool testing)
+    {
+        var id = string.IsNullOrWhiteSpace(uniqueId)
+            ? Guid.NewGuid().ToString("N")
+            : uniqueId;
+
+        var suffix = testing ? ":Test" : string.Empty;
+
+        return $"{storeAlias}:{eventName}:{id}{suffix}";
+    }
+
+    private static JsonObject ToProfileAttributes(this KlaviyoEventProfile c)
+    {
+        var attributes = new JsonObject();
+
+        if (!string.IsNullOrWhiteSpace(c.Email))
+            attributes["email"] = c.Email;
+
+        if (!string.IsNullOrWhiteSpace(c.PhoneNumber))
+            attributes["phone_number"] = c.PhoneNumber;
+
+        if (!string.IsNullOrWhiteSpace(c.ExternalId))
+            attributes["external_id"] = c.ExternalId;
+
+        if (!string.IsNullOrWhiteSpace(c.FirstName))
+            attributes["first_name"] = c.FirstName;
+
+        if (!string.IsNullOrWhiteSpace(c.LastName))
+            attributes["last_name"] = c.LastName;
+
+        if (!string.IsNullOrWhiteSpace(c.Organisation))
+            attributes["organization"] = c.Organisation;
+
+        var location = new JsonObject();
+
+        if (!string.IsNullOrWhiteSpace(c.Address))
+            location["address1"] = c.Address;
+
+        if (!string.IsNullOrWhiteSpace(c.Address2))
+            location["address2"] = c.Address2;
+
+        if (!string.IsNullOrWhiteSpace(c.ZipCode))
+            location["zip"] = c.ZipCode;
+
+        if (!string.IsNullOrWhiteSpace(c.City))
+            location["city"] = c.City;
+
+        if (!string.IsNullOrWhiteSpace(c.Country))
+            location["country"] = c.Country;
+
+        if (location.Count > 0)
+            attributes["location"] = location;
+
+        if (c.CustomProperties is null || c.CustomProperties.Count == 0)
+            return attributes;
+
+        var properties = new JsonObject();
+
+        foreach (var kvp in c.CustomProperties)
+        {
+            if (kvp.Value is null) continue;
+            if (kvp.Value is string s && string.IsNullOrWhiteSpace(s)) continue;
+
+            properties[kvp.Key] = JsonValue.Create(kvp.Value);
+        }
+
+        if (properties.Count > 0)
+            attributes["properties"] = properties;
+
+        return attributes;
+    }
+}

--- a/Plugins/Ekom.Klaviyo/Models/Events/KlaviyoCustomEvent.cs
+++ b/Plugins/Ekom.Klaviyo/Models/Events/KlaviyoCustomEvent.cs
@@ -1,0 +1,32 @@
+namespace Ekom.Klaviyo.Models.Events;
+
+public sealed record KlaviyoCustomEvent
+{
+    public required string StoreAlias { get; init; }
+    public required string EventName { get; init; }
+    public required KlaviyoEventProfile Profile { get; init; }
+    public object? Properties { get; init; }
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
+    public string? UniqueId { get; init; }
+}
+
+public sealed class KlaviyoEventProfile
+{
+    public string? Email { get; set; }
+    public string? PhoneNumber { get; set; }
+    public string? ExternalId { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? Address { get; set; }
+    public string? Address2 { get; set; }
+    public string? ZipCode { get; set; }
+    public string? City { get; set; }
+    public string? Country { get; set; }
+    public string? Organisation { get; set; }
+    public IReadOnlyDictionary<string, object?>? CustomProperties { get; init; }
+
+    public bool HasIdentifier =>
+        !string.IsNullOrWhiteSpace(Email) ||
+        !string.IsNullOrWhiteSpace(PhoneNumber) ||
+        !string.IsNullOrWhiteSpace(ExternalId);
+}

--- a/Plugins/Ekom.Klaviyo/README.md
+++ b/Plugins/Ekom.Klaviyo/README.md
@@ -193,6 +193,49 @@ If none are set, profiles are not added to a list.
 | `Dispatching` | `object` | Background dispatching settings. |
 
 
+## Generic Events
+
+Use `IKlaviyoEventService` to send project-specific events that are not built into the package. Generic events require a store alias and only depend on the global `Klaviyo:Enabled` setting; they do not require `Tracking:Enabled` to be enabled.
+
+```csharp
+using Ekom.Klaviyo.Models.Events;
+using Ekom.Klaviyo.Services;
+
+public sealed class AccountEmails
+{
+    private readonly IKlaviyoEventService _events;
+
+    public AccountEmails(IKlaviyoEventService events)
+    {
+        _events = events;
+    }
+
+    public Task VerifyEmailAsync(
+        string storeAlias,
+        string email,
+        string name,
+        string tokenUrl,
+        CancellationToken ct)
+        => _events.SendEventAsync(
+            storeAlias,
+            "Verify Email Requested",
+            new { activate_url = tokenUrl },
+            new KlaviyoEventProfile
+            {
+                Email = email,
+                FirstName = name
+            },
+            ct: ct);
+}
+```
+
+If you need full control over the Klaviyo request body, send the complete `/api/events` envelope with `SendRawEventAsync`:
+
+```csharp
+await events.SendRawEventAsync(storeAlias, payload, ct);
+```
+
+
 ## Tracking Enrichers
 
 Tracking events can be enriched before being mapped and dispatched. Implement `IKlaviyoTrackingEnricher` and register it with DI to add or modify properties on the tracking payload.

--- a/Plugins/Ekom.Klaviyo/Services/KlaviyoEventService.cs
+++ b/Plugins/Ekom.Klaviyo/Services/KlaviyoEventService.cs
@@ -1,0 +1,122 @@
+using Ekom.Klaviyo.Clients;
+using Ekom.Klaviyo.Mappers;
+using Ekom.Klaviyo.Models.Events;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Ekom.Klaviyo.Services;
+
+public interface IKlaviyoEventService
+{
+    Task SendEventAsync(KlaviyoCustomEvent payload, CancellationToken ct = default);
+
+    Task SendEventAsync(
+        string storeAlias,
+        string eventName,
+        object? properties,
+        KlaviyoEventProfile profile,
+        DateTimeOffset? occurredAt = null,
+        string? uniqueId = null,
+        CancellationToken ct = default);
+
+    Task SendRawEventAsync(string storeAlias, object payload, CancellationToken ct = default);
+}
+
+internal sealed class KlaviyoEventService : IKlaviyoEventService
+{
+    private readonly KlaviyoOptions _opt;
+    private readonly IKlaviyoEventsClient _client;
+    private readonly ILogger<KlaviyoEventService> _logger;
+
+    public KlaviyoEventService(
+        IOptions<KlaviyoOptions> opt,
+        IKlaviyoEventsClient client,
+        ILogger<KlaviyoEventService> logger)
+    {
+        _opt = opt.Value;
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task SendEventAsync(KlaviyoCustomEvent payload, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (!_opt.Enabled)
+            return;
+
+        if (!ValidatePayload(payload.StoreAlias, payload.EventName, payload.Profile))
+            return;
+
+        await _client.SendEventAsync(payload.ToCustomEventRequest(_opt), payload.StoreAlias, ct).ConfigureAwait(false);
+    }
+
+    public Task SendEventAsync(
+        string storeAlias,
+        string eventName,
+        object? properties,
+        KlaviyoEventProfile profile,
+        DateTimeOffset? occurredAt = null,
+        string? uniqueId = null,
+        CancellationToken ct = default)
+    {
+        var payload = new KlaviyoCustomEvent
+        {
+            StoreAlias = storeAlias,
+            EventName = eventName,
+            Properties = properties,
+            Profile = profile,
+            OccurredAt = occurredAt ?? DateTimeOffset.UtcNow,
+            UniqueId = uniqueId
+        };
+
+        return SendEventAsync(payload, ct);
+    }
+
+    public async Task SendRawEventAsync(string storeAlias, object payload, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (!_opt.Enabled)
+            return;
+
+        if (string.IsNullOrWhiteSpace(storeAlias))
+        {
+            _logger.LogWarning(
+                "Klaviyo: skipping raw event because no store alias was provided.");
+            return;
+        }
+
+        await _client.SendEventAsync(payload, storeAlias, ct).ConfigureAwait(false);
+    }
+
+    private bool ValidatePayload(string storeAlias, string eventName, KlaviyoEventProfile profile)
+    {
+        if (string.IsNullOrWhiteSpace(storeAlias))
+        {
+            _logger.LogWarning(
+                "Klaviyo: skipping {EventName} because no store alias was provided.",
+                eventName);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(eventName))
+        {
+            _logger.LogWarning(
+                "Klaviyo: skipping event because no event name was provided. Store={StoreAlias}",
+                storeAlias);
+            return false;
+        }
+
+        if (profile is null || !profile.HasIdentifier)
+        {
+            _logger.LogWarning(
+                "Klaviyo: skipping {EventName} because no customer identifier was provided. Store={StoreAlias}",
+                eventName,
+                storeAlias);
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IKlaviyoEventService` for sending project-specific Klaviyo events directly to `/api/events`.
- Support both helper-built event payloads and raw Klaviyo event request envelopes.
- Register the new event service/client and document generic event usage.

## Test Plan
- `dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj"`