### PR TITLE
fix(catalog): make categories filterable

### DIFF
--- a/Ekom/Ekom/Models/Response/ProductResponse.cs
+++ b/Ekom/Ekom/Models/Response/ProductResponse.cs
@@ -71,7 +71,7 @@ public class ProductResponse
     public int TotalProductCount { get; set; }
     public IEnumerable<MetafieldGrouped> Filters { get; set; } = new List<MetafieldGrouped>();
 
-    public Dictionary<string, List<(string, int)>> PropertySelectors { get; } = new();
+    public Dictionary<string, List<PropertySelectorValue>> PropertySelectors { get; } = new();
 
     // =========================
     // Single shared pipeline
@@ -145,6 +145,12 @@ public class ProductResponse
 
         foreach (var selector in query.PropertySelectors.Where(s => !string.IsNullOrEmpty(s.Key)))
         {
+            if (selector.Key.Equals("category", StringComparison.OrdinalIgnoreCase))
+            {
+                PropertySelectors[selector.Key] = BuildCategorySelectorValues(working);
+                continue;
+            }
+
             var sep = query.PropertySelectorsSeparator ?? string.Empty;
 
             var values = working
@@ -154,13 +160,42 @@ public class ProductResponse
                     ?? Array.Empty<string>())
                 .Where(v => !string.IsNullOrEmpty(v))
                 .GroupBy(v => v)
-                .Select(g => (g.Key, g.Count()))
+                .Select(g => new PropertySelectorValue
+                {
+                    Value = g.Key,
+                    Title = g.Key,
+                    Count = g.Count(),
+                })
                 .ToList();
 
             PropertySelectors[selector.Key] = values;
         }
 
         return working;
+    }
+
+    private static List<PropertySelectorValue> BuildCategorySelectorValues(IEnumerable<IProduct> products)
+    {
+        return products
+            .SelectMany(product => product.Categories
+                .Concat(product.CategoryAncestors)
+                .GroupBy(category => category.Id)
+                .Select(group => group.First()))
+            .GroupBy(category => category.Id)
+            .Select(group =>
+            {
+                var category = group.First();
+
+                return new PropertySelectorValue
+                {
+                    Id = category.Id,
+                    Value = category.Id.ToString(),
+                    Title = category.Title,
+                    Count = group.Count(),
+                };
+            })
+            .OrderBy(x => x.Title, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
     }
 
     private IEnumerable<IProduct> StepFiltersVisibleAll(IEnumerable<IProduct> working, ProductQuery query)
@@ -361,4 +396,12 @@ public class ProductResponse
 
         return products.OrderBy(x => x.SortOrder);
     }
+}
+
+public class PropertySelectorValue
+{
+    public int? Id { get; set; }
+    public string Value { get; set; } = string.Empty;
+    public string? Title { get; set; }
+    public int Count { get; set; }
 }

--- a/Ekom/Ekom/Services/MetafieldService.cs
+++ b/Ekom/Ekom/Services/MetafieldService.cs
@@ -436,6 +436,7 @@ internal class MetafieldService : IMetafieldService
         {
 
             products = FilterByPrice(products, query);
+            products = FilterByCategory(products, query);
 
             var filters = query.PropertyFilters
                 .Where(kv => !string.IsNullOrWhiteSpace(kv.Key) && kv.Value is { } vs && vs.Any())
@@ -505,6 +506,28 @@ internal class MetafieldService : IMetafieldService
         return products;
     }
 
+    private IEnumerable<IProduct> FilterByCategory(IEnumerable<IProduct> products, ProductQuery query)
+    {
+        var categoryFilter = query.PropertyFilters.FirstOrDefault(x => x.Key.Equals("category", StringComparison.OrdinalIgnoreCase));
+        if (categoryFilter.Value == null || !categoryFilter.Value.Any())
+            return products;
+
+        var categoryIds = categoryFilter.Value
+            .SelectMany(x => x.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(x => int.TryParse(x, out _))
+            .Select(int.Parse)
+            .ToHashSet();
+
+        RemovePropertyFilter(query, "category");
+
+        if (categoryIds.Count == 0)
+            return products;
+
+        return products.Where(product => product.Categories
+            .Concat(product.CategoryAncestors)
+            .Any(category => categoryIds.Contains(category.Id)));
+    }
+
     private IEnumerable<IProduct> FilterByPrice(IEnumerable<IProduct> products, ProductQuery query)
     {
 
@@ -553,9 +576,16 @@ internal class MetafieldService : IMetafieldService
             });
         }
 
-        query.PropertyFilters.Remove("priceFrom");
-        query.PropertyFilters.Remove("priceTo");
+        RemovePropertyFilter(query, "priceFrom");
+        RemovePropertyFilter(query, "priceTo");
 
         return products;
+    }
+
+    private static void RemovePropertyFilter(ProductQuery query, string key)
+    {
+        var matchingKey = query.PropertyFilters.Keys.FirstOrDefault(x => x.Equals(key, StringComparison.OrdinalIgnoreCase));
+        if (matchingKey != null)
+            query.PropertyFilters.Remove(matchingKey);
     }
 }


### PR DESCRIPTION
## Summary
- Add support for `property_category` product filtering with comma-separated category IDs.
- Match both direct product categories and category ancestors.
- Return category selector options with id, value, title, and count.
- Preserve existing property filter behavior by removing handled category filters before generic property filtering.

## Test Plan
- `dotnet build "Ekom Build.sln"`