### PR TITLE
fix(order): use variant discounts on order lines

### DIFF
--- a/Ekom/Ekom/Models/OrderLine.cs
+++ b/Ekom/Ekom/Models/OrderLine.cs
@@ -166,7 +166,7 @@ public class OrderLine : IOrderLine
         OrderInfo = orderInfo;
         OrderLineInfo = orderLineInfo;
         Product = new OrderedProduct(productJson, orderInfo.StoreInfo);
-        Discount = discount;
+        Discount = discount ?? Variant?.Price.Discount ?? Product.Price.Discount;
         Settings = settings;
     }
 
@@ -186,7 +186,7 @@ public class OrderLine : IOrderLine
         Quantity = quantity;
         Key = lineId;
         Product = new OrderedProduct(product, variant, orderInfo.StoreInfo, orderDynamic);
-        Discount = product.Price.Discount;
+        Discount = Variant?.Price.Discount ?? Product.Price.Discount;
         OrderLineInfo = new OrderLineInfo()
         {
             Properties = orderLineData


### PR DESCRIPTION
## Summary
- initialize order line discounts from variant prices when available
- preserve variant dynamic price discounts when order lines are rebuilt from saved JSON
- allow variant line discounts to be included in charged totals

## Test Plan
- git diff --check
- dotnet build "Ekom/Ekom/Ekom.csproj"
