### PR TITLE
fix(catalog): extract product query filters

### DIFF
--- a/Ekom/Ekom/Models/ProductQuery.cs
+++ b/Ekom/Ekom/Models/ProductQuery.cs
@@ -23,8 +23,8 @@ public class ProductQuery : ProductQueryBase
 
         _query = query;
 
-        MetaFilters = MetaFilters ?? ExtractFilters(query, FilterPrefix);
-        PropertyFilters = PropertyFilters ?? ExtractFilters(query, PropertyPrefix);
+        MetaFilters = ExtractFilters(query, FilterPrefix);
+        PropertyFilters = ExtractFilters(query, PropertyPrefix);
 
         SearchQuery = !string.IsNullOrEmpty(SearchQuery) ?
             SearchQuery :


### PR DESCRIPTION
## Summary
- Ensure `ProductQuery` extracts `filter_` and `property_` query-string values when constructed from the current request.
- Fix product responses ignoring property filters such as `?property_velveraBrand=GUM` because the filter dictionaries were initialized as empty and never populated.

## Test Plan
- `dotnet build "Ekom/Ekom/Ekom.csproj"`
