### PR TITLE
fix(klaviyo): include locale on profile updates

### DIFF
--- a/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/OrderMapper.cs
@@ -45,6 +45,7 @@ public static class OrderMapper
 
         var shippingProvider = order.ShippingProvider?.ToKlaviyoShippingProvider() ?? null;
         var paymentProvider = order.PaymentProvider?.ToKlaviyoPaymentProvider() ?? null;
+        var locale = NullIfWhiteSpace(order.Culture) ?? NullIfWhiteSpace(order.StoreInfo.Culture);
 
         KlaviyoProfileSubscribeRequest? consent = null;
 
@@ -71,7 +72,13 @@ public static class OrderMapper
                         TimestampUtc: DateTimeOffset.UtcNow,
                         ConsentTextVersion: "checkout-v1",
                         Ip: order.CustomerInformation.CustomerIpAddress)
-                }
+                },
+                CustomProperties: string.IsNullOrWhiteSpace(locale)
+                    ? null
+                    : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["locale"] = locale
+                    }
             );
         }
 
@@ -88,7 +95,7 @@ public static class OrderMapper
             Customer = order.ToKlaviyoProfile(opt),
             ShipTo = klaviyoShipTo,
             StoreAlias = order.StoreInfo.Alias,
-            Language = NullIfWhiteSpace(order.Culture) ?? order.StoreInfo.Culture,
+            Language = locale,
             Items = order.OrderLines.ToKlaviyoOrderLines(opt).ToList(),
             TaxValue = order.Vat.Value,
             DiscountValue = order.DiscountAmount.Value,

--- a/Plugins/Ekom.Klaviyo/Mappers/ProfileMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/ProfileMapper.cs
@@ -10,6 +10,8 @@ public static class ProfileMapper
 {
     public static KlaviyoOrderProfile ToKlaviyoProfile(this IOrderInfo order, KlaviyoOptions opt)
     {
+        var locale = NullIfWhiteSpace(order.Culture) ?? NullIfWhiteSpace(order.StoreInfo.Culture);
+
         return new KlaviyoOrderProfile()
         {
             Email = order.CustomerInformation.Customer.Email,
@@ -22,7 +24,13 @@ public static class ProfileMapper
             ZipCode = order.CustomerInformation.Customer.ZipCode,
             City = order.CustomerInformation.Customer.City,
             Country = order.CustomerInformation.Customer.Country,
-            Organisation = order.CustomerInformation.Customer.Company
+            Organisation = order.CustomerInformation.Customer.Company,
+            CustomProperties = string.IsNullOrWhiteSpace(locale)
+                ? null
+                : new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["locale"] = locale
+                }
         };
     }
 
@@ -326,6 +334,9 @@ private static (string? FirstName, string? LastName) GetNameParts(KlaviyoProfile
     var lastName = string.Join(' ', parts, 1, parts.Length - 1);
     return (parts[0], lastName);
 }
+
+private static string? NullIfWhiteSpace(string? value)
+    => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
 internal static JsonObject ToProfileData(this KlaviyoProfile p)
 {

--- a/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileConsentRequest.cs
+++ b/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileConsentRequest.cs
@@ -17,7 +17,8 @@ public sealed record KlaviyoProfileSubscribeRequest(
     string? PhoneNumber = null,
     string? FullName = null,
     string? FirstName = null,
-    string? LastName = null);
+    string? LastName = null,
+    IDictionary<string, object?>? CustomProperties = null);
 
 public sealed record KlaviyoProfileUnsubscribeRequest(
     string StoreAlias,

--- a/Plugins/Ekom.Klaviyo/Services/KlaviyoProfilesService.cs
+++ b/Plugins/Ekom.Klaviyo/Services/KlaviyoProfilesService.cs
@@ -332,7 +332,8 @@ internal sealed class KlaviyoProfilesService : IKlaviyoProfilesService
     {
         if (string.IsNullOrWhiteSpace(payload.FirstName) &&
             string.IsNullOrWhiteSpace(payload.LastName) &&
-            string.IsNullOrWhiteSpace(payload.FullName))
+            string.IsNullOrWhiteSpace(payload.FullName) &&
+            (payload.CustomProperties is null || payload.CustomProperties.Count == 0))
         {
             return;
         }
@@ -350,7 +351,8 @@ internal sealed class KlaviyoProfilesService : IKlaviyoProfilesService
                 {
                     FullName = payload.FullName,
                     FirstName = payload.FirstName,
-                    LastName = payload.LastName
+                    LastName = payload.LastName,
+                    CustomProperties = payload.CustomProperties
                 }
             });
 

--- a/Plugins/Ekom.Klaviyo/Services/KlaviyoTrackingService.cs
+++ b/Plugins/Ekom.Klaviyo/Services/KlaviyoTrackingService.cs
@@ -85,7 +85,7 @@ public sealed class KlaviyoTrackingService : IKlaviyoTrackingService
 
         var listId = _opt.ResolveSubscriptionListId(payload.StoreAlias, payload.ListId);
 
-        var email = payload?.Customer?.Email;
+        var email = payload.Customer.Email;
         if (string.IsNullOrWhiteSpace(email))
         {
             _logger.LogDebug(
@@ -100,13 +100,14 @@ public sealed class KlaviyoTrackingService : IKlaviyoTrackingService
             {
                 Customer = new KlaviyoCustomer
                 {
-                    Email = payload?.Customer?.Email,
-                    PhoneNumber = payload?.Customer?.PhoneNumber
+                    Email = payload.Customer.Email,
+                    PhoneNumber = payload.Customer.PhoneNumber
                 },
                 Attributes = new KlaviyoProfileAttributes
                 {
-                    FirstName = payload?.Customer?.FirstName,
-                    LastName = payload?.Customer?.LastName
+                    FirstName = payload.Customer.FirstName,
+                    LastName = payload.Customer.LastName,
+                    CustomProperties = payload.Customer.CustomProperties
                 }
             },
             ListId: listId);


### PR DESCRIPTION
## Summary
- Add the order culture as a Klaviyo profile custom property named `locale`.
- Preserve profile custom properties when the delayed Started Checkout profile upsert runs.
- Carry locale through checkout subscription profile upserts so marketing profiles can be segmented by locale.

## Test Plan
- dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj"
