### PR TITLE
fix(stock): use order store in checkout

### DIFF
--- a/Ekom/Ekom/Services/CheckoutService.cs
+++ b/Ekom/Ekom/Services/CheckoutService.cs
@@ -194,6 +194,8 @@ class CheckoutService
     /// <returns></returns>
     private async Task ProcessOrderLinesStockAsync(IOrderInfo order)
     {
+        string storeAlias = order.StoreInfo.Alias;
+
         foreach (IOrderLine line in order.OrderLines)
         {
             if (!line.Product.Backorder)
@@ -202,16 +204,16 @@ class CheckoutService
                 {
                     foreach (OrderedVariant? variant in line.Product.VariantGroups.SelectMany(x => x.Variants))
                     {
-                        decimal variantStock = Stock.Instance.GetStock(variant.Key);
+                        decimal variantStock = Stock.Instance.GetStock(variant.Key, storeAlias);
 
                         if (variantStock >= line.Quantity)
                         {
-                            await Stock.Instance.IncrementStockAsync(variant.Key, (line.Quantity * -1))
+                            await Stock.Instance.IncrementStockAsync(variant.Key, storeAlias, (line.Quantity * -1))
                                 .ConfigureAwait(false);
                         }
                         else
                         {
-                            _logger.LogError($"Variant Stock error on line {line.Key} with variant {variant.Key}");
+                            _logger.LogError("Variant Stock error on line {OrderLineKey} with variant {VariantKey} in store {StoreAlias}. Stock: {Stock}. Quantity: {Quantity}", line.Key, variant.Key, storeAlias, variantStock, line.Quantity);
                             throw new NotEnoughLineStockException("Stock error ")
                             {
                                 OrderLineKey = line.Key,
@@ -222,7 +224,7 @@ class CheckoutService
                 }
                 else
                 {
-                    decimal productStock = Stock.Instance.GetStock(line.ProductKey);
+                    decimal productStock = Stock.Instance.GetStock(line.ProductKey, storeAlias);
 
                     if (productStock >= line.Quantity)
                     {
@@ -234,12 +236,12 @@ class CheckoutService
                         //{
                         //    hangfireJobs.Add(await Stock.Instance.ReserveStockAsync(line.ProductKey, (line.Quantity * -1)));
                         //}
-                        await Stock.Instance.IncrementStockAsync(line.ProductKey, (line.Quantity * -1))
+                        await Stock.Instance.IncrementStockAsync(line.ProductKey, storeAlias, (line.Quantity * -1))
                             .ConfigureAwait(false);
                     }
                     else
                     {
-                        _logger.LogError($"Product Stock error one line {line.Key} with product {line.ProductKey}");
+                        _logger.LogError("Product Stock error on line {OrderLineKey} with product {ProductKey} in store {StoreAlias}. Stock: {Stock}. Quantity: {Quantity}", line.Key, line.ProductKey, storeAlias, productStock, line.Quantity);
                         throw new NotEnoughLineStockException("Stock error ")
                         {
                             OrderLineKey = line.Key,


### PR DESCRIPTION
## Summary
- use the order store alias when validating checkout stock
- decrement checkout stock against the order store instead of the current request store
- include store alias, stock, and quantity in checkout stock error logs

## Test Plan
- git diff --check
- dotnet build "Ekom/Ekom/Ekom.csproj"
