### PR TITLE
fix(discounts): support async applicable discount events

### DIFF
--- a/Ekom/Ekom/Events/DiscountEvents.cs
+++ b/Ekom/Ekom/Events/DiscountEvents.cs
@@ -5,13 +5,23 @@ namespace Ekom.Events;
 public class DiscountEvents
 {
     public event EventHandler<ProductDiscountEvaluationEventArgs>? BeforeEvaluateDiscounts;
-    public event EventHandler<ProductDiscountApplicableEventArgs>? AfterApplicableDiscounts;
+    public event Func<object?, ProductDiscountApplicableEventArgs, Task>? AfterApplicableDiscounts;
 
     public void RaiseBeforeEvaluateDiscounts(object sender, ProductDiscountEvaluationEventArgs e)
         => BeforeEvaluateDiscounts?.Invoke(sender, e);
 
-    public void RaiseAfterApplicableDiscounts(object sender, ProductDiscountApplicableEventArgs e)
-        => AfterApplicableDiscounts?.Invoke(sender, e);
+    public async Task RaiseAfterApplicableDiscountsAsync(object sender, ProductDiscountApplicableEventArgs e)
+    {
+        if (AfterApplicableDiscounts == null)
+            return;
+
+        foreach (var handler in AfterApplicableDiscounts
+            .GetInvocationList()
+            .Cast<Func<object?, ProductDiscountApplicableEventArgs, Task>>())
+        {
+            await handler(sender, e).ConfigureAwait(false);
+        }
+    }
 
     public class ProductDiscountEvaluationEventArgs : EventArgs
     {
@@ -45,5 +55,4 @@ public class DiscountEvents
     }
 
 }
-
 

--- a/Ekom/Ekom/Models/IProduct.cs
+++ b/Ekom/Ekom/Models/IProduct.cs
@@ -155,7 +155,7 @@ public interface IProduct : INodeEntityWithUrl, IPerStoreNodeEntity
     /// <summary>
     /// A discount specific to this product populated after product discount cache is filled.
     /// </summary>
-    IDiscount ProductDiscount(string? price = null);
+    Task<IDiscount?> ProductDiscountAsync(string? price = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get related products

--- a/Ekom/Ekom/Models/IVariant.cs
+++ b/Ekom/Ekom/Models/IVariant.cs
@@ -62,7 +62,7 @@ public interface IVariant : IPerStoreNodeEntity
     /// <summary>
     /// Product Stock Keeping Unit.
     /// </summary>
-    IProductDiscount ProductDiscount(string price);
+    Task<IProductDiscount?> ProductDiscountAsync(string price, CancellationToken ct = default);
 
     /// <summary>
     /// Get SKU

--- a/Ekom/Ekom/Models/OrderedObjects/OrderedProduct.cs
+++ b/Ekom/Ekom/Models/OrderedObjects/OrderedProduct.cs
@@ -1,6 +1,7 @@
 using Ekom.API;
 using Ekom.Services;
 using Ekom.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -271,7 +272,13 @@ public class OrderedProduct
             Prices = product.Prices.ToList();
         }
 
-        IDiscount productDiscount = product.ProductDiscount(Price.Value.ToString());
+        IDiscount? productDiscount = Configuration.Resolver.GetService<ProductDiscountService>()?
+            .GetProductDiscount(
+                product.Path,
+                product.Store.Alias,
+                Price.Value.ToString(CultureInfo.InvariantCulture),
+                product.Categories.Select(x => x.Id.ToString()).ToArray()
+            );
 
         ProductDiscount = productDiscount != null ? new OrderedDiscount(productDiscount) : null;
 

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -26,17 +26,34 @@ public class Product : PerStoreNodeEntity, IProduct
 
     private readonly ConcurrentDictionary<string, Lazy<object>> _cache = new();
 
-    public virtual IDiscount ProductDiscount(string? price = null)
+    public virtual IDiscount? ProductDiscount(string? price = null)
     {
-        price = string.IsNullOrEmpty(price) ? Price.OriginalValue.ToString() : price;
+        price = string.IsNullOrEmpty(price) ? OriginalPrice.OriginalValue.ToString() : price;
 
         return Configuration.Resolver.GetService<ProductDiscountService>()?
-                .GetProductDiscount(
-                    Path,
-                    Store.Alias,
-                    price,
-                    categories.Select(x => x.Id.ToString())?.ToArray()
-                );
+            .GetProductDiscount(
+                Path,
+                Store.Alias,
+                price,
+                categories.Select(x => x.Id.ToString()).ToArray()
+            );
+    }
+
+    public virtual async Task<IDiscount?> ProductDiscountAsync(string? price = null, CancellationToken ct = default)
+    {
+        price = string.IsNullOrEmpty(price) ? OriginalPrice.OriginalValue.ToString() : price;
+
+        var discountService = Configuration.Resolver.GetService<ProductDiscountService>();
+        if (discountService == null)
+            return null;
+
+        return await discountService.GetProductDiscountAsync(
+            Path,
+            Store.Alias,
+            price,
+            categories.Select(x => x.Id.ToString()).ToArray(),
+            ct: ct
+        ).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -3,7 +3,6 @@ using Ekom.Cache;
 using Ekom.Services;
 using Ekom.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Xml.Serialization;
@@ -124,6 +123,21 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
                 price,
                 Product?.Categories.Select(x => x.Id.ToString()).ToArray()
             );
+    }
+
+    public virtual async Task<IProductDiscount?> ProductDiscountAsync(string price, CancellationToken ct = default)
+    {
+        var discountService = Configuration.Resolver.GetService<ProductDiscountService>();
+        if (discountService == null)
+            return null;
+
+        return await discountService.GetProductDiscountAsync(
+            Path,
+            Store.Alias,
+            price,
+            Product?.Categories.Select(x => x.Id.ToString()).ToArray(),
+            ct: ct
+        ).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -1216,7 +1216,7 @@ partial class OrderService
                 isNewOrderLine = true;
             }
 
-            var productDiscount = product.ProductDiscount();
+            var productDiscount = await product.ProductDiscountAsync(ct: ct);
 
             // Product discounts do not contain constraints that change with quantity updates or order modifications
             // It's therefore enough to only check on OrderLine creation

--- a/Ekom/Ekom/Services/ProductDiscountService.cs
+++ b/Ekom/Ekom/Services/ProductDiscountService.cs
@@ -16,10 +16,44 @@ class ProductDiscountService
 
     public virtual IProductDiscount? GetProductDiscount(
         string path,
-        string storeAlias,
+        string? storeAlias,
         string inputPrice,
         string[]? categories = null)
+        => GetProductDiscountCoreAsync(
+            path,
+            storeAlias,
+            inputPrice,
+            categories,
+            raiseAfterApplicableDiscounts: false,
+            CancellationToken.None).GetAwaiter().GetResult();
+
+    public virtual Task<IProductDiscount?> GetProductDiscountAsync(
+        string path,
+        string? storeAlias,
+        string inputPrice,
+        string[]? categories = null,
+        CancellationToken ct = default)
+        => GetProductDiscountCoreAsync(
+            path,
+            storeAlias,
+            inputPrice,
+            categories,
+            raiseAfterApplicableDiscounts: true,
+            ct);
+
+    private async Task<IProductDiscount?> GetProductDiscountCoreAsync(
+        string path,
+        string? storeAlias,
+        string inputPrice,
+        string[]? categories = null,
+        bool raiseAfterApplicableDiscounts = true,
+        CancellationToken ct = default)
     {
+        ct.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(storeAlias))
+            return null;
+
         inputPrice = string.IsNullOrEmpty(inputPrice)
             ? "0"
             : inputPrice.Replace(',', '.');
@@ -105,7 +139,12 @@ class ProductDiscountService
             categories,
             applicableDiscounts);
 
-        _discountEvents.RaiseAfterApplicableDiscounts(this, applicableArgs);
+        if (raiseAfterApplicableDiscounts)
+        {
+            await _discountEvents.RaiseAfterApplicableDiscountsAsync(this, applicableArgs).ConfigureAwait(false);
+        }
+
+        ct.ThrowIfCancellationRequested();
 
         if (applicableArgs.ApplicableDiscounts.Count == 0)
             return null;

--- a/Ekom/Ekom/Utilities/PriceBuilder.cs
+++ b/Ekom/Ekom/Utilities/PriceBuilder.cs
@@ -35,7 +35,7 @@ public static class PriceBuilder
 
         var discountSvc = Configuration.Resolver.GetService<ProductDiscountService>();
 
-        bool isArray = priceJson.AsSpan().TrimStart().StartsWith("[");
+        var isArray = priceJson.AsSpan().TrimStart().StartsWith("[");
         if (!isArray)
         {
             IDiscount? disc = (!string.IsNullOrEmpty(path) && discountSvc != null)

--- a/Ekom/Ekom/Utilities/StringExtensions.cs
+++ b/Ekom/Ekom/Utilities/StringExtensions.cs
@@ -89,7 +89,7 @@ public static class StringExtension
             }
             else
             {
-                return (value == "1" || value.ToLower() == "y");
+                return value == "1" || value.Equals("y", StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -101,9 +101,10 @@ public static class StringExtension
             return false;
         }
 
-        input = input.Trim();
-        return input.StartsWith("{") && input.EndsWith("}")
-               || input.StartsWith("[") && input.EndsWith("]");
+        var span = input.AsSpan().Trim();
+        return span.Length > 1
+            && ((span[0] == '{' && span[^1] == '}')
+                || (span[0] == '[' && span[^1] == ']'));
     }
 
     internal static bool IsBoolean(this string? value)
@@ -219,36 +220,32 @@ public static class StringExtension
 
     internal static List<IPrice> GetPriceValuesConstructed(this string priceJson, decimal vat, bool vatIncludedInPrice, CurrencyModel fallbackCurrency = null)
     {
-        List<IPrice> prices = new List<IPrice>();
-
-
         if (priceJson.IsJson())
         {
             JArray _prices = JArray.Parse(priceJson);
+            var prices = new List<IPrice>(_prices.Count);
 
             foreach (JToken price in _prices)
             {
-                CurrencyModel? currency = price[KeyExists(price, "Currency") ? "Currency" : "currency"].ToObject<CurrencyModel>(EkomJsonDotNet.Serializer);
+                CurrencyModel? currency = GetPropertyIgnoreCase(price, "Currency")?.ToObject<CurrencyModel>(EkomJsonDotNet.Serializer);
 
                 prices.Add(new Price(price, currency, vat, vatIncludedInPrice));
             }
+
+            return prices;
         }
-        else
+
+        if (fallbackCurrency == null)
         {
-            if (fallbackCurrency == null)
-            {
-                IStore? store = API.Store.Instance.GetStore();
+            IStore? store = API.Store.Instance.GetStore();
 
-                fallbackCurrency = store.Currency;
-            }
-
-            prices = new List<IPrice>
-            {
-                new Price(priceJson, fallbackCurrency, vat, vatIncludedInPrice)
-            };
+            fallbackCurrency = store.Currency;
         }
 
-        return prices;
+        return new List<IPrice>(1)
+        {
+            new Price(priceJson, fallbackCurrency, vat, vatIncludedInPrice)
+        };
     }
 
     public static List<IPrice> GetPriceValues(
@@ -262,29 +259,31 @@ public static class StringExtension
         string[]? categories = null
         )
     {
-        var prices = new List<IPrice>();
+        var discountService = Configuration.Resolver.GetService<ProductDiscountService>();
 
         if (priceJson.IsJson())
         {
             var _prices = JArray.Parse(priceJson);
+            var prices = new List<IPrice>(_prices.Count);
 
             foreach (JToken price in _prices)
             {
-                string? currencyValue = price[KeyExists(price, "Currency") ? "Currency" : "currency"].Value<string>();
+                string? currencyValue = GetPropertyIgnoreCase(price, "Currency")?.Value<string>();
                 CurrencyModel? currency = storeCurrencies.FirstOrDefault(x => x.CurrencyValue == currencyValue) ?? storeCurrencies.FirstOrDefault();
+                string? priceValue = GetPropertyIgnoreCase(price, "Price")?.Value<string>();
 
-                IDiscount? productDiscount = !string.IsNullOrEmpty(path)
-                    ? Configuration.Resolver.GetService<ProductDiscountService>()
+                IDiscount? productDiscount = !string.IsNullOrEmpty(path) && discountService != null
+                    ? discountService
                         .GetProductDiscount(
                             path,
                             storeAlias,
-                            price[KeyExists(price, "Price") ? "Price" : "price"].Value<string>(),
+                            priceValue,
                             categories
                         )
                     : null;
 
                 prices.Add(new Price(
-                    price[KeyExists(price, "Price") ? "Price" : "price"].Value<string>(),
+                    priceValue,
                     currency,
                     vat,
                     vatIncludedInPrice,
@@ -293,40 +292,38 @@ public static class StringExtension
                         : null)
                 );
             }
+
+            return prices;
         }
-        else
+
+        if (fallbackCurrency == null)
         {
-            if (fallbackCurrency == null)
-            {
-                IStore? store = API.Store.Instance.GetStore();
+            IStore? store = API.Store.Instance.GetStore();
 
-                fallbackCurrency = store.Currency;
-            }
-
-            IDiscount? productDiscount = !string.IsNullOrEmpty(path)
-                ? Configuration.Resolver.GetService<ProductDiscountService>()?
-                    .GetProductDiscount(
-                        path,
-                        storeAlias,
-                        priceJson,
-                        categories
-                    )
-                : null;
-
-            prices = new List<IPrice>
-            {
-                new Price(
-                    priceJson,
-                    fallbackCurrency,
-                    vat,
-                    vatIncludedInPrice,
-                    productDiscount != null
-                        ? new OrderedDiscount(productDiscount)
-                        : null)
-            };
+            fallbackCurrency = store.Currency;
         }
 
-        return prices;
+        IDiscount? singleProductDiscount = !string.IsNullOrEmpty(path) && discountService != null
+            ? discountService
+                .GetProductDiscount(
+                    path,
+                    storeAlias,
+                    priceJson,
+                    categories
+                )
+            : null;
+
+        return new List<IPrice>(1)
+        {
+            new Price(
+                priceJson,
+                fallbackCurrency,
+                vat,
+                vatIncludedInPrice,
+                singleProductDiscount != null
+                    ? new OrderedDiscount(singleProductDiscount)
+                    : null)
+        };
     }
     public static List<CurrencyValue> GetCurrencyValues(this string priceJson, string? storeAlias = null)
     {
@@ -513,6 +510,13 @@ public static class StringExtension
         return obj?.ContainsKey(key) ?? false;
     }
 
+    private static JToken? GetPropertyIgnoreCase(JToken token, string key)
+    {
+        return token is JObject obj && obj.TryGetValue(key, StringComparison.OrdinalIgnoreCase, out var value)
+            ? value
+            : null;
+    }
+
     internal static List<CurrencyPrice> GetCurrencyPrices(this string priceJson)
     {
         List<CurrencyPrice>? values = new List<CurrencyPrice>();
@@ -543,13 +547,19 @@ public static class StringExtension
 
         if (!string.IsNullOrEmpty(nodeIds))
         {
+            var nodeService = Configuration.Resolver.GetService<INodeService>();
+            if (nodeService == null)
+                return Enumerable.Empty<Image>();
+
             if (nodeIds.StartsWith("[") && nodeIds.IndexOf("mediakey", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 List<MediaCropImage>? imageList = JsonConvert.DeserializeObject<List<MediaCropImage>>(nodeIds);
+                if (imageList == null)
+                    return Enumerable.Empty<Image>();
 
                 foreach (MediaCropImage image in imageList)
                 {
-                    UmbracoContent? node = Configuration.Resolver.GetService<INodeService>()?.MediaById(image.MediaKey);
+                    UmbracoContent? node = nodeService.MediaById(image.MediaKey);
 
                     if (node != null)
                     {
@@ -564,7 +574,7 @@ public static class StringExtension
                 foreach (string imgId in imageIds)
                 {
 
-                    UmbracoContent? node = Configuration.Resolver.GetService<INodeService>()?.MediaById(imgId);
+                    UmbracoContent? node = nodeService.MediaById(imgId);
 
                     if (node != null)
                     {


### PR DESCRIPTION
## Summary
- Make `AfterApplicableDiscounts` async so handlers can await service calls safely.
- Add async product discount evaluation while keeping legacy sync discount calculation separate.
- Update order creation to use async product discount lookup.
- Apply safe `StringExtensions` optimizations for JSON/price parsing and image lookup.

## Test Plan
- `dotnet build "Ekom Build.sln"`