### PR TITLE
feat(manager): export order lines

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
@@ -18,6 +18,10 @@
     $scope.averageAmount = 0;
     $scope.page = 1;
     $scope.pageMostSoldProducts = 1;
+    $scope.exportOptions = {
+      includeOrderLines: false,
+      exporting: false
+    };
     $scope.visibleDropdowns = {};
     $scope.labelDropdowns = {};
     $scope.filters = managerState.filters;
@@ -294,6 +298,28 @@
       };
     };
 
+    $scope.OpenExport = function () {
+      $scope.exportOptions = {
+        includeOrderLines: false,
+        exporting: false
+      };
+
+      $scope.overlay = {
+        title: "Export orders",
+        view: "/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html",
+        editModel: {
+          options: $scope.exportOptions
+        },
+        show: true,
+        submit: function () {
+          $scope.ExportCsv(null, $scope.exportOptions.includeOrderLines);
+        },
+        close: function () {
+          $scope.CloseModal();
+        }
+      };
+    };
+
     $scope.ViewOrder = function (order) {
       resources.OrderInfo(order.uniqueId)
         .then(function (result) {
@@ -524,37 +550,30 @@
         });
     };
 
-    $scope.ExportCsv = function (filename) {
-      var orders = $scope.result.orders;
+    function escapeCsvValue(value) {
+      var escapedValue = value;
 
-      if (!orders || !orders.length) {
-        return;
+      if (escapedValue == null) {
+        return "";
       }
 
-      var keys = Object.keys(orders[0]);
+      if (typeof escapedValue === "object") {
+        escapedValue = JSON.stringify(escapedValue);
+      }
+
+      escapedValue = String(escapedValue);
+
+      return /[",\r\n]/.test(escapedValue)
+        ? '"' + escapedValue.replace(/"/g, '""') + '"'
+        : escapedValue;
+    }
+
+    function downloadCsv(keys, rows, filename) {
       var lines = [keys.join(",")];
 
-      function escapeValue(value) {
-        var escapedValue = value;
-
-        if (escapedValue == null) {
-          return "";
-        }
-
-        if (typeof escapedValue === "object") {
-          escapedValue = JSON.stringify(escapedValue);
-        }
-
-        escapedValue = String(escapedValue);
-
-        return /[",\r\n]/.test(escapedValue)
-          ? '"' + escapedValue.replace(/"/g, '""') + '"'
-          : escapedValue;
-      }
-
-      orders.forEach(function (order) {
+      rows.forEach(function (row) {
         lines.push(keys.map(function (key) {
-          return escapeValue(order[key]);
+          return escapeCsvValue(row[key]);
         }).join(","));
       });
 
@@ -566,11 +585,116 @@
       anchor.download = filename || "orders.csv";
       document.body.appendChild(anchor);
 
-      $timeout(function () {
+      return $timeout(function () {
         anchor.click();
         document.body.removeChild(anchor);
         URL.revokeObjectURL(url);
       }, 0, false);
+    }
+
+    function getOrderLineExportKeys(orders) {
+      return ["rowType"].concat(Object.keys(orders[0]), [
+        "orderLineKey",
+        "productSku",
+        "productTitle",
+        "variantSku",
+        "variantTitle",
+        "quantity",
+        "unitPrice",
+        "vat",
+        "discount",
+        "lineTotal"
+      ]);
+    }
+
+    function getEmptyOrderLineExportData() {
+      return {
+        orderLineKey: "",
+        productSku: "",
+        productTitle: "",
+        variantSku: "",
+        variantTitle: "",
+        quantity: "",
+        unitPrice: "",
+        vat: "",
+        discount: "",
+        lineTotal: ""
+      };
+    }
+
+    function getOrderLineExportData(orderLine) {
+      return {
+        orderLineKey: orderLine.key,
+        productSku: orderLine.product && orderLine.product.sku,
+        productTitle: orderLine.product && orderLine.product.title,
+        variantSku: orderLine.variant && orderLine.variant.sku,
+        variantTitle: orderLine.variant && orderLine.variant.title,
+        quantity: orderLine.quantity,
+        unitPrice: orderLine.product && orderLine.product.price && orderLine.product.price.withVat && orderLine.product.price.withVat.currencyString,
+        vat: orderLine.amount && orderLine.amount.vat && orderLine.amount.vat.currencyString,
+        discount: orderLine.amount && orderLine.amount.discountAmount && orderLine.amount.discountAmount.currencyString,
+        lineTotal: orderLine.amount && orderLine.amount.withVat && orderLine.amount.withVat.currencyString
+      };
+    }
+
+    function getOrderLineRow(order, orderLine) {
+      return angular.extend({
+        rowType: "OrderLine",
+        referenceId: order.referenceId,
+        uniqueId: order.uniqueId
+      }, getEmptyOrderLineExportData(), getOrderLineExportData(orderLine));
+    }
+
+    function getOrderLineExportRows(orders) {
+      return $q.all(orders.map(function (order) {
+        return resources.OrderInfo(order.uniqueId)
+          .then(function (result) {
+            var orderInfo = result.data || {};
+            var orderLines = orderInfo.orderLines || [];
+            var rows = [angular.extend({ rowType: "Order" }, order, getEmptyOrderLineExportData())];
+
+            orderLines.forEach(function (orderLine) {
+              rows.push(getOrderLineRow(order, orderLine));
+            });
+
+            return rows;
+          });
+      })).then(function (orderLineRows) {
+        return [].concat.apply([], orderLineRows);
+      });
+    }
+
+    $scope.ExportCsv = function (filename, includeOrderLines) {
+      var orders = $scope.result.orders;
+
+      if (!orders || !orders.length) {
+        return;
+      }
+
+      $scope.exportOptions.exporting = true;
+
+      if (!includeOrderLines) {
+        return downloadCsv(Object.keys(orders[0]), orders, filename)
+          .then(function () {
+            $scope.CloseModal();
+          })
+          .finally(function () {
+            $scope.exportOptions.exporting = false;
+          });
+      }
+
+      return getOrderLineExportRows(orders)
+        .then(function (rows) {
+          return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
+        })
+        .then(function () {
+          $scope.CloseModal();
+        }, function () {
+          notificationsService.error("Error", "Error exporting order lines.");
+        })
+        .finally(function () {
+          $scope.exportOptions.exporting = false;
+        });
     };
 
     $scope.$on("$destroy", function () {

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/ekmManager.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/ekmManager.html
@@ -82,7 +82,7 @@
               </div>
 
               <div class="ekmManager__search">
-                <uui-button pristine="" type="" style="" look="outline" color="default" label="Export" class="ekmManager__filterButton" ng-click="ExportCsv()">
+                <uui-button pristine="" type="" style="" look="outline" color="default" label="Export" class="ekmManager__filterButton" ng-click="OpenExport()">
                   Export
                 </uui-button>
 

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
@@ -1,0 +1,22 @@
+<article class="ekmExport">
+  <p>Choose how to export the currently loaded orders.</p>
+
+  <label style="display:block; margin-top:15px;">
+    <input type="checkbox" no-dirty-check ng-model="model.editModel.options.includeOrderLines" ng-disabled="model.editModel.options.exporting" />
+    Include order lines
+  </label>
+
+  <p style="margin-top:10px;" ng-if="model.editModel.options.includeOrderLines">
+    Including order lines can take longer because each order needs to be loaded before the CSV is created.
+  </p>
+
+  <p style="margin-top:15px;" ng-if="model.editModel.options.exporting">
+    <i class="icon icon-loading"></i>
+    Exporting orders. This may take a while...
+  </p>
+
+  <div style="margin-top:25px; display:flex; gap:10px;">
+    <button type="button" class="btn umb-button__button btn-success" ng-click="model.submit()" ng-disabled="model.editModel.options.exporting">Export</button>
+    <button type="button" class="btn umb-button__button" ng-click="model.close()" ng-disabled="model.editModel.options.exporting">Cancel</button>
+  </div>
+</article>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
@@ -18,6 +18,10 @@
     $scope.averageAmount = 0;
     $scope.page = 1;
     $scope.pageMostSoldProducts = 1;
+    $scope.exportOptions = {
+      includeOrderLines: false,
+      exporting: false
+    };
     $scope.visibleDropdowns = {};
     $scope.labelDropdowns = {};
     $scope.filters = managerState.filters;
@@ -294,6 +298,28 @@
       };
     };
 
+    $scope.OpenExport = function () {
+      $scope.exportOptions = {
+        includeOrderLines: false,
+        exporting: false
+      };
+
+      $scope.overlay = {
+        title: "Export orders",
+        view: "/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html",
+        editModel: {
+          options: $scope.exportOptions
+        },
+        show: true,
+        submit: function () {
+          $scope.ExportCsv(null, $scope.exportOptions.includeOrderLines);
+        },
+        close: function () {
+          $scope.CloseModal();
+        }
+      };
+    };
+
     $scope.ViewOrder = function (order) {
       resources.OrderInfo(order.uniqueId)
         .then(function (result) {
@@ -524,37 +550,30 @@
         });
     };
 
-    $scope.ExportCsv = function (filename) {
-      var orders = $scope.result.orders;
+    function escapeCsvValue(value) {
+      var escapedValue = value;
 
-      if (!orders || !orders.length) {
-        return;
+      if (escapedValue == null) {
+        return "";
       }
 
-      var keys = Object.keys(orders[0]);
+      if (typeof escapedValue === "object") {
+        escapedValue = JSON.stringify(escapedValue);
+      }
+
+      escapedValue = String(escapedValue);
+
+      return /[",\r\n]/.test(escapedValue)
+        ? '"' + escapedValue.replace(/"/g, '""') + '"'
+        : escapedValue;
+    }
+
+    function downloadCsv(keys, rows, filename) {
       var lines = [keys.join(",")];
 
-      function escapeValue(value) {
-        var escapedValue = value;
-
-        if (escapedValue == null) {
-          return "";
-        }
-
-        if (typeof escapedValue === "object") {
-          escapedValue = JSON.stringify(escapedValue);
-        }
-
-        escapedValue = String(escapedValue);
-
-        return /[",\r\n]/.test(escapedValue)
-          ? '"' + escapedValue.replace(/"/g, '""') + '"'
-          : escapedValue;
-      }
-
-      orders.forEach(function (order) {
+      rows.forEach(function (row) {
         lines.push(keys.map(function (key) {
-          return escapeValue(order[key]);
+          return escapeCsvValue(row[key]);
         }).join(","));
       });
 
@@ -566,11 +585,116 @@
       anchor.download = filename || "orders.csv";
       document.body.appendChild(anchor);
 
-      $timeout(function () {
+      return $timeout(function () {
         anchor.click();
         document.body.removeChild(anchor);
         URL.revokeObjectURL(url);
       }, 0, false);
+    }
+
+    function getOrderLineExportKeys(orders) {
+      return ["rowType"].concat(Object.keys(orders[0]), [
+        "orderLineKey",
+        "productSku",
+        "productTitle",
+        "variantSku",
+        "variantTitle",
+        "quantity",
+        "unitPrice",
+        "vat",
+        "discount",
+        "lineTotal"
+      ]);
+    }
+
+    function getEmptyOrderLineExportData() {
+      return {
+        orderLineKey: "",
+        productSku: "",
+        productTitle: "",
+        variantSku: "",
+        variantTitle: "",
+        quantity: "",
+        unitPrice: "",
+        vat: "",
+        discount: "",
+        lineTotal: ""
+      };
+    }
+
+    function getOrderLineExportData(orderLine) {
+      return {
+        orderLineKey: orderLine.key,
+        productSku: orderLine.product && orderLine.product.sku,
+        productTitle: orderLine.product && orderLine.product.title,
+        variantSku: orderLine.variant && orderLine.variant.sku,
+        variantTitle: orderLine.variant && orderLine.variant.title,
+        quantity: orderLine.quantity,
+        unitPrice: orderLine.product && orderLine.product.price && orderLine.product.price.withVat && orderLine.product.price.withVat.currencyString,
+        vat: orderLine.amount && orderLine.amount.vat && orderLine.amount.vat.currencyString,
+        discount: orderLine.amount && orderLine.amount.discountAmount && orderLine.amount.discountAmount.currencyString,
+        lineTotal: orderLine.amount && orderLine.amount.withVat && orderLine.amount.withVat.currencyString
+      };
+    }
+
+    function getOrderLineRow(order, orderLine) {
+      return angular.extend({
+        rowType: "OrderLine",
+        referenceId: order.referenceId,
+        uniqueId: order.uniqueId
+      }, getEmptyOrderLineExportData(), getOrderLineExportData(orderLine));
+    }
+
+    function getOrderLineExportRows(orders) {
+      return $q.all(orders.map(function (order) {
+        return resources.OrderInfo(order.uniqueId)
+          .then(function (result) {
+            var orderInfo = result.data || {};
+            var orderLines = orderInfo.orderLines || [];
+            var rows = [angular.extend({ rowType: "Order" }, order, getEmptyOrderLineExportData())];
+
+            orderLines.forEach(function (orderLine) {
+              rows.push(getOrderLineRow(order, orderLine));
+            });
+
+            return rows;
+          });
+      })).then(function (orderLineRows) {
+        return [].concat.apply([], orderLineRows);
+      });
+    }
+
+    $scope.ExportCsv = function (filename, includeOrderLines) {
+      var orders = $scope.result.orders;
+
+      if (!orders || !orders.length) {
+        return;
+      }
+
+      $scope.exportOptions.exporting = true;
+
+      if (!includeOrderLines) {
+        return downloadCsv(Object.keys(orders[0]), orders, filename)
+          .then(function () {
+            $scope.CloseModal();
+          })
+          .finally(function () {
+            $scope.exportOptions.exporting = false;
+          });
+      }
+
+      return getOrderLineExportRows(orders)
+        .then(function (rows) {
+          return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
+        })
+        .then(function () {
+          $scope.CloseModal();
+        }, function () {
+          notificationsService.error("Error", "Error exporting order lines.");
+        })
+        .finally(function () {
+          $scope.exportOptions.exporting = false;
+        });
     };
 
     $scope.$on("$destroy", function () {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/ekmManager.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/ekmManager.html
@@ -82,7 +82,7 @@
               </div>
 
               <div class="ekmManager__search">
-                <uui-button pristine="" type="" style="" look="outline" color="default" label="Export" class="ekmManager__filterButton" ng-click="ExportCsv()">
+                <uui-button pristine="" type="" style="" look="outline" color="default" label="Export" class="ekmManager__filterButton" ng-click="OpenExport()">
                   Export
                 </uui-button>
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
@@ -1,0 +1,22 @@
+<article class="ekmExport">
+  <p>Choose how to export the currently loaded orders.</p>
+
+  <label style="display:block; margin-top:15px;">
+    <input type="checkbox" no-dirty-check ng-model="model.editModel.options.includeOrderLines" ng-disabled="model.editModel.options.exporting" />
+    Include order lines
+  </label>
+
+  <p style="margin-top:10px;" ng-if="model.editModel.options.includeOrderLines">
+    Including order lines can take longer because each order needs to be loaded before the CSV is created.
+  </p>
+
+  <p style="margin-top:15px;" ng-if="model.editModel.options.exporting">
+    <i class="icon icon-loading"></i>
+    Exporting orders. This may take a while...
+  </p>
+
+  <div style="margin-top:25px; display:flex; gap:10px;">
+    <button type="button" class="btn umb-button__button btn-success" ng-click="model.submit()" ng-disabled="model.editModel.options.exporting">Export</button>
+    <button type="button" class="btn umb-button__button" ng-click="model.close()" ng-disabled="model.editModel.options.exporting">Cancel</button>
+  </div>
+</article>


### PR DESCRIPTION
## Summary
- Add an export overlay for manager order CSV exports.
- Keep the existing order-only CSV export path available by default.
- Add an optional order line export mode that loads each order and appends line rows with product, variant, quantity, and totals.
- Mirror the manager plugin changes into the U10 sample site plugin files.

## Test Plan
- Not run; UI-only AngularJS/backoffice export change.
