### PR TITLE
fix(order): use provided order for coupon code

### DIFF
--- a/Ekom/Ekom/API/Order.Discounts.cs
+++ b/Ekom/Ekom/API/Order.Discounts.cs
@@ -106,11 +106,16 @@ public partial class Order
     }
 
 
-    public async Task SetCouponCodeAsync(string coupon, DiscountOrderSettings? discountOrderSettings = null, CancellationToken ct = default)
+    public async Task<IOrderInfo?> SetCouponCodeAsync(string coupon, DiscountOrderSettings? discountOrderSettings = null, CancellationToken ct = default)
     {
-        var storeAlias = _storeSvc.GetStoreFromCache()?.Alias;
+        return await SetCouponCodeAsync(coupon, null, discountOrderSettings, ct).ConfigureAwait(false);
+    }
 
-        await _orderService.SetCouponCodeAsync(coupon, storeAlias, discountOrderSettings, ct: ct).ConfigureAwait(false);
+    public async Task<IOrderInfo?> SetCouponCodeAsync(string coupon, string? storeAlias, DiscountOrderSettings? discountOrderSettings = null, CancellationToken ct = default)
+    {
+        storeAlias = storeAlias ?? _storeSvc.GetStoreFromCache()?.Alias;
+
+        return await _orderService.SetCouponCodeAsync(coupon, storeAlias, discountOrderSettings, ct: ct).ConfigureAwait(false);
     }
 
     

--- a/Ekom/Ekom/Services/OrderService.Discounts.cs
+++ b/Ekom/Ekom/Services/OrderService.Discounts.cs
@@ -254,26 +254,33 @@ partial class OrderService
     /// <summary>
     /// Manually set coupon code on order, does not validate coupon or use other discount functionality
     /// </summary>
-    public async Task SetCouponCodeAsync(string couponCode, string? storeAlias, DiscountOrderSettings? settings = null, CancellationToken ct = default)
+    public async Task<IOrderInfo?> SetCouponCodeAsync(string couponCode, string? storeAlias, DiscountOrderSettings? settings = null, CancellationToken ct = default)
     {
-        if (string.IsNullOrEmpty(couponCode))
-        {
-            return;
-        }
-
-        var orderInfo = await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
+        var orderInfo = settings?.OrderInfo as OrderInfo;
 
         if (orderInfo == null)
         {
-            return;
+            orderInfo = await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
+        }
+
+        if (string.IsNullOrEmpty(couponCode))
+        {
+            return orderInfo;
+        }
+
+        if (orderInfo == null)
+        {
+            return orderInfo;
         }
 
         if (orderInfo.Coupon != couponCode)
         {
             orderInfo.Coupon = couponCode;
 
-            await UpdateOrderAndOrderInfoAsync(orderInfo, fireOnOrderUpdatedEvents: settings?.FireOnOrderUpdatedEvent ?? true, ct: ct).ConfigureAwait(false);
+            return await UpdateOrderAndOrderInfoAsync(orderInfo, fireOnOrderUpdatedEvents: settings?.FireOnOrderUpdatedEvent ?? true, ct: ct).ConfigureAwait(false);
         }
+
+        return orderInfo;
     }
 
 


### PR DESCRIPTION
## Summary
- use the supplied OrderInfo from discount settings when setting a coupon code
- return the updated order info so callers can continue with the refreshed order instance
- add a store-alias overload while preserving the existing settings-based API shape

## Test Plan
- git diff --check
- dotnet build "Ekom/Ekom/Ekom.csproj"
