### PR TITLE
fix(checkout): resolve payment return URLs by culture

### DIFF
--- a/Ekom/Ekom/Controllers/EkomCheckoutController.cs
+++ b/Ekom/Ekom/Controllers/EkomCheckoutController.cs
@@ -167,8 +167,8 @@ public class EkomCheckoutApiController : ControllerBase
         API.Order.Instance.EnsureOrderCookie(orderId, order.StoreInfo.Alias);
 
         string redirectUrlSetting = outcome == "cancel"
-            ? paymentProvider.GetValue("cancelUrl", order.StoreInfo.Alias)
-            : paymentProvider.GetValue("errorUrl", order.StoreInfo.Alias);
+            ? _checkoutControllerService.ResolvePaymentProviderUrl(paymentProvider, "cancelUrl", order)
+            : _checkoutControllerService.ResolvePaymentProviderUrl(paymentProvider, "errorUrl", order);
 
         string redirectUrl = Ekom.Utilities.UriHelper.EnsureFullUri(
             redirectUrlSetting,

--- a/Ekom/Ekom/Services/CheckoutControllerService.cs
+++ b/Ekom/Ekom/Services/CheckoutControllerService.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using OrderStatus = Ekom.Utilities.OrderStatus;
 
 namespace Ekom.Services;
@@ -584,9 +586,9 @@ public class CheckoutControllerService
             ekomPP.Name,
             isOfflinePayment);
 
-        string paymentErrorUrl = ekomPP.GetValue("errorUrl", storeAlias);
+        string paymentErrorUrl = ResolvePaymentProviderUrl(ekomPP, "errorUrl", order, paymentRequest.Culture);
 
-        string paymentSuccessUrl = ekomPP.GetValue("successUrl", storeAlias);
+        string paymentSuccessUrl = ResolvePaymentProviderUrl(ekomPP, "successUrl", order, paymentRequest.Culture);
 
         string GetEncodedUrl = _httpCtx.Request.GetEncodedUrl();
 
@@ -666,7 +668,7 @@ public class CheckoutControllerService
             Uri paymentReturnCancelUrl = new(BuildPaymentReturnUrl(order.UniqueId, "cancel"));
 
             Uri successUrl = PaymentsUriHelper.EnsureFullUri(
-                ekomPP.GetValue("successUrl", storeAlias),
+                ResolvePaymentProviderUrl(ekomPP, "successUrl", order, paymentRequest.Culture),
                 _httpCtx.Request);
             successUrl = PaymentsUriHelper.AddQueryString(
                 successUrl,
@@ -741,6 +743,162 @@ public class CheckoutControllerService
             };
         }
     }
+
+    internal virtual string ResolvePaymentProviderUrl(
+        Models.IPaymentProvider paymentProvider,
+        string propertyAlias,
+        IOrderInfo order,
+        string? culture = null)
+    {
+        ArgumentNullException.ThrowIfNull(paymentProvider);
+        ArgumentNullException.ThrowIfNull(order);
+
+        var resolvedCulture = NullIfWhiteSpace(culture)
+            ?? NullIfWhiteSpace(order.Culture)
+            ?? NullIfWhiteSpace(order.StoreInfo.Culture);
+        var storeAlias = order.StoreInfo.Alias;
+
+        var value = ResolvePaymentProviderPropertyValue(
+            paymentProvider,
+            propertyAlias,
+            resolvedCulture,
+            storeAlias);
+
+        return ResolveContentPickerUrl(value, resolvedCulture);
+    }
+
+    private static string ResolvePaymentProviderPropertyValue(
+        Models.IPaymentProvider paymentProvider,
+        string propertyAlias,
+        string? culture,
+        string storeAlias)
+    {
+        var rawValue = paymentProvider.GetRawValue(propertyAlias);
+        var editorType = TryGetPropertyEditorType(rawValue);
+
+        if (editorType == PropertyEditorType.Language)
+        {
+            return ResolvePropertyValue(rawValue, culture)
+                ?? ResolvePropertyValue(rawValue, storeAlias)
+                ?? ResolvePropertyValue(rawValue, null, fallback: true)
+                ?? string.Empty;
+        }
+
+        if (editorType == PropertyEditorType.Store)
+        {
+            return ResolvePropertyValue(rawValue, storeAlias)
+                ?? ResolvePropertyValue(rawValue, culture)
+                ?? ResolvePropertyValue(rawValue, null, fallback: true)
+                ?? string.Empty;
+        }
+
+        return ResolvePropertyValue(rawValue, culture)
+            ?? ResolvePropertyValue(rawValue, storeAlias)
+            ?? ResolvePropertyValue(rawValue, null, fallback: true)
+            ?? string.Empty;
+    }
+
+    private static PropertyEditorType? TryGetPropertyEditorType(string? rawValue)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue) || !rawValue.IsJson())
+            return null;
+
+        try
+        {
+            var node = JsonNode.Parse(rawValue);
+            var type = node?["type"]?.GetValue<string>();
+
+            return Enum.TryParse<PropertyEditorType>(type, ignoreCase: true, out var editorType)
+                ? editorType
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ResolvePropertyValue(string? rawValue, string? alias, bool fallback = false)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue))
+            return null;
+
+        var value = rawValue.GetEkomPropertyEditorValue(alias ?? string.Empty, fallback);
+
+        return NullIfWhiteSpace(value);
+    }
+
+    private string ResolveContentPickerUrl(string value, string? culture)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var pickerValue = TryGetContentPickerValue(value) ?? value;
+
+        if (!LooksLikeContentPickerValue(pickerValue))
+            return value;
+
+        var nodeService = _factory.GetService<INodeService>();
+        var url = nodeService?.GetUrl(pickerValue, culture ?? string.Empty);
+
+        return !string.IsNullOrWhiteSpace(url) && url != "#"
+            ? url
+            : value;
+    }
+
+    private static string? TryGetContentPickerValue(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !value.IsJson())
+            return null;
+
+        try
+        {
+            var node = JsonNode.Parse(value);
+
+            if (node is JsonArray array)
+                return array.Select(TryGetContentPickerValue).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
+
+            return TryGetContentPickerValue(node);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetContentPickerValue(JsonNode? node)
+    {
+        if (node is null)
+            return null;
+
+        if (node is JsonValue jsonValue && jsonValue.TryGetValue<string>(out var value))
+            return NullIfWhiteSpace(value);
+
+        if (node is not JsonObject obj)
+            return null;
+
+        foreach (var key in new[] { "udi", "value", "key", "id" })
+        {
+            if (obj.TryGetPropertyValue(key, out var propertyValue))
+            {
+                var propertyStringValue = TryGetContentPickerValue(propertyValue);
+                if (!string.IsNullOrWhiteSpace(propertyStringValue))
+                    return propertyStringValue;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeContentPickerValue(string value)
+    {
+        return value.StartsWith("umb://document/", StringComparison.OrdinalIgnoreCase)
+            || Guid.TryParse(value, out _)
+            || int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _);
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private string BuildPaymentReturnUrl(Guid orderId, string outcome)
     {


### PR DESCRIPTION
## Summary
- Resolve payment provider success, error, and cancel URLs using the order/payment culture before falling back to store alias values.
- Support Ekom property editor language/store JSON values while preserving plain text URL/path values.
- Resolve content picker-like values to node URLs in the active culture when possible.

## Test Plan
- dotnet build "Ekom/Ekom/Ekom.csproj"
