### PR TITLE
fix(manager): export all filtered orders

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
@@ -124,6 +124,15 @@
       };
     }
 
+    function buildExportOrdersQuery() {
+      var query = buildOrdersQuery();
+
+      query.page = 1;
+      query.pageSize = $scope.result.count || 0;
+
+      return query;
+    }
+
     function buildChartQuery() {
       return {
         start: formatDateQueryValue($scope.filters.dateFrom),
@@ -675,33 +684,45 @@
       });
     }
 
-    $scope.ExportCsv = function (filename, includeOrderLines) {
-      var orders = $scope.result.orders;
+    function getExportOrders() {
+      if (!$scope.result.count) {
+        return $q.when([]);
+      }
 
-      if (!orders || !orders.length) {
+      return resources.SearchOrders(buildExportOrdersQuery())
+        .then(function (result) {
+          var data = result.data || {};
+
+          return data.orders || [];
+        });
+    }
+
+    $scope.ExportCsv = function (filename, includeOrderLines) {
+      if (!$scope.result.count) {
         return;
       }
 
       $scope.exportOptions.exporting = true;
 
-      if (!includeOrderLines) {
-        return downloadCsv(Object.keys(orders[0]), orders, filename)
-          .then(function () {
-            $scope.CloseModal();
-          })
-          .finally(function () {
-            $scope.exportOptions.exporting = false;
-          });
-      }
+      return getExportOrders()
+        .then(function (orders) {
+          if (!orders.length) {
+            return;
+          }
 
-      return getOrderLineExportRows(orders)
-        .then(function (rows) {
-          return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
+          if (!includeOrderLines) {
+            return downloadCsv(Object.keys(orders[0]), orders, filename);
+          }
+
+          return getOrderLineExportRows(orders)
+            .then(function (rows) {
+              return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
+            });
         })
         .then(function () {
           $scope.CloseModal();
         }, function () {
-          notificationsService.error("Error", "Error exporting order lines.");
+          notificationsService.error("Error", "Error exporting orders.");
         })
         .finally(function () {
           $scope.exportOptions.exporting = false;

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
@@ -1,5 +1,5 @@
 <article class="ekmExport">
-  <p>Choose how to export the currently loaded orders.</p>
+  <p>Choose how to export the orders matching the current filters.</p>
 
   <label style="display:block; margin-top:15px;">
     <input type="checkbox" no-dirty-check ng-model="model.editModel.options.includeOrderLines" ng-disabled="model.editModel.options.exporting" />
@@ -7,7 +7,7 @@
   </label>
 
   <p style="margin-top:10px;" ng-if="model.editModel.options.includeOrderLines">
-    Including order lines can take longer because each order needs to be loaded before the CSV is created.
+    Including order lines can take longer because each matching order needs to be loaded before the CSV is created.
   </p>
 
   <p style="margin-top:15px;" ng-if="model.editModel.options.exporting">

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
@@ -124,6 +124,15 @@
       };
     }
 
+    function buildExportOrdersQuery() {
+      var query = buildOrdersQuery();
+
+      query.page = 1;
+      query.pageSize = $scope.result.count || 0;
+
+      return query;
+    }
+
     function buildChartQuery() {
       return {
         start: formatDateQueryValue($scope.filters.dateFrom),
@@ -675,33 +684,45 @@
       });
     }
 
-    $scope.ExportCsv = function (filename, includeOrderLines) {
-      var orders = $scope.result.orders;
+    function getExportOrders() {
+      if (!$scope.result.count) {
+        return $q.when([]);
+      }
 
-      if (!orders || !orders.length) {
+      return resources.SearchOrders(buildExportOrdersQuery())
+        .then(function (result) {
+          var data = result.data || {};
+
+          return data.orders || [];
+        });
+    }
+
+    $scope.ExportCsv = function (filename, includeOrderLines) {
+      if (!$scope.result.count) {
         return;
       }
 
       $scope.exportOptions.exporting = true;
 
-      if (!includeOrderLines) {
-        return downloadCsv(Object.keys(orders[0]), orders, filename)
-          .then(function () {
-            $scope.CloseModal();
-          })
-          .finally(function () {
-            $scope.exportOptions.exporting = false;
-          });
-      }
+      return getExportOrders()
+        .then(function (orders) {
+          if (!orders.length) {
+            return;
+          }
 
-      return getOrderLineExportRows(orders)
-        .then(function (rows) {
-          return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
+          if (!includeOrderLines) {
+            return downloadCsv(Object.keys(orders[0]), orders, filename);
+          }
+
+          return getOrderLineExportRows(orders)
+            .then(function (rows) {
+              return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
+            });
         })
         .then(function () {
           $scope.CloseModal();
         }, function () {
-          notificationsService.error("Error", "Error exporting order lines.");
+          notificationsService.error("Error", "Error exporting orders.");
         })
         .finally(function () {
           $scope.exportOptions.exporting = false;

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/views/overlays/ekmExport.html
@@ -1,5 +1,5 @@
 <article class="ekmExport">
-  <p>Choose how to export the currently loaded orders.</p>
+  <p>Choose how to export the orders matching the current filters.</p>
 
   <label style="display:block; margin-top:15px;">
     <input type="checkbox" no-dirty-check ng-model="model.editModel.options.includeOrderLines" ng-disabled="model.editModel.options.exporting" />
@@ -7,7 +7,7 @@
   </label>
 
   <p style="margin-top:10px;" ng-if="model.editModel.options.includeOrderLines">
-    Including order lines can take longer because each order needs to be loaded before the CSV is created.
+    Including order lines can take longer because each matching order needs to be loaded before the CSV is created.
   </p>
 
   <p style="margin-top:15px;" ng-if="model.editModel.options.exporting">


### PR DESCRIPTION
## Summary
- Fetch all orders matching the current manager filters before generating order CSV exports.
- Keep order-line exports consistent by loading order lines for the full filtered export set.
- Update export overlay copy to clarify exports use the current filters, not just the visible page.

## Test Plan
- Ran `node --check` for both manager controller files.
- Ran `git diff --cached --check` before committing.
- Manually reviewed the PR diff to confirm only manager export files are included.