### PR TITLE
fix(stock): use store alias for stock checks

### DIFF
--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -83,7 +83,7 @@ public class Product : PerStoreNodeEntity, IProduct
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public virtual decimal Stock => API.Stock.Instance.GetStock(Key);
+    public virtual decimal Stock => API.Stock.Instance.GetStock(Key, Store.Alias);
 
     /// <summary>
     /// Get the current product Stock

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -30,7 +30,7 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public virtual decimal Stock => API.Stock.Instance.GetStock(Key);
+    public virtual decimal Stock => API.Stock.Instance.GetStock(Key, Store.Alias);
 
     /// <summary>
     /// Get the backorder status

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -2004,7 +2004,7 @@ partial class OrderService
         && existingStock < quantity)
         {
             throw new NotEnoughStockException(
-                $"Stock not available for product {product.Key} and variant {variant?.Key}");
+                $"Stock not available for product {product.Key} and variant {variant?.Key}. ExistingStock: {existingStock}. Quantity: {quantity} BufferStock: {bufferStock}");
         }
     }
 


### PR DESCRIPTION
## Summary
- use the current store alias when reading product and variant stock
- keep stock exception messages detailed with stock, quantity, and buffer values

## Testing
- dotnet build "Ekom/Ekom/Ekom.csproj"
