### PR TITLE
feat(klaviyo): enrich product feed pricing

### DIFF
--- a/Plugins/Ekom.Klaviyo/Controllers/KlaviyoProductController.cs
+++ b/Plugins/Ekom.Klaviyo/Controllers/KlaviyoProductController.cs
@@ -1,3 +1,4 @@
+using Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
 using Ekom.Klaviyo.Mappers;
 using Ekom.Klaviyo.Models.Catalog;
 using Ekom.Models;
@@ -17,13 +18,16 @@ internal class KlaviyoProductController : ControllerBase
 {
     private readonly KlaviyoOptions _opt;
     private readonly IMemoryCache _cache;
+    private readonly KlaviyoProductFeedEnrichmentPipeline _pipeline;
 
     public KlaviyoProductController(
         IOptions<KlaviyoOptions> opt,
-        IMemoryCache cache)
+        IMemoryCache cache,
+        KlaviyoProductFeedEnrichmentPipeline pipeline)
     {
         _opt = opt.Value;
         _cache = cache;
+        _pipeline = pipeline;
     }
 
     [HttpGet("feed")]
@@ -54,12 +58,28 @@ internal class KlaviyoProductController : ControllerBase
             var productsResponse = await API.Catalog.Instance.GetAllProductsAsync(storeAlias, ct: ct);
             var products = productsResponse?.Products;
 
-            var feed = products is null
-                ? new List<KlaviyoProductFeedItem>()
-                : products
-                    .Where(HasProductImage)
-                    .ToKlaviyoProductFeedItems(_opt)
-                    .ToList();
+            var feed = new List<KlaviyoProductFeedItem>();
+
+            if (products is not null)
+            {
+                foreach (var product in products.Where(HasProductImage))
+                {
+                    var item = product.ToKlaviyoProductFeedItem(_opt);
+
+                    await _pipeline.ApplyAsync(
+                        item,
+                        new KlaviyoProductFeedEnrichmentContext
+                        {
+                            StoreAlias = storeAlias,
+                            Product = product,
+                            FeedItem = item,
+                            Options = _opt
+                        },
+                        ct);
+
+                    feed.Add(item);
+                }
+            }
 
             var jsonOptions = new JsonSerializerOptions
             {

--- a/Plugins/Ekom.Klaviyo/Enrichers/ProductFeedEnricher/IKlaviyoProductFeedItemEnricher.cs
+++ b/Plugins/Ekom.Klaviyo/Enrichers/ProductFeedEnricher/IKlaviyoProductFeedItemEnricher.cs
@@ -1,0 +1,8 @@
+using Ekom.Klaviyo.Models.Catalog;
+
+namespace Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
+
+public interface IKlaviyoProductFeedItemEnricher
+{
+    ValueTask EnrichAsync(KlaviyoProductFeedItem item, KlaviyoProductFeedEnrichmentContext ctx, CancellationToken ct);
+}

--- a/Plugins/Ekom.Klaviyo/Enrichers/ProductFeedEnricher/KlaviyoProductFeedEnrichmentContext.cs
+++ b/Plugins/Ekom.Klaviyo/Enrichers/ProductFeedEnricher/KlaviyoProductFeedEnrichmentContext.cs
@@ -1,0 +1,12 @@
+using Ekom.Klaviyo.Models.Catalog;
+using Ekom.Models;
+
+namespace Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
+
+public sealed class KlaviyoProductFeedEnrichmentContext
+{
+    public required string StoreAlias { get; init; }
+    public required IProduct Product { get; init; }
+    public required KlaviyoProductFeedItem FeedItem { get; init; }
+    public required KlaviyoOptions Options { get; init; }
+}

--- a/Plugins/Ekom.Klaviyo/Enrichers/ProductFeedEnricher/KlaviyoProductFeedEnrichmentPipeline.cs
+++ b/Plugins/Ekom.Klaviyo/Enrichers/ProductFeedEnricher/KlaviyoProductFeedEnrichmentPipeline.cs
@@ -1,0 +1,17 @@
+using Ekom.Klaviyo.Models.Catalog;
+
+namespace Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
+
+internal sealed class KlaviyoProductFeedEnrichmentPipeline
+{
+    private readonly IReadOnlyList<IKlaviyoProductFeedItemEnricher> _enrichers;
+
+    public KlaviyoProductFeedEnrichmentPipeline(IEnumerable<IKlaviyoProductFeedItemEnricher> enrichers)
+        => _enrichers = enrichers.ToList();
+
+    public async ValueTask ApplyAsync(KlaviyoProductFeedItem item, KlaviyoProductFeedEnrichmentContext ctx, CancellationToken ct)
+    {
+        foreach (var enricher in _enrichers)
+            await enricher.EnrichAsync(item, ctx, ct);
+    }
+}

--- a/Plugins/Ekom.Klaviyo/KlaviyoServiceCollectionExtensions.cs
+++ b/Plugins/Ekom.Klaviyo/KlaviyoServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Ekom.Klaviyo.Dispatching.Profiles;
 using Ekom.Klaviyo.Dispatching.Tracking;
 using Ekom.Klaviyo.Enrichers.TrackingEnricher;
 using Ekom.Klaviyo.Enrichers.OrderEnricher;
+using Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
 using Ekom.Klaviyo.Enrichers.ProductEnricher;
 using Ekom.Klaviyo.Enrichers.ProfilesEnricher;
 using Ekom.Klaviyo.Http;
@@ -79,6 +80,7 @@ public static class KlaviyoServiceCollectionExtensions
 
         // Enrichers
         services.AddSingleton<KlaviyoProductEnrichmentPipeline>();
+        services.AddSingleton<KlaviyoProductFeedEnrichmentPipeline>();
         services.AddSingleton<KlaviyoProfilesEnrichmentPipeline>();
         services.AddSingleton<KlaviyoPlacedOrderEnrichmentPipeline>();
 

--- a/Plugins/Ekom.Klaviyo/Mappers/ProductFeedMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/ProductFeedMapper.cs
@@ -18,7 +18,7 @@ internal static class ProductFeedMapper
             ? null
             : UrlBuilder.Combine(options.SiteBaseUrl, imageUrl + options.Catalog.ImageCrop);
 
-        var price = options.Catalog.ShowPrice ? product.OriginalPrice?.Value : null;
+        var price = options.Catalog.ShowPrice ? product.Price?.Value : null;
 
         IReadOnlyList<string>? categories = product.Categories.Select(x => x.Title).ToList();
 
@@ -40,18 +40,19 @@ internal static class ProductFeedMapper
         var description = !string.IsNullOrEmpty(product.Description) ? product.Description :
                           !string.IsNullOrEmpty(product.Summary) ? product.Summary : product.Title;
 
-        return new KlaviyoProductFeedItem(
-            Id: $"{product.Store.Alias}:{product.Key.ToString()}",
-            Title: product.Title ?? string.Empty,
-            Link: link,
-            Description: description,
-            Price: price,
-            ImageLink: imageLink,
-            Categories: categories,
-            InventoryQuantity: inventoryQty,
-            InventoryPolicy: inventoryPolicy,
-            CustomAttributes: mergedCustom
-        );
+        return new KlaviyoProductFeedItem
+        {
+            Id = $"{product.Store.Alias}:{product.Key.ToString()}",
+            Title = product.Title ?? string.Empty,
+            Link = link,
+            Description = description,
+            Price = price,
+            ImageLink = imageLink,
+            Categories = categories,
+            InventoryQuantity = inventoryQty,
+            InventoryPolicy = inventoryPolicy,
+            CustomAttributes = mergedCustom
+        };
     }
 
     public static IEnumerable<KlaviyoProductFeedItem> ToKlaviyoProductFeedItems(
@@ -70,7 +71,11 @@ internal static class ProductFeedMapper
         {
             ["sku"] = product.SKU,
             ["store_alias"] = product.Store?.Alias,
-            ["currency"] = product.OriginalPrice?.Currency?.ISOCurrencySymbol,
+            ["currency"] = product.Price?.Currency?.ISOCurrencySymbol ?? product.OriginalPrice?.Currency?.ISOCurrencySymbol,
+            ["original_price"] = product.OriginalPrice?.Value,
+            ["discount_price"] = product.Price?.Value,
+            ["discount_amount"] = product.Price?.DiscountAmount?.Value,
+            ["has_discount"] = product.Price?.HasDiscount ?? false,
             ["published"] = true,
             ["summary"] = product.Summary
         };

--- a/Plugins/Ekom.Klaviyo/Models/Catalog/KlaviyoProductFeedItem.cs
+++ b/Plugins/Ekom.Klaviyo/Models/Catalog/KlaviyoProductFeedItem.cs
@@ -2,35 +2,36 @@ using System.Text.Json.Serialization;
 
 namespace Ekom.Klaviyo.Models.Catalog;
 
-internal sealed record KlaviyoProductFeedItem(
-    [property: JsonPropertyName("id")]
-    string Id,
+public sealed class KlaviyoProductFeedItem
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
 
-    [property: JsonPropertyName("title")]
-    string Title,
+    [JsonPropertyName("title")]
+    public required string Title { get; set; }
 
-    [property: JsonPropertyName("link")]
-    string Link,
+    [JsonPropertyName("link")]
+    public required string Link { get; set; }
 
-    [property: JsonPropertyName("description")]
-    string? Description,
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
 
-    [property: JsonPropertyName("price")]
-    decimal? Price,
+    [JsonPropertyName("price")]
+    public decimal? Price { get; set; }
 
-    [property: JsonPropertyName("image_link")]
-    string? ImageLink,
+    [JsonPropertyName("image_link")]
+    public string? ImageLink { get; set; }
 
-    [property: JsonPropertyName("categories")]
-    IReadOnlyList<string>? Categories,
+    [JsonPropertyName("categories")]
+    public IReadOnlyList<string>? Categories { get; set; }
 
-    [property: JsonPropertyName("inventory_quantity")]
-    decimal? InventoryQuantity,
+    [JsonPropertyName("inventory_quantity")]
+    public decimal? InventoryQuantity { get; set; }
 
-    [property: JsonPropertyName("inventory_policy")]
-    int? InventoryPolicy,
+    [JsonPropertyName("inventory_policy")]
+    public int? InventoryPolicy { get; set; }
 
     // Arbitrary additional fields
-    [property: JsonPropertyName("custom_attributes")]
-    IReadOnlyDictionary<string, object?>? CustomAttributes
-);
+    [JsonPropertyName("custom_attributes")]
+    public Dictionary<string, object?>? CustomAttributes { get; set; }
+}

--- a/Plugins/Ekom.Klaviyo/README.md
+++ b/Plugins/Ekom.Klaviyo/README.md
@@ -161,6 +161,10 @@ If none are set, profiles are not added to a list.
 | `SyncMode` | `string` | Catalog sync strategy (`ApiPush` or `FeedPull`). |
 | `DeleteMode` | `string` | Product deletion behavior (`Hard` or `Soft`). |
 
+Feed pull uses the current Ekom product price for `price`. When a product discount is active, the original price, discount price, discount amount, and discount state are also included in `custom_attributes`.
+
+Projects can customize feed items by registering one or more `IKlaviyoProductFeedItemEnricher` implementations. Enrichers run before feed serialization and can update the mapped item or its custom attributes.
+
 
 ## Tracking
 
@@ -236,21 +240,85 @@ await events.SendRawEventAsync(storeAlias, payload, ct);
 ```
 
 
-## Tracking Enrichers
+## Enrichers
 
-Tracking events can be enriched before being mapped and dispatched. Implement `IKlaviyoTrackingEnricher` and register it with DI to add or modify properties on the tracking payload.
+Enrichers let a site add, override, or inspect Klaviyo payload data before the plugin serializes and queues it. Register one or more implementations in DI after `AddKlaviyo`; they run in DI registration order.
+
+```csharp
+builder.Services.AddKlaviyo();
+builder.Services.AddSingleton<IKlaviyoProductFeedItemEnricher, ProductFeedBrandEnricher>();
+builder.Services.AddSingleton<IKlaviyoProductItemEnricher, CatalogProductBrandEnricher>();
+builder.Services.AddSingleton<IKlaviyoTrackingEnricher, TrackingSourceEnricher>();
+builder.Services.AddSingleton<IKlaviyoPlacedOrderEnricher, OrderChannelEnricher>();
+builder.Services.AddSingleton<IKlaviyoProfilesEnricher, ConsentAuditEnricher>();
+```
+
+Use singleton enrichers unless the enricher depends on scoped services. Keep enrichers fast and avoid logging secrets, API keys, or unnecessary PII.
+
+### Product feed enrichers
+
+Feed enrichers run only for catalog `FeedPull` responses from `/ekom/klaviyo/product/feed`. They receive the original Ekom `IProduct`, the mapped `KlaviyoProductFeedItem`, the store alias, and the current options. Use this to adjust feed data, add custom attributes, or override fields before JSON serialization.
+
+```csharp
+using Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
+using Ekom.Klaviyo.Models.Catalog;
+
+public sealed class ProductFeedBrandEnricher : IKlaviyoProductFeedItemEnricher
+{
+    public ValueTask EnrichAsync(
+        KlaviyoProductFeedItem item,
+        KlaviyoProductFeedEnrichmentContext ctx,
+        CancellationToken ct)
+    {
+        item.CustomAttributes ??= new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        item.CustomAttributes["sku"] = ctx.Product.SKU;
+        item.CustomAttributes["feed_store"] = ctx.StoreAlias;
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+### Catalog API product enrichers
+
+Catalog product enrichers run for catalog `ApiPush` synchronization before items are sent to Klaviyo's catalog API. Use this when you push catalog items through the background dispatcher instead of exposing the feed endpoint.
+
+```csharp
+using Ekom.Klaviyo.Enrichers.ProductEnricher;
+using Ekom.Klaviyo.Models.Catalog;
+
+public sealed class CatalogProductBrandEnricher : IKlaviyoProductItemEnricher
+{
+    public ValueTask EnrichAsync(
+        KlaviyoProductItem item,
+        KlaviyoProductEnrichmentContext ctx,
+        CancellationToken ct)
+    {
+        item.CustomMetadata ??= new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        item.CustomMetadata["source"] = "ekom-api-push";
+        item.CustomMetadata["is_first_publish"] = ctx.IsFirstPublish;
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+### Tracking enrichers
+
+Tracking enrichers run before tracking payloads are mapped and queued. The context contains the tracking event type, store alias, and concrete payload object. Cast the payload to the event type you want to modify.
 
 ```csharp
 using Ekom.Klaviyo.Enrichers.TrackingEnricher;
 using Ekom.Klaviyo.Models.Tracking;
 
-public sealed class MyTrackingEnricher : IKlaviyoTrackingEnricher
+public sealed class TrackingSourceEnricher : IKlaviyoTrackingEnricher
 {
     public ValueTask EnrichAsync(KlaviyoTrackingEnrichmentContext context, CancellationToken ct = default)
     {
-        if (context.Payload is KlaviyoViewedProductEvent e)
+        if (context.Payload is KlaviyoViewedProductEvent viewedProduct)
         {
-            e.CustomProperties["source"] = "ekom";
+            viewedProduct.CustomProperties["source"] = "ekom";
+            viewedProduct.CustomProperties["store_alias"] = context.StoreAlias;
         }
 
         return ValueTask.CompletedTask;
@@ -258,10 +326,60 @@ public sealed class MyTrackingEnricher : IKlaviyoTrackingEnricher
 }
 ```
 
-Register your enricher in DI:
+### Placed order enrichers
+
+Placed order enrichers run before `Placed Order` events are mapped and queued. Use them to add custom event properties, normalize order data, or attach project-specific metadata.
 
 ```csharp
-services.AddSingleton<IKlaviyoTrackingEnricher, MyTrackingEnricher>();
+using Ekom.Klaviyo.Enrichers.OrderEnricher;
+using Ekom.Klaviyo.Models.Orders;
+
+public sealed class OrderChannelEnricher : IKlaviyoPlacedOrderEnricher
+{
+    public ValueTask EnrichAsync(KlaviyoPlacedOrder order, CancellationToken ct)
+    {
+        order.CustomProperties["sales_channel"] = "web";
+        order.CustomProperties["store_alias"] = order.StoreAlias;
+
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+### Profile enrichers
+
+Profile enrichers run before profile upsert and subscribe operations are dispatched. The current profile enricher contract receives the profile email and consent changes, which is useful for auditing, validation, or side effects that should happen alongside Klaviyo profile updates.
+
+```csharp
+using Ekom.Klaviyo.Enrichers.ProfilesEnricher;
+using Ekom.Klaviyo.Models.Profiles;
+using Microsoft.Extensions.Logging;
+
+public sealed class ConsentAuditEnricher : IKlaviyoProfilesEnricher
+{
+    private readonly ILogger<ConsentAuditEnricher> _logger;
+
+    public ConsentAuditEnricher(ILogger<ConsentAuditEnricher> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask EnrichAsync(
+        string email,
+        IReadOnlyList<KlaviyoProfileConsentChange>? consents,
+        CancellationToken ct)
+    {
+        if (consents is { Count: > 0 })
+        {
+            _logger.LogInformation(
+                "Klaviyo profile consent update for {Email} with {ConsentCount} consent changes.",
+                email,
+                consents.Count);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
 ```
 
 


### PR DESCRIPTION
## Summary
- Send the current Ekom product price in Klaviyo feed pull responses so discounted prices are available as the catalog price.
- Include original price, discount price, discount amount, and discount state in feed custom attributes.
- Add a product feed enricher extension point and document all Klaviyo enrichers with examples.

## Test Plan
- dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj" --no-restore