### PR TITLE
fix(stock): filter editor stores by product

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js
@@ -1,4 +1,11 @@
-angular.module('umbraco').controller('Ekom.Stock', function ($scope, $routeParams, $http, contentResource, $q) {
+angular.module('umbraco').controller('Ekom.Stock', [
+  '$scope',
+  '$routeParams',
+  '$http',
+  'contentResource',
+  '$q',
+  'Ekom.Resources',
+  function ($scope, $routeParams, $http, contentResource, $q, ekmResources) {
 
   if ($routeParams.section !== 'content') { return; }
 
@@ -13,26 +20,17 @@ angular.module('umbraco').controller('Ekom.Stock', function ($scope, $routeParam
     if ($scope.perStoreStock) {
 
 
-      $http.get(Umbraco.Sys.ServerVariables.ekom.apiEndpoint + 'Stores').then(function (results) {
+      ekmResources.getStoresByNode($routeParams.id).then(function (stores) {
 
-        if (results.data.length > 1) {
-          results.data.forEach(function (store) {
+        stores.forEach(function (store) {
 
-            getStockValue(store.alias).then(function (stockValue) {
-              $scope.stocks.push({
-                storeAlias: store.alias,
-                value: stockValue
-              });
-            })
-          });
-        } else {
-          getStockValue('').then(function (stockValue) {
+          getStockValue(store.alias).then(function (stockValue) {
             $scope.stocks.push({
-              storeAlias: '',
+              storeAlias: store.alias,
               value: stockValue
             });
           })
-        }
+        });
       });
 
     } else {
@@ -97,4 +95,5 @@ angular.module('umbraco').controller('Ekom.Stock', function ($scope, $routeParam
     $scope.model.value = $scope.stocks;
   });
 
-});
+  }
+]);

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js
@@ -1,4 +1,11 @@
-angular.module('umbraco').controller('Ekom.Stock', function ($scope, $routeParams, $http, contentResource, $q) {
+angular.module('umbraco').controller('Ekom.Stock', [
+  '$scope',
+  '$routeParams',
+  '$http',
+  'contentResource',
+  '$q',
+  'Ekom.Resources',
+  function ($scope, $routeParams, $http, contentResource, $q, ekmResources) {
 
   if ($routeParams.section !== 'content') { return; }
 
@@ -13,26 +20,17 @@ angular.module('umbraco').controller('Ekom.Stock', function ($scope, $routeParam
     if ($scope.perStoreStock) {
 
 
-      $http.get(Umbraco.Sys.ServerVariables.ekom.apiEndpoint + 'Stores').then(function (results) {
+      ekmResources.getStoresByNode($routeParams.id).then(function (stores) {
 
-        if (results.data.length > 1) {
-          results.data.forEach(function (store) {
+        stores.forEach(function (store) {
 
-            getStockValue(store.alias).then(function (stockValue) {
-              $scope.stocks.push({
-                storeAlias: store.alias,
-                value: stockValue
-              });
-            })
-          });
-        } else {
-          getStockValue('').then(function (stockValue) {
+          getStockValue(store.alias).then(function (stockValue) {
             $scope.stocks.push({
-              storeAlias: '',
+              storeAlias: store.alias,
               value: stockValue
             });
           })
-        }
+        });
       });
 
     } else {
@@ -97,4 +95,5 @@ angular.module('umbraco').controller('Ekom.Stock', function ($scope, $routeParam
     $scope.model.value = $scope.stocks;
   });
 
-});
+  }
+]);


### PR DESCRIPTION
## Summary
- Update the stock editor to use product-specific store filtering, matching the price editor behavior.
- Only show and save stock rows for stores enabled on the current product node.
- Apply the same App_Plugins change in both Ekom.Web and the demo site.

## Test Plan
- `node --check "Ekom/Ekom.Web/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js"`
- `node --check "Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js"`
- `git diff --check -- "Ekom/Ekom.Web/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js" "Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/StockEditor/ekomStock.controller.js"`