### PR TITLE
fix: Fix Klaviyo feed culture context

### DIFF
--- a/Ekom/Ekom.Common/PriceCache.cs
+++ b/Ekom/Ekom.Common/PriceCache.cs
@@ -39,6 +39,17 @@ public static class PriceCache
         return gen;
     }
 
+    public static async ValueTask<string> GetItemGenerationAsync(string itemKey, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var gen = _itemGenerations.GetOrAdd(itemKey, _ => Guid.NewGuid().ToString("N"));
+
+        gen = await RaiseGenerationCreatedAsync(itemKey, gen, ct).ConfigureAwait(false);
+
+        return gen;
+    }
+
     public static void InvalidateItem(string itemKey)
     {
         var newGen = Guid.NewGuid().ToString("N");
@@ -66,12 +77,30 @@ public static class PriceCache
     }
 
     public static event EventHandler<PriceGenerationEventArgs>? OnGenerationCreated;
+    public static event Func<PriceGenerationEventArgs, CancellationToken, ValueTask>? OnGenerationCreatedAsync;
     public static event EventHandler<PriceGenerationEventArgs>? OnGenerationInvalidated;
 
     private static string RaiseGenerationCreated(string itemKey, string gen)
     {
         var args = new PriceGenerationEventArgs(itemKey, gen);
         OnGenerationCreated?.Invoke(null, args);
+        return args.Generation;
+    }
+
+    private static async ValueTask<string> RaiseGenerationCreatedAsync(string itemKey, string gen, CancellationToken ct)
+    {
+        var args = new PriceGenerationEventArgs(itemKey, gen);
+        var handlers = OnGenerationCreatedAsync;
+
+        if (handlers is null)
+            return args.Generation;
+
+        foreach (var handler in handlers.GetInvocationList())
+        {
+            ct.ThrowIfCancellationRequested();
+            await ((Func<PriceGenerationEventArgs, CancellationToken, ValueTask>)handler)(args, ct).ConfigureAwait(false);
+        }
+
         return args.Generation;
     }
 

--- a/Ekom/Ekom.Tests/Tests/PriceCacheTests.cs
+++ b/Ekom/Ekom.Tests/Tests/PriceCacheTests.cs
@@ -1,0 +1,99 @@
+using Ekom.Cache;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class PriceCacheTests
+{
+    [Fact]
+    public async Task GetItemGenerationAsync_InvokesAsyncHandler()
+    {
+        var itemKey = CreateItemKey();
+        var expectedGeneration = Guid.NewGuid().ToString("N");
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            args.Generation = expectedGeneration;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+
+        try
+        {
+            var generation = await PriceCache.GetItemGenerationAsync(itemKey);
+
+            Assert.Equal(expectedGeneration, generation);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    [Fact]
+    public async Task GetItemGenerationAsync_InvokesAsyncHandlersInRegistrationOrder()
+    {
+        var itemKey = CreateItemKey();
+        var invocations = new List<int>();
+
+        ValueTask FirstHandler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invocations.Add(1);
+            return ValueTask.CompletedTask;
+        }
+
+        ValueTask SecondHandler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invocations.Add(2);
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += FirstHandler;
+        PriceCache.OnGenerationCreatedAsync += SecondHandler;
+
+        try
+        {
+            await PriceCache.GetItemGenerationAsync(itemKey);
+
+            Assert.Equal([1, 2], invocations);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= SecondHandler;
+            PriceCache.OnGenerationCreatedAsync -= FirstHandler;
+        }
+    }
+
+    [Fact]
+    public async Task GetItemGenerationAsync_ThrowsWhenCancelled()
+    {
+        var itemKey = CreateItemKey();
+        var invoked = false;
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invoked = true;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+
+        try
+        {
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await PriceCache.GetItemGenerationAsync(itemKey, cts.Token));
+
+            Assert.False(invoked);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    private static string CreateItemKey() => $"test-{Guid.NewGuid():N}";
+}

--- a/Plugins/Ekom.Klaviyo/Controllers/KlaviyoProductController.cs
+++ b/Plugins/Ekom.Klaviyo/Controllers/KlaviyoProductController.cs
@@ -1,11 +1,15 @@
+using Ekom.Exceptions;
 using Ekom.Klaviyo.Enrichers.ProductFeedEnricher;
 using Ekom.Klaviyo.Mappers;
 using Ekom.Klaviyo.Models.Catalog;
 using Ekom.Models;
+using Ekom.Services;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -19,20 +23,26 @@ internal class KlaviyoProductController : ControllerBase
     private readonly KlaviyoOptions _opt;
     private readonly IMemoryCache _cache;
     private readonly KlaviyoProductFeedEnrichmentPipeline _pipeline;
+    private readonly IStoreService _storeService;
 
     public KlaviyoProductController(
         IOptions<KlaviyoOptions> opt,
         IMemoryCache cache,
-        KlaviyoProductFeedEnrichmentPipeline pipeline)
+        KlaviyoProductFeedEnrichmentPipeline pipeline,
+        IStoreService storeService)
     {
         _opt = opt.Value;
         _cache = cache;
         _pipeline = pipeline;
+        _storeService = storeService;
     }
 
     [HttpGet("feed")]
     [Produces("application/json")]
-    public async Task<IActionResult> GetProductFeedAsync([FromQuery] string? storeAlias = null, CancellationToken ct = default)
+    public async Task<IActionResult> GetProductFeedAsync(
+        [FromQuery] string? storeAlias = null,
+        [FromQuery] string? culture = null,
+        CancellationToken ct = default)
     {
         if (!_opt.Enabled || !_opt.Catalog.Enabled || _opt.Catalog.SyncMode != KlaviyoCatalogSyncMode.FeedPull)
             return BadRequest("Klaviyo integration is disabled.");
@@ -48,45 +58,75 @@ internal class KlaviyoProductController : ControllerBase
         if (string.IsNullOrWhiteSpace(storeAlias))
             return BadRequest("Missing storeAlias and no default store is configured.");
 
-        var cacheKey = $"klaviyo:feed:v2:{storeAlias}";
+        IStore? store;
+        try
+        {
+            store = _storeService.GetStoreByAlias(storeAlias);
+        }
+        catch (StoreNotFoundException)
+        {
+            return BadRequest($"Unknown storeAlias '{storeAlias}'.");
+        }
+
+        if (store is null)
+            return BadRequest($"Unknown storeAlias '{storeAlias}'.");
+
+        storeAlias = store.Alias;
+
+        var resolvedCulture = ResolveCulture(store, culture);
+        if (resolvedCulture is null)
+            return BadRequest($"Missing culture and store '{storeAlias}' has no default culture configured.");
+
+        if (!IsSupportedCulture(store, resolvedCulture))
+            return BadRequest($"Culture '{resolvedCulture}' is not supported by store '{storeAlias}'.");
+
+        var cacheKey = $"klaviyo:feed:v3:{storeAlias}:{resolvedCulture}";
 
         var json = await _cache.GetOrCreateAsync(cacheKey, async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(60);
             entry.Priority = CacheItemPriority.High;
 
-            var productsResponse = await API.Catalog.Instance.GetAllProductsAsync(storeAlias, ct: ct);
-            var products = productsResponse?.Products;
-
-            var feed = new List<KlaviyoProductFeedItem>();
-
-            if (products is not null)
+            using var context = ApplyEkomRequestContext(store, resolvedCulture);
+            try
             {
-                foreach (var product in products.Where(HasProductImage))
+                var productsResponse = await API.Catalog.Instance.GetAllProductsAsync(storeAlias, ct: ct);
+                var products = productsResponse?.Products;
+
+                var feed = new List<KlaviyoProductFeedItem>();
+
+                if (products is not null)
                 {
-                    var item = product.ToKlaviyoProductFeedItem(_opt);
+                    foreach (var product in products.Where(HasProductImage))
+                    {
+                        var item = product.ToKlaviyoProductFeedItem(_opt);
 
-                    await _pipeline.ApplyAsync(
-                        item,
-                        new KlaviyoProductFeedEnrichmentContext
-                        {
-                            StoreAlias = storeAlias,
-                            Product = product,
-                            FeedItem = item,
-                            Options = _opt
-                        },
-                        ct);
+                        await _pipeline.ApplyAsync(
+                            item,
+                            new KlaviyoProductFeedEnrichmentContext
+                            {
+                                StoreAlias = storeAlias,
+                                Product = product,
+                                FeedItem = item,
+                                Options = _opt
+                            },
+                            ct);
 
-                    feed.Add(item);
+                        feed.Add(item);
+                    }
                 }
+
+                var jsonOptions = new JsonSerializerOptions
+                {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                };
+
+                return JsonSerializer.Serialize(feed, jsonOptions);
             }
-
-            var jsonOptions = new JsonSerializerOptions
+            finally
             {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            };
-
-            return JsonSerializer.Serialize(feed, jsonOptions);
+                context.Restore();
+            }
         });
 
         Response.Headers.CacheControl = "private, max-age=3600";
@@ -98,6 +138,153 @@ internal class KlaviyoProductController : ControllerBase
           
         return Content(json ?? "", "application/json");
     }
+
+    private string? ResolveCulture(IStore store, string? culture)
+    {
+        if (string.IsNullOrWhiteSpace(culture) &&
+            Request.Query.TryGetValue("Culture", out var cultureValues) &&
+            !string.IsNullOrWhiteSpace(cultureValues.FirstOrDefault()))
+        {
+            culture = cultureValues.FirstOrDefault();
+        }
+
+        if (!string.IsNullOrWhiteSpace(culture))
+            return culture.Trim();
+
+        return NullIfWhiteSpace(store.Culture?.Name)
+            ?? store.Cultures
+                .Select(c => c.Name)
+                .FirstOrDefault(c => !string.IsNullOrWhiteSpace(c));
+    }
+
+    private static bool IsSupportedCulture(IStore store, string culture)
+    {
+        return store.Cultures.Any(c => c.Name.Equals(culture, StringComparison.OrdinalIgnoreCase))
+            || store.Culture?.Name.Equals(culture, StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private RequestContextScope ApplyEkomRequestContext(IStore store, string culture)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        var previousUiCulture = CultureInfo.CurrentUICulture;
+        var newCulture = CultureInfo.GetCultureInfo(culture);
+
+        CultureInfo.CurrentCulture = newCulture;
+        CultureInfo.CurrentUICulture = newCulture;
+
+        var previousRequestCultureFeature = HttpContext.Features.Get<IRequestCultureFeature>();
+        HttpContext.Features.Set<IRequestCultureFeature>(
+            new RequestCultureFeature(
+                new RequestCulture(newCulture),
+                provider: null));
+
+        var previousEkomRequest = HttpContext.Items.TryGetValue(Configuration.EkmRequestKey, out var currentEkomRequest)
+            ? currentEkomRequest
+            : null;
+        var previousShortEkomRequest = HttpContext.Items.TryGetValue("ekmRequest", out var currentShortEkomRequest)
+            ? currentShortEkomRequest
+            : null;
+        var hadEkomRequest = HttpContext.Items.ContainsKey(Configuration.EkmRequestKey);
+        var hadShortEkomRequest = HttpContext.Items.ContainsKey("ekmRequest");
+
+        var ekmRequest = ResolveContentRequest(previousEkomRequest);
+        ekmRequest.Store = store;
+
+        var lazyRequest = new Lazy<ContentRequest>(() => ekmRequest);
+        HttpContext.Items[Configuration.EkmRequestKey] = lazyRequest;
+        HttpContext.Items["ekmRequest"] = lazyRequest;
+
+        return new RequestContextScope(
+            HttpContext,
+            previousCulture,
+            previousUiCulture,
+            previousRequestCultureFeature,
+            previousEkomRequest,
+            previousShortEkomRequest,
+            hadEkomRequest,
+            hadShortEkomRequest);
+    }
+
+    private static ContentRequest ResolveContentRequest(object? value)
+    {
+        return value switch
+        {
+            Lazy<ContentRequest> lazyContentRequest => lazyContentRequest.Value,
+            Lazy<object> lazyObject when lazyObject.Value is ContentRequest contentRequest => contentRequest,
+            ContentRequest contentRequest => contentRequest,
+            _ => new ContentRequest()
+        };
+    }
+
+    private sealed class RequestContextScope : IDisposable
+    {
+        private readonly HttpContext _httpContext;
+        private readonly CultureInfo _previousCulture;
+        private readonly CultureInfo _previousUiCulture;
+        private readonly IRequestCultureFeature? _previousRequestCultureFeature;
+        private readonly object? _previousEkomRequest;
+        private readonly object? _previousShortEkomRequest;
+        private readonly bool _hadEkomRequest;
+        private readonly bool _hadShortEkomRequest;
+        private bool _restored;
+
+        public RequestContextScope(
+            HttpContext httpContext,
+            CultureInfo previousCulture,
+            CultureInfo previousUiCulture,
+            IRequestCultureFeature? previousRequestCultureFeature,
+            object? previousEkomRequest,
+            object? previousShortEkomRequest,
+            bool hadEkomRequest,
+            bool hadShortEkomRequest)
+        {
+            _httpContext = httpContext;
+            _previousCulture = previousCulture;
+            _previousUiCulture = previousUiCulture;
+            _previousRequestCultureFeature = previousRequestCultureFeature;
+            _previousEkomRequest = previousEkomRequest;
+            _previousShortEkomRequest = previousShortEkomRequest;
+            _hadEkomRequest = hadEkomRequest;
+            _hadShortEkomRequest = hadShortEkomRequest;
+        }
+
+        public void Restore()
+        {
+            if (_restored)
+                return;
+
+            CultureInfo.CurrentCulture = _previousCulture;
+            CultureInfo.CurrentUICulture = _previousUiCulture;
+
+            _httpContext.Features.Set(_previousRequestCultureFeature);
+
+            if (_hadEkomRequest)
+            {
+                _httpContext.Items[Configuration.EkmRequestKey] = _previousEkomRequest;
+            }
+            else
+            {
+                _httpContext.Items.Remove(Configuration.EkmRequestKey);
+            }
+
+            if (_hadShortEkomRequest)
+            {
+                _httpContext.Items["ekmRequest"] = _previousShortEkomRequest;
+            }
+            else
+            {
+                _httpContext.Items.Remove("ekmRequest");
+            }
+
+            _restored = true;
+        }
+
+        public void Dispose()
+            => Restore();
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
 
     private static bool HasProductImage(IProduct product)
     {


### PR DESCRIPTION
## Summary
- add optional culture query support to the Klaviyo product feed
- resolve and validate the requested culture against the selected Ekom store
- set Ekom request store and ASP.NET request culture while generating the feed
- vary the feed cache by store and culture

## Verification
- not run, per request