### PR TITLE
fix(price-cache): add async generation event

### DIFF
--- a/Ekom/Ekom.Common/PriceCache.cs
+++ b/Ekom/Ekom.Common/PriceCache.cs
@@ -39,6 +39,17 @@ public static class PriceCache
         return gen;
     }
 
+    public static async ValueTask<string> GetItemGenerationAsync(string itemKey, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var gen = _itemGenerations.GetOrAdd(itemKey, _ => Guid.NewGuid().ToString("N"));
+
+        gen = await RaiseGenerationCreatedAsync(itemKey, gen, ct).ConfigureAwait(false);
+
+        return gen;
+    }
+
     public static void InvalidateItem(string itemKey)
     {
         var newGen = Guid.NewGuid().ToString("N");
@@ -66,12 +77,30 @@ public static class PriceCache
     }
 
     public static event EventHandler<PriceGenerationEventArgs>? OnGenerationCreated;
+    public static event Func<PriceGenerationEventArgs, CancellationToken, ValueTask>? OnGenerationCreatedAsync;
     public static event EventHandler<PriceGenerationEventArgs>? OnGenerationInvalidated;
 
     private static string RaiseGenerationCreated(string itemKey, string gen)
     {
         var args = new PriceGenerationEventArgs(itemKey, gen);
         OnGenerationCreated?.Invoke(null, args);
+        return args.Generation;
+    }
+
+    private static async ValueTask<string> RaiseGenerationCreatedAsync(string itemKey, string gen, CancellationToken ct)
+    {
+        var args = new PriceGenerationEventArgs(itemKey, gen);
+        var handlers = OnGenerationCreatedAsync;
+
+        if (handlers is null)
+            return args.Generation;
+
+        foreach (var handler in handlers.GetInvocationList())
+        {
+            ct.ThrowIfCancellationRequested();
+            await ((Func<PriceGenerationEventArgs, CancellationToken, ValueTask>)handler)(args, ct).ConfigureAwait(false);
+        }
+
         return args.Generation;
     }
 

--- a/Ekom/Ekom.Tests/Tests/PriceCacheTests.cs
+++ b/Ekom/Ekom.Tests/Tests/PriceCacheTests.cs
@@ -1,0 +1,99 @@
+using Ekom.Cache;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class PriceCacheTests
+{
+    [Fact]
+    public async Task GetItemGenerationAsync_InvokesAsyncHandler()
+    {
+        var itemKey = CreateItemKey();
+        var expectedGeneration = Guid.NewGuid().ToString("N");
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            args.Generation = expectedGeneration;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+
+        try
+        {
+            var generation = await PriceCache.GetItemGenerationAsync(itemKey);
+
+            Assert.Equal(expectedGeneration, generation);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    [Fact]
+    public async Task GetItemGenerationAsync_InvokesAsyncHandlersInRegistrationOrder()
+    {
+        var itemKey = CreateItemKey();
+        var invocations = new List<int>();
+
+        ValueTask FirstHandler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invocations.Add(1);
+            return ValueTask.CompletedTask;
+        }
+
+        ValueTask SecondHandler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invocations.Add(2);
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += FirstHandler;
+        PriceCache.OnGenerationCreatedAsync += SecondHandler;
+
+        try
+        {
+            await PriceCache.GetItemGenerationAsync(itemKey);
+
+            Assert.Equal([1, 2], invocations);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= SecondHandler;
+            PriceCache.OnGenerationCreatedAsync -= FirstHandler;
+        }
+    }
+
+    [Fact]
+    public async Task GetItemGenerationAsync_ThrowsWhenCancelled()
+    {
+        var itemKey = CreateItemKey();
+        var invoked = false;
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invoked = true;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await PriceCache.GetItemGenerationAsync(itemKey, cts.Token));
+
+            Assert.False(invoked);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    private static string CreateItemKey() => $"test-{Guid.NewGuid():N}";
+}


### PR DESCRIPTION
## Summary
- Add an async `PriceCache.OnGenerationCreatedAsync` event for generation creation hooks.
- Add `GetItemGenerationAsync` to await async generation handlers without changing the existing sync API.
- Cover async handler invocation, registration order, and cancellation with focused tests.

## Test Plan
- `dotnet build "Ekom/Ekom.Common/Ekom.Common.csproj"`
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --no-restore --filter "FullyQualifiedName~PriceCacheTests"`
