### PR TITLE
fix(stock): use explicit store stock lookups

### DIFF
--- a/Ekom/Ekom/API/Settings/OrderSettings.cs
+++ b/Ekom/Ekom/API/Settings/OrderSettings.cs
@@ -42,7 +42,7 @@ public class OrderSettings
     /// This allows callers to supporting methods to provide a completed order, 
     /// circumventing our IsOrderFinal logic
     /// </summary>
-    public IOrderInfo OrderInfo { get; set; }
+    public IOrderInfo? OrderInfo { get; set; }
 
     public OrderDynamicRequest OrderDynamicRequest { get; set; }
     public Dictionary<string, string> CustomData { get; set; } = [];

--- a/Ekom/Ekom/API/Stock.cs
+++ b/Ekom/Ekom/API/Stock.cs
@@ -72,9 +72,9 @@ public partial class Stock
     /// <returns></returns>
     public decimal GetStock(Guid key, string storeAlias)
     {
-        if (string.IsNullOrEmpty(storeAlias))
+        if (string.IsNullOrWhiteSpace(storeAlias) || !_config.PerStoreStock)
         {
-            throw new ArgumentException("StoreAlias empty, did you mean to use GetStock(key) instead?", nameof(storeAlias));
+            return GetStock(key);
         }
 
         return GetStockData(key, storeAlias).Stock;
@@ -118,6 +118,10 @@ public partial class Stock
     /// <returns></returns>
     public StockData GetStockData(Guid key, string storeAlias)
     {
+        if (string.IsNullOrWhiteSpace(storeAlias) || !_config.PerStoreStock)
+        {
+            return GetStockData(key);
+        }
 
         return _stockPerStoreCache.Cache.ContainsKey(storeAlias) && _stockPerStoreCache.Cache[storeAlias].ContainsKey(key)
         ? _stockPerStoreCache.Cache[storeAlias][key]
@@ -151,7 +155,7 @@ public partial class Stock
             {
                 foreach (OrderedVariant? orderedVariant in orderLine.Product.VariantGroups.SelectMany(x => x.Variants))
                 {
-                    IVariant? variant = Catalog.Instance.GetVariant(orderedVariant.Key, orderInfo.StoreInfo.Alias);
+                    IVariant? variant = await Catalog.Instance.GetVariantAsync(orderedVariant.Key, orderInfo.StoreInfo.Alias, ct: ct);
 
                     if (variant == null)
                     {

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -497,7 +497,7 @@ partial class OrderService
         OrderInfo? orderInfo;
         if (settings.OrderInfo == null)
         {
-            orderInfo = await GetOrderAsync(store).ConfigureAwait(false);
+            orderInfo = await GetOrderAsync(store, ct: ct).ConfigureAwait(false);
         }
         else
         {
@@ -540,15 +540,15 @@ partial class OrderService
 
                 ArgumentNullException.ThrowIfNull(orderedVariant, "Ordered Variant is null");
 
-                variant = Catalog.Instance.GetVariant(orderedVariant.Key, storeAlias);
+                variant = await Catalog.Instance.GetVariantAsync(orderedVariant.Key, storeAlias, ct: ct);
 
                 ArgumentNullException.ThrowIfNull(variant, "Variant is null");
 
-                existingStock = variant.Stock;
+                existingStock = Stock.Instance.GetStock(variant.Key, store.Alias);
             }
             else
             {
-                existingStock = product.Stock;
+                existingStock = Stock.Instance.GetStock(product.Key, store.Alias);
             }
 
             VerifyStock(quantity, existingStock, product, variant);


### PR DESCRIPTION
## Summary
- Fall back to the default stock lookup when a store alias is blank or per-store stock is disabled.
- Use explicit store-based stock reads when verifying order line quantity updates.
- Load variants asynchronously with cancellation support during stock validation.
- Mark `OrderSettings.OrderInfo` nullable to match existing null checks.

## Test Plan
- `dotnet build "Ekom/Ekom/Ekom.csproj"`
- Confirm add-to-cart stock verification reads the requested store's stock when per-store stock is enabled.
