### PR TITLE
fix(klaviyo): format event dates invariantly

### DIFF
--- a/Plugins/Ekom.Klaviyo/Helpers/KlaviyoDateFormatter.cs
+++ b/Plugins/Ekom.Klaviyo/Helpers/KlaviyoDateFormatter.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace Ekom.Klaviyo.Helpers;
+
+internal static class KlaviyoDateFormatter
+{
+    private const string DateTimeFormat = "yyyy-MM-dd'T'HH':'mm':'ss'Z'";
+
+    internal static string ToKlaviyoDateTime(this DateTimeOffset value)
+        => value.ToUniversalTime().ToString(DateTimeFormat, CultureInfo.InvariantCulture);
+
+    internal static string? ToKlaviyoDateTime(this DateTimeOffset? value)
+        => value?.ToKlaviyoDateTime();
+}

--- a/Plugins/Ekom.Klaviyo/Mappers/EventMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/EventMapper.cs
@@ -1,3 +1,4 @@
+using Ekom.Klaviyo.Helpers;
 using Ekom.Klaviyo.Models.Events;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -42,7 +43,7 @@ internal static class EventMapper
                             ["attributes"] = e.Profile.ToProfileAttributes()
                         }
                     },
-                    ["time"] = occurredAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
+                    ["time"] = occurredAt.ToKlaviyoDateTime(),
                     ["properties"] = ToPropertiesObject(e.Properties)
                 }
             }

--- a/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
@@ -159,9 +159,9 @@ public static class OrderMapper
             ["value"] = o.Value,
             ["value_formatted"] = o.ValueFormatted,
             ["currency"] = o.Currency,
-            ["placed_at"] = o.PlacedAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
-            ["created_at"] = o.CreatedAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
-            ["paid_at"] = o.PaidAt?.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
+            ["placed_at"] = o.PlacedAt.ToKlaviyoDateTime(),
+            ["created_at"] = o.CreatedAt.ToKlaviyoDateTime(),
+            ["paid_at"] = o.PaidAt.ToKlaviyoDateTime(),
             ["checkout_url"] = o.CheckoutUrl,
             ["payment_method"] = o.PaymentProvider?.ToPaymentProviderEvent() ?? null,
             ["discount_value"] = o.DiscountValue,
@@ -203,7 +203,7 @@ public static class OrderMapper
                     }
                 },
 
-                time = o.PlacedAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
+                time = o.PlacedAt.ToKlaviyoDateTime(),
                 properties
             }
         };

--- a/Plugins/Ekom.Klaviyo/Mappers/TrackingMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/TrackingMapper.cs
@@ -147,7 +147,7 @@ internal static class TrackingMapper
         var properties = new JsonObject
         {
             ["store_alias"] = e.StoreAlias,
-            ["occurred_at"] = e.OccurredAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'")
+            ["occurred_at"] = e.OccurredAt.ToKlaviyoDateTime()
         };
 
         if (!string.IsNullOrWhiteSpace(e.OrderId))
@@ -181,7 +181,7 @@ internal static class TrackingMapper
         var properties = new JsonObject
         {
             ["store_alias"] = e.StoreAlias,
-            ["occurred_at"] = e.OccurredAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'")
+            ["occurred_at"] = e.OccurredAt.ToKlaviyoDateTime()
         };
 
         if (!string.IsNullOrWhiteSpace(e.OrderId))
@@ -238,7 +238,7 @@ internal static class TrackingMapper
                         attributes = customer.ToProfileAttributes()
                     }
                 },
-                time = occurredAt.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'"),
+                time = occurredAt.ToKlaviyoDateTime(),
                 properties
             }
         };


### PR DESCRIPTION
## Summary
- Add a shared Klaviyo date formatter that emits invariant UTC timestamps accepted by Klaviyo.
- Update generic, tracking, and order event payload dates to avoid culture-specific time separators.
- Remove milliseconds from Klaviyo event date strings to match accepted API formats.

## Test Plan
- `dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj" --no-restore`
- `git diff --check -- Plugins/Ekom.Klaviyo`