### PR TITLE
fix: Update CSS for EKM Manager Order Print

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerOrderPrint.css
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/styles/ekmManagerOrderPrint.css
@@ -1,3 +1,8 @@
+@page {
+    size: A4 portrait;
+    margin: 12mm;
+}
+
 @media print {
 
     * {
@@ -7,35 +12,114 @@
         height: auto !important;
         max-height: none !important;
         overflow: visible !important;
+        box-shadow: none !important;
+        animation: none !important;
+        transition: none !important;
     }
 
-    .umb-app-header {
-        display: none !important;
-    }
+    /* Hide Umbraco chrome */
+    .umb-app-header,
+    .umb-editor-header,
+    .umb-overlay-header,
+    .umb-overlay-drawer,
+    .umb-pane { display: none !important; }
 
-    .umb-dashboard__content {
-        padding: 5px !important;
-    }
+    .umb-dashboard__content { padding: 0 !important; }
 
+    /* Overlay reset */
     .ekmManager .umb-overlay {
-        width: 100% !important;
-        height: 100% !important;
-        max-width: 100% !important;
-        top: 0 !important;
-        z-index: 999999999999 !important;
         background: white !important;
+        border: none !important;
     }
 
-    .ekmManager .umb-overlay-container {
-        max-height: calc(100vh) !important;
-        padding: 0 !important;
+    .ekmManager .umb-overlay-container { padding: 0 !important; }
+
+    /* ── Hide non-essentials ───────────────────────────────────────────── */
+
+    /* Status bar (dropdown, buttons, checkbox) */
+    .ekmOrder__header > div:first-of-type { display: none !important; }
+
+    /* UniqueId */
+    .ekmOrder__header > p:first-of-type { display: none !important; }
+
+    /* Order actions */
+    .ekmOrder [ng-if*="orderActions"] { display: none !important; }
+
+    /* Tracking, consent and activity log */
+    .ekmOrderTracking,
+    .ekmOrderActivityLog { display: none !important; }
+
+    /* Extra customer/shipping/payment data sub-lists */
+    .ekmSplit__column > div[ng-if*="extraCustomer"],
+    .ekmSplit__column > div[ng-if*="extraShipping"],
+    .ekmSplit__column > div[ng-if*="extraCustom"] { display: none !important; }
+
+    /* ── Typography ────────────────────────────────────────────────────── */
+
+    .ekmOrder { font-size: 9pt !important; font-family: Arial, sans-serif !important; color: #000 !important; }
+
+    .ekmOrder__ordernumber { font-size: 15pt !important; margin: 0 0 4px !important; }
+
+    /* ── Header ────────────────────────────────────────────────────────── */
+
+    .ekmOrder__header {
+        margin-bottom: 8px !important;
+        padding-bottom: 6px !important;
     }
 
-    .ekmManager .ekmOrder__ordernumber {
-        font-size: 30px !important;
+    .ekmOrder__header > p {
+        margin: 1px 0 !important;
+        line-height: 1.4 !important;
     }
 
-    .ekmManager header, .ekmManager .umb-overlay-header, .ekmManager .umb-overlay-drawer, .ekmManager .ekmOrder__header #changeOrderStatusButton, .ekmManager .ekmOrder__header #notifyOrderStatus, .ekmManager .umb-pane, .ekmManager .umb-editor-header {
-        display: none !important;
+    /* ── Two-column address/method sections ────────────────────────────── */
+
+    .ekmSplit {
+        display: flex !important;
+        gap: 12px !important;
+        margin-bottom: 8px !important;
     }
+
+    .ekmSplit__column { flex: 1 !important; }
+
+    .ekmSplit__column h4 {
+        font-size: 8pt !important;
+        font-weight: bold !important;
+        text-transform: uppercase !important;
+        letter-spacing: 0.04em !important;
+        margin: 0 0 3px !important;
+    }
+
+    .ekmSplit__column p {
+        margin: 1px 0 !important;
+        line-height: 1.4 !important;
+    }
+
+    /* ── Order lines section heading ───────────────────────────────────── */
+
+    .ekmOrder > h4 {
+        font-size: 8pt !important;
+        font-weight: bold !important;
+        text-transform: uppercase !important;
+        letter-spacing: 0.04em !important;
+        margin: 6px 0 3px !important;
+    }
+
+    /* ── Order lines table ─────────────────────────────────────────────── */
+
+    .umb-table { font-size: 8.5pt !important; }
+
+    .umb-table-head .umb-table-row { background: #f2f2f2 !important; }
+
+    .umb-table-head .umb-table-cell {
+        font-weight: bold !important;
+        padding: 3px 5px !important;
+    }
+
+    .umb-table-body .umb-table-row,
+    .umb-table-footer .umb-table-row { border: none !important; }
+
+    .umb-table-footer .umb-table-row:last-child .umb-table-cell { font-weight: bold !important; }
+
+    .umb-table-cell { padding: 2px 5px !important; border: none !important; }
 }


### PR DESCRIPTION
This pull request updates the print stylesheet for order management in the Ekom Manager to significantly improve the appearance and readability of printed order pages. The changes focus on removing unnecessary UI elements, optimizing the layout for print, and standardizing typography for clarity.

**Print layout and appearance improvements:**

* Added an `@page` rule to set A4 portrait size and appropriate margins for printed pages.
* Standardized font sizes, families, and colors for order content, headings, and tables for better print clarity.
* Improved layout of address and method sections using a two-column flexbox structure, and refined spacing and typography throughout.

**UI cleanup for print:**

* Hid non-essential Umbraco chrome (headers, overlays, panes) and various order management UI elements (status bar, unique ID, order actions, tracking, activity log, extra data sub-lists) to ensure only relevant order information is printed.

**Table and section styling:**

* Enhanced the appearance of order lines tables, including header backgrounds, cell padding, and removal of borders for a cleaner printout.
* Reset box-shadow, animation, and transition styles to prevent unwanted effects in print.