### PR TITLE
fix(order): respect event flag on line updates

### DIFF
--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -555,13 +555,17 @@ partial class OrderService
 
             orderline.Quantity = quantity;
 
-            var updatedEventArgs = new UpdatedOrderlineEventArgs()
+            if (settings.FireEvents)
             {
-                OrderInfo = orderInfo
-            };
+                var updatedEventArgs = new UpdatedOrderlineEventArgs()
+                {
+                    OrderInfo = orderInfo
+                };
 
-            OrderEvents.OnUpdatedOrderline(this, updatedEventArgs);
-            await OrderEvents.OnUpdatedOrderlineAsync(this, updatedEventArgs, ct);
+                OrderEvents.OnUpdatedOrderline(this, updatedEventArgs);
+                await OrderEvents.OnUpdatedOrderlineAsync(this, updatedEventArgs, ct);
+            }
+
 
             return await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
                 .ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- only raise updated order line events when order settings allow events
- prevent update event handlers from running when FireEvents is disabled

## Test Plan
- git diff --check
- dotnet build "Ekom/Ekom/Ekom.csproj"
