### PR TITLE
fix(discounts): run async event from sync path

### DIFF
--- a/Ekom/Ekom/Services/ProductDiscountService.cs
+++ b/Ekom/Ekom/Services/ProductDiscountService.cs
@@ -24,7 +24,7 @@ class ProductDiscountService
             storeAlias,
             inputPrice,
             categories,
-            raiseAfterApplicableDiscounts: false,
+            raiseAfterApplicableDiscounts: true,
             CancellationToken.None).GetAwaiter().GetResult();
 
     public virtual Task<IProductDiscount?> GetProductDiscountAsync(


### PR DESCRIPTION
## Summary
- Run `AfterApplicableDiscounts` from the legacy sync discount path as well as the async path.
- Preserve the existing sync API by blocking on the shared async core, allowing existing sync product/price calculations to trigger async discount handlers.

## Test Plan
- Ran `dotnet build "Ekom Build.sln"` before committing; build completed with warnings and no errors.
- Verified only `ProductDiscountService.cs` is included in this PR.
