### PR TITLE
fix(manager): use order list currencies

### DIFF
--- a/Ekom/Ekom.Tests/Tests/ManagerOrderCurrencyTests.cs
+++ b/Ekom/Ekom.Tests/Tests/ManagerOrderCurrencyTests.cs
@@ -1,0 +1,44 @@
+using Ekom.Models;
+using Ekom.Models.Manager;
+using System.Globalization;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class ManagerOrderCurrencyTests
+{
+    [Fact]
+    public void FormattedTotal_UsesOrderCurrency()
+    {
+        var order = new OrderData
+        {
+            Currency = "EUR",
+            TotalAmount = 1234m
+        };
+
+        string formattedTotal = order.FormattedTotal;
+
+        Assert.Contains("€", formattedTotal, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OrderListData_UsesProvidedCurrencyForTotals()
+    {
+        var orders = new[]
+        {
+            new OrderData()
+        };
+        var totals = new OrderListDataTotals
+        {
+            Count = 1,
+            TotalAmount = 1234m,
+            AverageAmount = 1234m
+        };
+
+        var orderListData = new OrderListData(orders, totals, "de-DE");
+        string expectedTotal = string.Format(new CultureInfo("de-DE"), "{0:C}", 1234m);
+
+        Assert.Equal(expectedTotal, orderListData.GrandTotal);
+        Assert.Equal(expectedTotal, orderListData.AverageAmount);
+    }
+}

--- a/Ekom/Ekom/Models/Data/OrderData.cs
+++ b/Ekom/Ekom/Models/Data/OrderData.cs
@@ -61,10 +61,7 @@ namespace Ekom.Models
         {
             get
             {
-
-                string currencyCode = "ISK";
-
-                CultureInfo cultureInfo = CultureHelper.GetCultureInfoByCurrencyCode(currencyCode);
+                CultureInfo? cultureInfo = CultureHelper.GetCultureInfo(Currency);
 
                 if (cultureInfo != null)
                 {

--- a/Ekom/Ekom/Models/Manager/OrderListData.cs
+++ b/Ekom/Ekom/Models/Manager/OrderListData.cs
@@ -1,9 +1,12 @@
+using Ekom.Utilities;
+using System.Globalization;
+
 namespace Ekom.Models.Manager
 {
     public class OrderListData
     {
 
-        public OrderListData(IEnumerable<OrderData> orders, OrderListDataTotals totals)
+        public OrderListData(IEnumerable<OrderData> orders, OrderListDataTotals totals, string? currency = null)
         {
             Orders = orders;
 
@@ -13,15 +16,17 @@ namespace Ekom.Models.Manager
             {
                 decimal _grandTotal = totals.TotalAmount;
                 decimal _averageAmount = totals.AverageAmount;
-                this.GrandTotal = string.Format(Configuration.IsCultureInfo, "{0:C}", _grandTotal) + "";
-                this.AverageAmount = string.Format(Configuration.IsCultureInfo, "{0:C}", _averageAmount) + "";
+                CultureInfo cultureInfo = CultureHelper.GetCultureInfo(currency) ?? Configuration.IsCultureInfo;
+
+                this.GrandTotal = string.Format(cultureInfo, "{0:C}", _grandTotal) + "";
+                this.AverageAmount = string.Format(cultureInfo, "{0:C}", _averageAmount) + "";
             }
 
         }
 
         public IEnumerable<OrderData> Orders { get; set; }
-        public string GrandTotal { get; set; }
-        public string AverageAmount { get; set; }
+        public string GrandTotal { get; set; } = string.Empty;
+        public string AverageAmount { get; set; } = string.Empty;
         public int Count { get; set; }
         public int Page { get; set; } = 1;
         public int PageSize { get; set; } = 30;

--- a/Ekom/Ekom/Repositories/ManagerRepository.cs
+++ b/Ekom/Ekom/Repositories/ManagerRepository.cs
@@ -13,6 +13,7 @@ public class ManagerRepository
     readonly ILogger _logger;
     readonly Configuration _config;
     readonly DatabaseFactory _databaseFactory;
+    readonly IStoreService _storeService;
 
     /// <summary>
     /// ctor
@@ -20,11 +21,13 @@ public class ManagerRepository
     public ManagerRepository(
         ILogger<ManagerRepository> logger,
         Configuration config,
-        DatabaseFactory databaseFactory)
+        DatabaseFactory databaseFactory,
+        IStoreService storeService)
     {
         _logger = logger;
         _config = config;
         _databaseFactory = databaseFactory;
+        _storeService = storeService;
     }
 
     public async Task<IEnumerable<OrderData>> GetOrdersAsync(IReadOnlyCollection<string> allowedStoreAliases)
@@ -119,13 +122,18 @@ public class ManagerRepository
 
         var totals = db.Execute<OrderListDataTotals>(sqlTotalQuery, param);
 
-        var orderListData = new OrderListData(orders, totals)
+        var orderListData = new OrderListData(orders, totals, GetStoreCurrency(store))
         {
             Page = _page,
             PageSize = _pageSize
         };
 
         return orderListData;
+    }
+
+    private string? GetStoreCurrency(string storeAlias)
+    {
+        return _storeService.GetStoreByAlias(storeAlias)?.Currency.CurrencyValue;
     }
 
     public async Task<List<ChartAggregateRow>> GetChartAggregatesAsync(DateTime start, DateTime end, string store, string orderStatus)

--- a/Ekom/Ekom/Utilities/CultureHelper.cs
+++ b/Ekom/Ekom/Utilities/CultureHelper.cs
@@ -4,7 +4,31 @@ namespace Ekom.Utilities
 {
     static class CultureHelper
     {
-        public static CultureInfo GetCultureInfoByCurrencyCode(string currencyCode)
+        public static CultureInfo? GetCultureInfo(string? currency)
+        {
+            if (string.IsNullOrWhiteSpace(currency))
+            {
+                return null;
+            }
+
+            if (currency.Length == 3 && !currency.Contains('-', StringComparison.Ordinal))
+            {
+                return GetCultureInfoByCurrencyCode(currency);
+            }
+
+            try
+            {
+                var cultureInfo = new CultureInfo(currency);
+
+                return cultureInfo.TwoLetterISOLanguageName == "is" ? Configuration.IsCultureInfo : cultureInfo;
+            }
+            catch (CultureNotFoundException)
+            {
+                return GetCultureInfoByCurrencyCode(currency);
+            }
+        }
+
+        public static CultureInfo? GetCultureInfoByCurrencyCode(string currencyCode)
         {
             return CultureInfo.GetCultures(CultureTypes.SpecificCultures)
                 .FirstOrDefault(c =>


### PR DESCRIPTION
## Summary
- Format order list payment totals from each order's stored currency instead of hardcoded ISK.
- Format manager summary totals with the selected store currency.
- Add focused coverage for order list currency formatting.

## Test Plan
- Ran `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~ManagerOrderCurrencyTests"`.
- Ran `git diff --cached --check` before committing.
- Reviewed the PR diff to confirm only the manager currency fix files are included.