### PR TITLE
feat(manager): edit order customer information

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -23,6 +23,31 @@
     $scope.executingOrderActionKey = null;
     $scope.ga4TrackingData = [];
     $scope.metaTrackingData = [];
+    $scope.customerInformationEditorOpen = false;
+    $scope.customerInformationSaving = false;
+    $scope.customerInformationEditModel = null;
+
+    var customerFields = [
+      { key: "customerName", label: "Name", property: "name" },
+      { key: "customerEmail", label: "Email", property: "email" },
+      { key: "customerAddress", label: "Address", property: "address" },
+      { key: "customerApartment", label: "Apartment", property: "apartment" },
+      { key: "customerCity", label: "City", property: "city" },
+      { key: "customerCountry", label: "Country", property: "country" },
+      { key: "customerZipCode", label: "Zipcode", property: "zipCode" },
+      { key: "customerPhone", label: "Phone", property: "phone" }
+    ];
+
+    var shippingFields = [
+      { key: "shippingName", label: "Name", property: "name" },
+      { key: "shippingEmail", label: "Email", property: "email" },
+      { key: "shippingAddress", label: "Address", property: "address" },
+      { key: "shippingApartment", label: "Apartment", property: "apartment" },
+      { key: "shippingCity", label: "City", property: "city" },
+      { key: "shippingCountry", label: "Country", property: "country" },
+      { key: "shippingZipCode", label: "Zipcode", property: "zipCode" },
+      { key: "shippingPhone", label: "Phone", property: "phone" }
+    ];
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -99,11 +124,14 @@
         "shippingaddress",
         "shippingcity",
         "shippingcountry",
+        "shippingemail",
+        "shippingapartment",
         "shippingzipcode",
         "shippingphone",
         "customeremail",
         "customername",
         "customeraddress",
+        "customerapartment",
         "customercity",
         "customercountry",
         "customerzipcode",
@@ -169,6 +197,62 @@
         .filter(function (entry) {
           return !!entry.key;
         });
+    }
+
+    function getCustomerInformationValue(information, field) {
+      var properties = information && information.properties ? information.properties : {};
+      var value = information && information[field.property] ? information[field.property] : properties[field.key];
+
+      return value ? htmlDecode(value) : "";
+    }
+
+    function mapStandardFields(information, fields) {
+      return fields.map(function (field) {
+        return {
+          key: field.key,
+          label: field.label,
+          value: getCustomerInformationValue(information, field),
+          isExtra: false
+        };
+      });
+    }
+
+    function mapExtraFields(properties, prefix) {
+      return Object.entries(properties || {})
+        .filter(function (entry) {
+          var key = entry[0];
+          var value = entry[1];
+          var normalisedKey = (key || "").toLowerCase();
+
+          return !!value && normalisedKey.startsWith(prefix) && !$scope.isDefaultKey(normalisedKey);
+        })
+        .map(function (entry) {
+          return {
+            key: entry[0],
+            label: cleanExtraFieldLabel(entry[0]),
+            value: htmlDecode(entry[1]),
+            isExtra: true
+          };
+        });
+    }
+
+    function cleanExtraFieldLabel(key) {
+      var label = $scope.cleanKey(key)
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+        .replace(/[_-]+/g, " ")
+        .trim();
+
+      return label || key;
+    }
+
+    function buildCustomerInformationPayload(fields) {
+      var payload = {};
+
+      fields.forEach(function (field) {
+        payload[field.key] = field.value || "";
+      });
+
+      return payload;
     }
 
     function applyOrderData(order) {
@@ -352,6 +436,53 @@
         })
         .finally(function () {
           $scope.executingOrderActionKey = null;
+        });
+    };
+
+    $scope.openCustomerInformationEditor = function () {
+      var order = $scope.model.editModel.order;
+      var customer = order.customerInformation.customer || {};
+      var shipping = order.customerInformation.shipping || {};
+
+      $scope.customerInformationEditModel = {
+        customer: mapStandardFields(customer, customerFields).concat(mapExtraFields(customer.properties, "customer")),
+        shipping: mapStandardFields(shipping, shippingFields).concat(mapExtraFields(shipping.properties, "shipping"))
+      };
+      $scope.customerInformationEditorOpen = true;
+    };
+
+    $scope.closeCustomerInformationEditor = function () {
+      if ($scope.customerInformationSaving) {
+        return;
+      }
+
+      $scope.customerInformationEditorOpen = false;
+      $scope.customerInformationEditModel = null;
+    };
+
+    $scope.saveCustomerInformation = function () {
+      if (!$scope.customerInformationEditModel || $scope.customerInformationSaving) {
+        return;
+      }
+
+      $scope.customerInformationSaving = true;
+
+      resources.UpdateCustomerInformation({
+        orderId: orderId,
+        customer: buildCustomerInformationPayload($scope.customerInformationEditModel.customer),
+        shipping: buildCustomerInformationPayload($scope.customerInformationEditModel.shipping)
+      })
+        .then(function (result) {
+          applyOrderData(result.data);
+          $scope.customerInformationEditorOpen = false;
+          $scope.customerInformationEditModel = null;
+          notificationsService.success("Success", "Customer information updated.");
+          eventsService.emit("order.changed", {});
+        }, function (error) {
+          notificationsService.error("Error", getErrorMessage(error, "Error updating customer information."));
+        })
+        .finally(function () {
+          $scope.customerInformationSaving = false;
         });
     };
 

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -42,6 +42,14 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       });
     }
 
+    function postJson(url, data) {
+      return $http({
+        method: "POST",
+        url: url,
+        data: data
+      });
+    }
+
     return {
       SearchOrders: function (query) {
         return get(backofficeBaseUrl + "SearchOrders", query);
@@ -76,6 +84,9 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       },
       ChangeOrderStatus: function (query) {
         return post(backofficeBaseUrl + "ChangeOrderStatus", query);
+      },
+      UpdateCustomerInformation: function (data) {
+        return postJson(backofficeBaseUrl + "UpdateCustomerInformation", data);
       },
       PaymentProviders: function (storeAlias) {
         return get(baseUrl + "provider/paymentsproviders/" + storeAlias);

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -49,6 +49,9 @@
 
     <div class="ekmOrder__shipping ekmSplit__column">
       <h4>Billing</h4>
+      <button type="button" class="btn btn-outline umb-outline" style="margin-bottom:10px;" ng-click="openCustomerInformationEditor()">
+        Edit customer information
+      </button>
 
       <p>Name: {{ model.editModel.order.customerInformation.customer.name }}</p>
       <p>Email: {{ model.editModel.order.customerInformation.customer.email }}</p>
@@ -341,6 +344,52 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="ekmCustomerInformationModal" ng-if="customerInformationEditorOpen" style="position:fixed; inset:0; background:rgba(0,0,0,.35); z-index:10000; display:flex; align-items:center; justify-content:center; padding:20px;">
+    <div style="background:#fff; width:100%; max-width:760px; max-height:90vh; overflow:auto; border-radius:3px; box-shadow:0 10px 30px rgba(0,0,0,.25);">
+      <div style="display:flex; align-items:center; justify-content:space-between; padding:20px; border-bottom:1px solid #d8d7d9;">
+        <h3 style="margin:0;">Edit customer information</h3>
+        <button type="button" class="btn-reset" ng-click="closeCustomerInformationEditor()" ng-disabled="customerInformationSaving" aria-label="Close">&times;</button>
+      </div>
+
+      <form name="customerInformationForm" ng-submit="saveCustomerInformation()" style="padding:20px;">
+        <div class="ekmSplit">
+          <div class="ekmSplit__column">
+            <h4>Billing</h4>
+            <div class="control-group umb-control-group" ng-repeat="field in customerInformationEditModel.customer track by field.key">
+              <label class="control-label">
+                {{ field.label }}
+                <small ng-if="field.isExtra">({{ field.key }})</small>
+              </label>
+              <div class="umb-property-editor">
+                <input type="text" class="umb-editor umb-textstring" ng-model="field.value" ng-disabled="customerInformationSaving" />
+              </div>
+            </div>
+          </div>
+
+          <div class="ekmSplit__column">
+            <h4>Shipping</h4>
+            <div class="control-group umb-control-group" ng-repeat="field in customerInformationEditModel.shipping track by field.key">
+              <label class="control-label">
+                {{ field.label }}
+                <small ng-if="field.isExtra">({{ field.key }})</small>
+              </label>
+              <div class="umb-property-editor">
+                <input type="text" class="umb-editor umb-textstring" ng-model="field.value" ng-disabled="customerInformationSaving" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div style="display:flex; justify-content:flex-end; gap:10px; padding-top:20px; border-top:1px solid #d8d7d9;">
+          <button type="button" class="btn btn-outline umb-outline" ng-click="closeCustomerInformationEditor()" ng-disabled="customerInformationSaving">Cancel</button>
+          <button type="submit" class="btn btn-success" ng-disabled="customerInformationSaving">
+            {{ customerInformationSaving ? 'Saving...' : 'Save customer information' }}
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 </article>

--- a/Ekom/Ekom/Controllers/EkomManagerController.cs
+++ b/Ekom/Ekom/Controllers/EkomManagerController.cs
@@ -255,6 +255,60 @@ public class EkomManagerController : ControllerBase
         }
     }
 
+    [HttpPost]
+    [Route("UpdateCustomerInformation")]
+    [UmbracoUserAuthorize]
+    public async Task<IActionResult> UpdateCustomerInformationAsync([FromBody] OrderCustomerInformationUpdateRequest? request, CancellationToken ct = default)
+    {
+        if (request == null || request.OrderId == Guid.Empty)
+        {
+            return BadRequest("Invalid customer information update request.");
+        }
+
+        try
+        {
+            var orderData = await _repo.GetOrderAsync(request.OrderId, ct);
+
+            if (!CanAccessStore(orderData.StoreAlias))
+            {
+                return ForbidStore(orderData.StoreAlias);
+            }
+
+            var order = await _repo.GetOrderInfoAsync(request.OrderId, ct);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            var form = new Dictionary<string, string>
+            {
+                ["storeAlias"] = orderData.StoreAlias
+            };
+
+            AddFormValues(form, request.Customer);
+            AddFormValues(form, request.Shipping);
+
+            var updatedOrder = await Order.Instance.UpdateCustomerInformationAsync(form, new OrderSettings
+            {
+                FireEvents = false,
+                OrderInfo = order
+            }, ct).ConfigureAwait(false);
+
+            return Ok(updatedOrder);
+        }
+        catch (FormatException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update customer information. {OrderId}", request.OrderId);
+
+            return StatusCode(500, "An unexpected error occurred.");
+        }
+    }
+
     [HttpGet]
     [Route("charts")]
     [UmbracoUserAuthorize]
@@ -321,6 +375,14 @@ public class EkomManagerController : ControllerBase
     {
         _logger.LogWarning("Manager access denied for store {StoreAlias}", storeAlias);
         return Forbid();
+    }
+
+    private static void AddFormValues(Dictionary<string, string> form, Dictionary<string, string?> values)
+    {
+        foreach (var value in values)
+        {
+            form[value.Key] = value.Value ?? string.Empty;
+        }
     }
 
     public class ChartData

--- a/Ekom/Ekom/Models/Manager/OrderCustomerInformationUpdateRequest.cs
+++ b/Ekom/Ekom/Models/Manager/OrderCustomerInformationUpdateRequest.cs
@@ -1,0 +1,10 @@
+namespace Ekom.Models.Manager;
+
+public sealed class OrderCustomerInformationUpdateRequest
+{
+    public Guid OrderId { get; init; }
+
+    public Dictionary<string, string?> Customer { get; init; } = [];
+
+    public Dictionary<string, string?> Shipping { get; init; } = [];
+}

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -23,6 +23,31 @@
     $scope.executingOrderActionKey = null;
     $scope.ga4TrackingData = [];
     $scope.metaTrackingData = [];
+    $scope.customerInformationEditorOpen = false;
+    $scope.customerInformationSaving = false;
+    $scope.customerInformationEditModel = null;
+
+    var customerFields = [
+      { key: "customerName", label: "Name", property: "name" },
+      { key: "customerEmail", label: "Email", property: "email" },
+      { key: "customerAddress", label: "Address", property: "address" },
+      { key: "customerApartment", label: "Apartment", property: "apartment" },
+      { key: "customerCity", label: "City", property: "city" },
+      { key: "customerCountry", label: "Country", property: "country" },
+      { key: "customerZipCode", label: "Zipcode", property: "zipCode" },
+      { key: "customerPhone", label: "Phone", property: "phone" }
+    ];
+
+    var shippingFields = [
+      { key: "shippingName", label: "Name", property: "name" },
+      { key: "shippingEmail", label: "Email", property: "email" },
+      { key: "shippingAddress", label: "Address", property: "address" },
+      { key: "shippingApartment", label: "Apartment", property: "apartment" },
+      { key: "shippingCity", label: "City", property: "city" },
+      { key: "shippingCountry", label: "Country", property: "country" },
+      { key: "shippingZipCode", label: "Zipcode", property: "zipCode" },
+      { key: "shippingPhone", label: "Phone", property: "phone" }
+    ];
 
     $scope.toggleDropdown = function (dropdownId) {
       $scope.visibleDropdowns[dropdownId] = !$scope.visibleDropdowns[dropdownId];
@@ -99,11 +124,14 @@
         "shippingaddress",
         "shippingcity",
         "shippingcountry",
+        "shippingemail",
+        "shippingapartment",
         "shippingzipcode",
         "shippingphone",
         "customeremail",
         "customername",
         "customeraddress",
+        "customerapartment",
         "customercity",
         "customercountry",
         "customerzipcode",
@@ -169,6 +197,62 @@
         .filter(function (entry) {
           return !!entry.key;
         });
+    }
+
+    function getCustomerInformationValue(information, field) {
+      var properties = information && information.properties ? information.properties : {};
+      var value = information && information[field.property] ? information[field.property] : properties[field.key];
+
+      return value ? htmlDecode(value) : "";
+    }
+
+    function mapStandardFields(information, fields) {
+      return fields.map(function (field) {
+        return {
+          key: field.key,
+          label: field.label,
+          value: getCustomerInformationValue(information, field),
+          isExtra: false
+        };
+      });
+    }
+
+    function mapExtraFields(properties, prefix) {
+      return Object.entries(properties || {})
+        .filter(function (entry) {
+          var key = entry[0];
+          var value = entry[1];
+          var normalisedKey = (key || "").toLowerCase();
+
+          return !!value && normalisedKey.startsWith(prefix) && !$scope.isDefaultKey(normalisedKey);
+        })
+        .map(function (entry) {
+          return {
+            key: entry[0],
+            label: cleanExtraFieldLabel(entry[0]),
+            value: htmlDecode(entry[1]),
+            isExtra: true
+          };
+        });
+    }
+
+    function cleanExtraFieldLabel(key) {
+      var label = $scope.cleanKey(key)
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+        .replace(/[_-]+/g, " ")
+        .trim();
+
+      return label || key;
+    }
+
+    function buildCustomerInformationPayload(fields) {
+      var payload = {};
+
+      fields.forEach(function (field) {
+        payload[field.key] = field.value || "";
+      });
+
+      return payload;
     }
 
     function applyOrderData(order) {
@@ -352,6 +436,53 @@
         })
         .finally(function () {
           $scope.executingOrderActionKey = null;
+        });
+    };
+
+    $scope.openCustomerInformationEditor = function () {
+      var order = $scope.model.editModel.order;
+      var customer = order.customerInformation.customer || {};
+      var shipping = order.customerInformation.shipping || {};
+
+      $scope.customerInformationEditModel = {
+        customer: mapStandardFields(customer, customerFields).concat(mapExtraFields(customer.properties, "customer")),
+        shipping: mapStandardFields(shipping, shippingFields).concat(mapExtraFields(shipping.properties, "shipping"))
+      };
+      $scope.customerInformationEditorOpen = true;
+    };
+
+    $scope.closeCustomerInformationEditor = function () {
+      if ($scope.customerInformationSaving) {
+        return;
+      }
+
+      $scope.customerInformationEditorOpen = false;
+      $scope.customerInformationEditModel = null;
+    };
+
+    $scope.saveCustomerInformation = function () {
+      if (!$scope.customerInformationEditModel || $scope.customerInformationSaving) {
+        return;
+      }
+
+      $scope.customerInformationSaving = true;
+
+      resources.UpdateCustomerInformation({
+        orderId: orderId,
+        customer: buildCustomerInformationPayload($scope.customerInformationEditModel.customer),
+        shipping: buildCustomerInformationPayload($scope.customerInformationEditModel.shipping)
+      })
+        .then(function (result) {
+          applyOrderData(result.data);
+          $scope.customerInformationEditorOpen = false;
+          $scope.customerInformationEditModel = null;
+          notificationsService.success("Success", "Customer information updated.");
+          eventsService.emit("order.changed", {});
+        }, function (error) {
+          notificationsService.error("Error", getErrorMessage(error, "Error updating customer information."));
+        })
+        .finally(function () {
+          $scope.customerInformationSaving = false;
         });
     };
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -42,6 +42,14 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       });
     }
 
+    function postJson(url, data) {
+      return $http({
+        method: "POST",
+        url: url,
+        data: data
+      });
+    }
+
     return {
       SearchOrders: function (query) {
         return get(backofficeBaseUrl + "SearchOrders", query);
@@ -76,6 +84,9 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       },
       ChangeOrderStatus: function (query) {
         return post(backofficeBaseUrl + "ChangeOrderStatus", query);
+      },
+      UpdateCustomerInformation: function (data) {
+        return postJson(backofficeBaseUrl + "UpdateCustomerInformation", data);
       },
       PaymentProviders: function (storeAlias) {
         return get(baseUrl + "provider/paymentsproviders/" + storeAlias);

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -48,6 +48,9 @@
 
     <div class="ekmOrder__shipping ekmSplit__column">
       <h4>Billing</h4>
+      <button type="button" class="btn btn-outline umb-outline" style="margin-bottom:10px;" ng-click="openCustomerInformationEditor()">
+        Edit customer information
+      </button>
 
       <p>Name: {{ model.editModel.order.customerInformation.customer.name }}</p>
       <p>Email: {{ model.editModel.order.customerInformation.customer.email }}</p>
@@ -340,6 +343,52 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+
+  <div class="ekmCustomerInformationModal" ng-if="customerInformationEditorOpen" style="position:fixed; inset:0; background:rgba(0,0,0,.35); z-index:10000; display:flex; align-items:center; justify-content:center; padding:20px;">
+    <div style="background:#fff; width:100%; max-width:760px; max-height:90vh; overflow:auto; border-radius:3px; box-shadow:0 10px 30px rgba(0,0,0,.25);">
+      <div style="display:flex; align-items:center; justify-content:space-between; padding:20px; border-bottom:1px solid #d8d7d9;">
+        <h3 style="margin:0;">Edit customer information</h3>
+        <button type="button" class="btn-reset" ng-click="closeCustomerInformationEditor()" ng-disabled="customerInformationSaving" aria-label="Close">&times;</button>
+      </div>
+
+      <form name="customerInformationForm" ng-submit="saveCustomerInformation()" style="padding:20px;">
+        <div class="ekmSplit">
+          <div class="ekmSplit__column">
+            <h4>Billing</h4>
+            <div class="control-group umb-control-group" ng-repeat="field in customerInformationEditModel.customer track by field.key">
+              <label class="control-label">
+                {{ field.label }}
+                <small ng-if="field.isExtra">({{ field.key }})</small>
+              </label>
+              <div class="umb-property-editor">
+                <input type="text" class="umb-editor umb-textstring" ng-model="field.value" ng-disabled="customerInformationSaving" />
+              </div>
+            </div>
+          </div>
+
+          <div class="ekmSplit__column">
+            <h4>Shipping</h4>
+            <div class="control-group umb-control-group" ng-repeat="field in customerInformationEditModel.shipping track by field.key">
+              <label class="control-label">
+                {{ field.label }}
+                <small ng-if="field.isExtra">({{ field.key }})</small>
+              </label>
+              <div class="umb-property-editor">
+                <input type="text" class="umb-editor umb-textstring" ng-model="field.value" ng-disabled="customerInformationSaving" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div style="display:flex; justify-content:flex-end; gap:10px; padding-top:20px; border-top:1px solid #d8d7d9;">
+          <button type="button" class="btn btn-outline umb-outline" ng-click="closeCustomerInformationEditor()" ng-disabled="customerInformationSaving">Cancel</button>
+          <button type="submit" class="btn btn-success" ng-disabled="customerInformationSaving">
+            {{ customerInformationSaving ? 'Saving...' : 'Save customer information' }}
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 </article>


### PR DESCRIPTION
## Summary
- Add a manager-only endpoint to silently update order customer information.
- Add an edit customer information modal to the manager order view.
- Allow editing visible billing/shipping fields and existing extra customer/shipping data.
- Mirror manager plugin frontend changes into the U10 sample site.

## Test Plan
- Ran `dotnet build "Ekom/Ekom/Ekom.csproj" --no-restore`.
- Open an order in Ekom manager and click "Edit customer information".
- Update billing or shipping fields and save.
- Confirm the modal closes, the order view refreshes, and customer details are updated.
- Confirm invalid email input returns an error notification.
