### PR TITLE
fix(events): run async hooks from sync paths

### DIFF
--- a/Ekom/Ekom.Common/PriceCache.cs
+++ b/Ekom/Ekom.Common/PriceCache.cs
@@ -34,7 +34,7 @@ public static class PriceCache
     {
         var gen = _itemGenerations.GetOrAdd(itemKey, _ => Guid.NewGuid().ToString("N"));
 
-        gen = RaiseGenerationCreated(itemKey, gen);
+        gen = RaiseGenerationCreatedAsync(itemKey, gen, CancellationToken.None).GetAwaiter().GetResult();
 
         return gen;
     }
@@ -76,16 +76,8 @@ public static class PriceCache
         (Cache as MemoryCache)?.Compact(1.0);
     }
 
-    public static event EventHandler<PriceGenerationEventArgs>? OnGenerationCreated;
     public static event Func<PriceGenerationEventArgs, CancellationToken, ValueTask>? OnGenerationCreatedAsync;
     public static event EventHandler<PriceGenerationEventArgs>? OnGenerationInvalidated;
-
-    private static string RaiseGenerationCreated(string itemKey, string gen)
-    {
-        var args = new PriceGenerationEventArgs(itemKey, gen);
-        OnGenerationCreated?.Invoke(null, args);
-        return args.Generation;
-    }
 
     private static async ValueTask<string> RaiseGenerationCreatedAsync(string itemKey, string gen, CancellationToken ct)
     {

--- a/Ekom/Ekom.Tests/Tests/DiscountEventsTests.cs
+++ b/Ekom/Ekom.Tests/Tests/DiscountEventsTests.cs
@@ -1,0 +1,59 @@
+using Ekom.Events;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class DiscountEventsTests
+{
+    [Fact]
+    public async Task BeforeEvaluateDiscountsAsync_InvokesHandlersInRegistrationOrder()
+    {
+        var discountEvents = new DiscountEvents();
+        var invocations = new List<int>();
+
+        Task FirstHandler(object? sender, DiscountEvents.ProductDiscountEvaluationEventArgs args)
+        {
+            invocations.Add(1);
+            return Task.CompletedTask;
+        }
+
+        Task SecondHandler(object? sender, DiscountEvents.ProductDiscountEvaluationEventArgs args)
+        {
+            invocations.Add(2);
+            return Task.CompletedTask;
+        }
+
+        discountEvents.BeforeEvaluateDiscountsAsync += FirstHandler;
+        discountEvents.BeforeEvaluateDiscountsAsync += SecondHandler;
+
+        await discountEvents.RaiseBeforeEvaluateDiscountsAsync(
+            this,
+            new DiscountEvents.ProductDiscountEvaluationEventArgs(),
+            CancellationToken.None);
+
+        Assert.Equal([1, 2], invocations);
+    }
+
+    [Fact]
+    public async Task BeforeEvaluateDiscountsAsync_AllowsHandlerToUpdateArgs()
+    {
+        var discountEvents = new DiscountEvents();
+
+        Task Handler(object? sender, DiscountEvents.ProductDiscountEvaluationEventArgs args)
+        {
+            args.StoreAlias = "updated";
+            return Task.CompletedTask;
+        }
+
+        var eventArgs = new DiscountEvents.ProductDiscountEvaluationEventArgs
+        {
+            StoreAlias = "original"
+        };
+
+        discountEvents.BeforeEvaluateDiscountsAsync += Handler;
+
+        await discountEvents.RaiseBeforeEvaluateDiscountsAsync(this, eventArgs, CancellationToken.None);
+
+        Assert.Equal("updated", eventArgs.StoreAlias);
+    }
+}

--- a/Ekom/Ekom.Tests/Tests/PriceCacheTests.cs
+++ b/Ekom/Ekom.Tests/Tests/PriceCacheTests.cs
@@ -6,6 +6,66 @@ namespace Ekom.Tests.Tests;
 public class PriceCacheTests
 {
     [Fact]
+    public void GetItemGeneration_InvokesAsyncHandler()
+    {
+        var itemKey = CreateItemKey();
+        var expectedGeneration = Guid.NewGuid().ToString("N");
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            args.Generation = expectedGeneration;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+
+        try
+        {
+            var generation = PriceCache.GetItemGeneration(itemKey);
+
+            Assert.Equal(expectedGeneration, generation);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    [Fact]
+    public void GetItemGeneration_InvokesAsyncHandlersInRegistrationOrder()
+    {
+        var itemKey = CreateItemKey();
+        var invocations = new List<int>();
+
+        ValueTask FirstHandler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invocations.Add(1);
+            return ValueTask.CompletedTask;
+        }
+
+        ValueTask SecondHandler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            invocations.Add(2);
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += FirstHandler;
+        PriceCache.OnGenerationCreatedAsync += SecondHandler;
+
+        try
+        {
+            PriceCache.GetItemGeneration(itemKey);
+
+            Assert.Equal([1, 2], invocations);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= SecondHandler;
+            PriceCache.OnGenerationCreatedAsync -= FirstHandler;
+        }
+    }
+
+    [Fact]
     public async Task GetItemGenerationAsync_InvokesAsyncHandler()
     {
         var itemKey = CreateItemKey();

--- a/Ekom/Ekom/Events/DiscountEvents.cs
+++ b/Ekom/Ekom/Events/DiscountEvents.cs
@@ -4,21 +4,33 @@ namespace Ekom.Events;
 
 public class DiscountEvents
 {
-    public event EventHandler<ProductDiscountEvaluationEventArgs>? BeforeEvaluateDiscounts;
-    public event Func<object?, ProductDiscountApplicableEventArgs, Task>? AfterApplicableDiscounts;
+    public event Func<object?, ProductDiscountEvaluationEventArgs, Task>? BeforeEvaluateDiscountsAsync;
+    public event Func<object?, ProductDiscountApplicableEventArgs, Task>? AfterApplicableDiscountsAsync;
 
-    public void RaiseBeforeEvaluateDiscounts(object sender, ProductDiscountEvaluationEventArgs e)
-        => BeforeEvaluateDiscounts?.Invoke(sender, e);
-
-    public async Task RaiseAfterApplicableDiscountsAsync(object sender, ProductDiscountApplicableEventArgs e)
+    public async Task RaiseBeforeEvaluateDiscountsAsync(object sender, ProductDiscountEvaluationEventArgs e, CancellationToken ct)
     {
-        if (AfterApplicableDiscounts == null)
+        if (BeforeEvaluateDiscountsAsync == null)
             return;
 
-        foreach (var handler in AfterApplicableDiscounts
+        foreach (var handler in BeforeEvaluateDiscountsAsync
+            .GetInvocationList()
+            .Cast<Func<object?, ProductDiscountEvaluationEventArgs, Task>>())
+        {
+            ct.ThrowIfCancellationRequested();
+            await handler(sender, e).ConfigureAwait(false);
+        }
+    }
+
+    public async Task RaiseAfterApplicableDiscountsAsync(object sender, ProductDiscountApplicableEventArgs e, CancellationToken ct)
+    {
+        if (AfterApplicableDiscountsAsync == null)
+            return;
+
+        foreach (var handler in AfterApplicableDiscountsAsync
             .GetInvocationList()
             .Cast<Func<object?, ProductDiscountApplicableEventArgs, Task>>())
         {
+            ct.ThrowIfCancellationRequested();
             await handler(sender, e).ConfigureAwait(false);
         }
     }
@@ -55,4 +67,3 @@ public class DiscountEvents
     }
 
 }
-

--- a/Ekom/Ekom/Services/ProductDiscountService.cs
+++ b/Ekom/Ekom/Services/ProductDiscountService.cs
@@ -24,7 +24,6 @@ class ProductDiscountService
             storeAlias,
             inputPrice,
             categories,
-            raiseAfterApplicableDiscounts: true,
             CancellationToken.None).GetAwaiter().GetResult();
 
     public virtual Task<IProductDiscount?> GetProductDiscountAsync(
@@ -38,7 +37,6 @@ class ProductDiscountService
             storeAlias,
             inputPrice,
             categories,
-            raiseAfterApplicableDiscounts: true,
             ct);
 
     private async Task<IProductDiscount?> GetProductDiscountCoreAsync(
@@ -46,7 +44,6 @@ class ProductDiscountService
         string? storeAlias,
         string inputPrice,
         string[]? categories = null,
-        bool raiseAfterApplicableDiscounts = true,
         CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
@@ -69,7 +66,7 @@ class ProductDiscountService
             Categories = categories
         };
 
-        _discountEvents.RaiseBeforeEvaluateDiscounts(this, evalArgs);
+        await _discountEvents.RaiseBeforeEvaluateDiscountsAsync(this, evalArgs, ct).ConfigureAwait(false);
 
         // use possibly modified values from event args
         path = evalArgs.Path;
@@ -139,10 +136,7 @@ class ProductDiscountService
             categories,
             applicableDiscounts);
 
-        if (raiseAfterApplicableDiscounts)
-        {
-            await _discountEvents.RaiseAfterApplicableDiscountsAsync(this, applicableArgs).ConfigureAwait(false);
-        }
+        await _discountEvents.RaiseAfterApplicableDiscountsAsync(this, applicableArgs, ct).ConfigureAwait(false);
 
         ct.ThrowIfCancellationRequested();
 

--- a/Ekom/Ekom/Services/ProductDiscountService.cs
+++ b/Ekom/Ekom/Services/ProductDiscountService.cs
@@ -24,7 +24,7 @@ class ProductDiscountService
             storeAlias,
             inputPrice,
             categories,
-            raiseAfterApplicableDiscounts: false,
+            raiseAfterApplicableDiscounts: true,
             CancellationToken.None).GetAwaiter().GetResult();
 
     public virtual Task<IProductDiscount?> GetProductDiscountAsync(


### PR DESCRIPTION
## Summary
- Make discount evaluation use async-only before/after hooks and run them from the shared sync/async discount path.
- Remove the sync price generation-created hook and run the async price generation hook from sync price cache paths.
- Add focused tests for discount event mutation/order and sync price generation invoking async handlers.

## Test Plan
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~DiscountEventsTests|FullyQualifiedName~PriceCacheTests"`
