### PR TITLE
fix(manager): export order lines server-side

### DIFF
--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
@@ -570,34 +570,7 @@
         });
     };
 
-    function escapeCsvValue(value) {
-      var escapedValue = value;
-
-      if (escapedValue == null) {
-        return "";
-      }
-
-      if (typeof escapedValue === "object") {
-        escapedValue = JSON.stringify(escapedValue);
-      }
-
-      escapedValue = String(escapedValue);
-
-      return /[",\r\n]/.test(escapedValue)
-        ? '"' + escapedValue.replace(/"/g, '""') + '"'
-        : escapedValue;
-    }
-
-    function downloadCsv(keys, rows, filename) {
-      var lines = [keys.join(",")];
-
-      rows.forEach(function (row) {
-        lines.push(keys.map(function (key) {
-          return escapeCsvValue(row[key]);
-        }).join(","));
-      });
-
-      var blob = new Blob(["\uFEFF", lines.join("\r\n")], { type: "text/csv;charset=utf-8;" });
+    function downloadBlob(blob, filename) {
       var url = URL.createObjectURL(blob);
       var anchor = document.createElement("a");
 
@@ -612,112 +585,21 @@
       }, 0, false);
     }
 
-    function getOrderLineExportKeys(orders) {
-      return ["rowType"].concat(Object.keys(orders[0]), [
-        "orderLineKey",
-        "productSku",
-        "productTitle",
-        "variantSku",
-        "variantTitle",
-        "quantity",
-        "unitPrice",
-        "vat",
-        "discount",
-        "lineTotal"
-      ]);
-    }
-
-    function getEmptyOrderLineExportData() {
-      return {
-        orderLineKey: "",
-        productSku: "",
-        productTitle: "",
-        variantSku: "",
-        variantTitle: "",
-        quantity: "",
-        unitPrice: "",
-        vat: "",
-        discount: "",
-        lineTotal: ""
-      };
-    }
-
-    function getOrderLineExportData(orderLine) {
-      return {
-        orderLineKey: orderLine.key,
-        productSku: orderLine.product && orderLine.product.sku,
-        productTitle: orderLine.product && orderLine.product.title,
-        variantSku: orderLine.variant && orderLine.variant.sku,
-        variantTitle: orderLine.variant && orderLine.variant.title,
-        quantity: orderLine.quantity,
-        unitPrice: orderLine.product && orderLine.product.price && orderLine.product.price.withVat && orderLine.product.price.withVat.currencyString,
-        vat: orderLine.amount && orderLine.amount.vat && orderLine.amount.vat.currencyString,
-        discount: orderLine.amount && orderLine.amount.discountAmount && orderLine.amount.discountAmount.currencyString,
-        lineTotal: orderLine.amount && orderLine.amount.withVat && orderLine.amount.withVat.currencyString
-      };
-    }
-
-    function getOrderLineRow(order, orderLine) {
-      return angular.extend({
-        rowType: "OrderLine",
-        referenceId: order.referenceId,
-        uniqueId: order.uniqueId
-      }, getEmptyOrderLineExportData(), getOrderLineExportData(orderLine));
-    }
-
-    function getOrderLineExportRows(orders) {
-      return $q.all(orders.map(function (order) {
-        return resources.OrderInfo(order.uniqueId)
-          .then(function (result) {
-            var orderInfo = result.data || {};
-            var orderLines = orderInfo.orderLines || [];
-            var rows = [angular.extend({ rowType: "Order" }, order, getEmptyOrderLineExportData())];
-
-            orderLines.forEach(function (orderLine) {
-              rows.push(getOrderLineRow(order, orderLine));
-            });
-
-            return rows;
-          });
-      })).then(function (orderLineRows) {
-        return [].concat.apply([], orderLineRows);
-      });
-    }
-
-    function getExportOrders() {
-      if (!$scope.result.count) {
-        return $q.when([]);
-      }
-
-      return resources.SearchOrders(buildExportOrdersQuery())
-        .then(function (result) {
-          var data = result.data || {};
-
-          return data.orders || [];
-        });
-    }
-
     $scope.ExportCsv = function (filename, includeOrderLines) {
       if (!$scope.result.count) {
         return;
       }
 
+      var query = buildExportOrdersQuery();
+      query.includeOrderLines = !!includeOrderLines;
+
       $scope.exportOptions.exporting = true;
 
-      return getExportOrders()
-        .then(function (orders) {
-          if (!orders.length) {
-            return;
-          }
+      return resources.ExportOrders(query)
+        .then(function (result) {
+          var exportFilename = filename || (includeOrderLines ? "orders-with-orderlines.csv" : "orders.csv");
 
-          if (!includeOrderLines) {
-            return downloadCsv(Object.keys(orders[0]), orders, filename);
-          }
-
-          return getOrderLineExportRows(orders)
-            .then(function (rows) {
-              return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
-            });
+          return downloadBlob(result.data, exportFilename);
         })
         .then(function () {
           $scope.CloseModal();

--- a/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Ekom/Ekom.Web/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -54,6 +54,13 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       SearchOrders: function (query) {
         return get(backofficeBaseUrl + "SearchOrders", query);
       },
+      ExportOrders: function (query) {
+        return $http({
+          method: "GET",
+          url: backofficeBaseUrl + "ExportOrders" + buildQueryString(query),
+          responseType: "blob"
+        });
+      },
       StatusList: function () {
         return get(backofficeBaseUrl + "StatusList");
       },

--- a/Ekom/Ekom/Controllers/EkomManagerController.cs
+++ b/Ekom/Ekom/Controllers/EkomManagerController.cs
@@ -8,6 +8,8 @@ using Ekom.Services;
 using Ekom.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
+using System.Text;
 
 namespace Ekom.Controllers;
 
@@ -189,6 +191,32 @@ public class EkomManagerController : ControllerBase
         }
 
         return Ok(await _repo.SearchOrdersAsync(start, end, query, store, orderStatus, paymentProvider, productSku, trackingSource, trackingMedium, trackingCampaign, trackingTerm, trackingContent, trackingClickId, page, pageSize));
+    }
+
+    [HttpGet]
+    [Route("ExportOrders")]
+    [UmbracoUserAuthorize]
+    public async Task<IActionResult> ExportOrdersAsync(DateTime start, DateTime end, string query, string store, string orderStatus, string paymentProvider, string productSku, string trackingSource, string trackingMedium, string trackingCampaign, string trackingTerm, string trackingContent, string trackingClickId, bool includeOrderLines, CancellationToken ct = default)
+    {
+        if (!CanAccessStore(store))
+        {
+            return ForbidStore(store);
+        }
+
+        try
+        {
+            List<OrderData> orders = await _repo.GetOrdersForExportAsync(start, end, query, store, orderStatus, paymentProvider, productSku, trackingSource, trackingMedium, trackingCampaign, trackingTerm, trackingContent, trackingClickId, includeOrderLines).ConfigureAwait(false);
+            string csv = CreateOrderCsv(orders, includeOrderLines);
+            string fileName = includeOrderLines ? "orders-with-orderlines.csv" : "orders.csv";
+
+            return File(Encoding.UTF8.GetPreamble().Concat(Encoding.UTF8.GetBytes(csv)).ToArray(), "text/csv", fileName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export orders for store {StoreAlias}.", store);
+
+            return StatusCode(500, "An unexpected error occurred.");
+        }
     }
 
     [HttpGet]
@@ -383,6 +411,153 @@ public class EkomManagerController : ControllerBase
         {
             form[value.Key] = value.Value ?? string.Empty;
         }
+    }
+
+    private static string CreateOrderCsv(IReadOnlyCollection<OrderData> orders, bool includeOrderLines)
+    {
+        string[] headers = includeOrderLines
+            ? OrderExportHeaders.LineExportHeaders
+            : OrderExportHeaders.OrderHeaders;
+
+        var csv = new StringBuilder();
+        csv.AppendLine(string.Join(',', headers));
+
+        foreach (OrderData order in orders)
+        {
+            AppendCsvRow(csv, headers, CreateOrderExportRow(order));
+
+            if (!includeOrderLines || string.IsNullOrWhiteSpace(order.OrderInfo))
+            {
+                continue;
+            }
+
+            var orderInfo = new OrderInfo(order);
+
+            foreach (IOrderLine orderLine in orderInfo.OrderLines)
+            {
+                AppendCsvRow(csv, headers, CreateOrderLineExportRow(order, orderLine));
+            }
+        }
+
+        return csv.ToString();
+    }
+
+    private static Dictionary<string, string?> CreateOrderExportRow(OrderData order)
+    {
+        return new Dictionary<string, string?>
+        {
+            ["rowType"] = "Order",
+            ["uniqueId"] = order.UniqueId.ToString(),
+            ["referenceId"] = order.ReferenceId.ToString(CultureInfo.InvariantCulture),
+            ["orderInfo"] = string.Empty,
+            ["orderNumber"] = order.OrderNumber,
+            ["orderStatusCol"] = order.OrderStatusCol,
+            ["orderStatus"] = order.OrderStatus.ToString(),
+            ["formattedTotal"] = order.FormattedTotal,
+            ["customerEmail"] = order.CustomerEmail,
+            ["customerName"] = order.CustomerName,
+            ["customerId"] = order.CustomerId.ToString(CultureInfo.InvariantCulture),
+            ["customerUsername"] = order.CustomerUsername,
+            ["shippingCountry"] = order.ShippingCountry,
+            ["totalAmount"] = order.TotalAmount.ToString(CultureInfo.InvariantCulture),
+            ["currency"] = order.Currency,
+            ["storeAlias"] = order.StoreAlias,
+            ["createDate"] = FormatDate(order.CreateDate),
+            ["updateDate"] = FormatDate(order.UpdateDate),
+            ["paidDate"] = FormatDate(order.PaidDate),
+            ["orderLineKey"] = string.Empty,
+            ["productSku"] = string.Empty,
+            ["productTitle"] = string.Empty,
+            ["variantSku"] = string.Empty,
+            ["variantTitle"] = string.Empty,
+            ["quantity"] = string.Empty,
+            ["unitPrice"] = string.Empty,
+            ["vat"] = string.Empty,
+            ["discount"] = string.Empty,
+            ["lineTotal"] = string.Empty
+        };
+    }
+
+    private static Dictionary<string, string?> CreateOrderLineExportRow(OrderData order, IOrderLine orderLine)
+    {
+        Dictionary<string, string?> row = CreateOrderExportRow(order);
+
+        row["rowType"] = "OrderLine";
+        row["orderLineKey"] = orderLine.Key.ToString();
+        row["productSku"] = orderLine.Product?.SKU;
+        row["productTitle"] = orderLine.Product?.Title;
+        row["variantSku"] = orderLine.Variant?.SKU;
+        row["variantTitle"] = orderLine.Variant?.Title;
+        row["quantity"] = orderLine.Quantity.ToString(CultureInfo.InvariantCulture);
+        row["unitPrice"] = orderLine.Product?.Price?.WithVat?.CurrencyString;
+        row["vat"] = orderLine.Amount?.Vat?.CurrencyString;
+        row["discount"] = orderLine.Amount?.DiscountAmount?.CurrencyString;
+        row["lineTotal"] = orderLine.Amount?.WithVat?.CurrencyString;
+
+        return row;
+    }
+
+    private static void AppendCsvRow(StringBuilder csv, IReadOnlyList<string> headers, IReadOnlyDictionary<string, string?> row)
+    {
+        csv.AppendLine(string.Join(',', headers.Select(header => EscapeCsvValue(row.TryGetValue(header, out string? value) ? value : string.Empty))));
+    }
+
+    private static string EscapeCsvValue(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.IndexOfAny(new[] { '"', ',', '\r', '\n' }) >= 0
+            ? '"' + value.Replace("\"", "\"\"", StringComparison.Ordinal) + '"'
+            : value;
+    }
+
+    private static string FormatDate(DateTime date) => date.ToString("O", CultureInfo.InvariantCulture);
+
+    private static string FormatDate(DateTime? date) => date?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty;
+
+    private static class OrderExportHeaders
+    {
+        public static readonly string[] OrderHeaders =
+        {
+            "uniqueId",
+            "referenceId",
+            "orderInfo",
+            "orderNumber",
+            "orderStatusCol",
+            "orderStatus",
+            "formattedTotal",
+            "customerEmail",
+            "customerName",
+            "customerId",
+            "customerUsername",
+            "shippingCountry",
+            "totalAmount",
+            "currency",
+            "storeAlias",
+            "createDate",
+            "updateDate",
+            "paidDate"
+        };
+
+        public static readonly string[] LineExportHeaders = new[] { "rowType" }
+            .Concat(OrderHeaders)
+            .Concat(new[]
+            {
+                "orderLineKey",
+                "productSku",
+                "productTitle",
+                "variantSku",
+                "variantTitle",
+                "quantity",
+                "unitPrice",
+                "vat",
+                "discount",
+                "lineTotal"
+            })
+            .ToArray();
     }
 
     public class ChartData

--- a/Ekom/Ekom/Repositories/ManagerRepository.cs
+++ b/Ekom/Ekom/Repositories/ManagerRepository.cs
@@ -128,6 +128,40 @@ public class ManagerRepository
         return orderListData;
     }
 
+    public async Task<List<OrderData>> GetOrdersForExportAsync(DateTime start, DateTime end, string query, string store, string orderStatus, string paymentProvider, string productSku, string trackingSource, string trackingMedium, string trackingCampaign, string trackingTerm, string trackingContent, string trackingClickId, bool includeOrderInfo)
+    {
+        string whereClause = GenerateWhereClause(orderStatus, query, store, paymentProvider, productSku, trackingSource, trackingMedium, trackingCampaign, trackingTerm, trackingContent, trackingClickId);
+        string orderInfoColumn = includeOrderInfo ? ",OrderInfo" : string.Empty;
+        string sqlQuery = $"SELECT ReferenceId,UniqueId,OrderNumber,OrderStatusCol,CustomerEmail,CustomerName,CustomerId,CustomerUsername,ShippingCountry,TotalAmount,Currency,StoreAlias,CreateDate,UpdateDate,PaidDate{orderInfoColumn} FROM EkomOrders {whereClause} ORDER BY ReferenceId desc";
+
+        string? paymentProviderValue = null;
+        if (!string.IsNullOrEmpty(paymentProvider) && Guid.TryParse(paymentProvider, out Guid parsedPaymentProvider))
+        {
+            paymentProviderValue = parsedPaymentProvider.ToString();
+        }
+
+        var param = new
+        {
+            startDate = start.Date,
+            endDate = end.Date.AddDays(1).AddTicks(-1),
+            query = "%" + query + "%",
+            orderStatus,
+            store,
+            paymentProvider = paymentProviderValue,
+            productSku = string.IsNullOrWhiteSpace(productSku) ? null : productSku.Trim(),
+            trackingSource = string.IsNullOrWhiteSpace(trackingSource) ? null : trackingSource.Trim(),
+            trackingMedium = string.IsNullOrWhiteSpace(trackingMedium) ? null : trackingMedium.Trim(),
+            trackingCampaign = string.IsNullOrWhiteSpace(trackingCampaign) ? null : trackingCampaign.Trim(),
+            trackingTerm = string.IsNullOrWhiteSpace(trackingTerm) ? null : trackingTerm.Trim(),
+            trackingContent = string.IsNullOrWhiteSpace(trackingContent) ? null : trackingContent.Trim(),
+            trackingClickId = string.IsNullOrWhiteSpace(trackingClickId) ? null : trackingClickId.Trim()
+        };
+
+        await using DbContext db = _databaseFactory.GetDatabase();
+
+        return await db.QueryToListAsync<OrderData>(sqlQuery, param).ConfigureAwait(false);
+    }
+
     public async Task<List<ChartAggregateRow>> GetChartAggregatesAsync(DateTime start, DateTime end, string store, string orderStatus)
     {
         string whereClause = GenerateWhereClause(orderStatus, string.Empty, store, string.Empty);

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/controllers/ekmManager.controller.js
@@ -570,34 +570,7 @@
         });
     };
 
-    function escapeCsvValue(value) {
-      var escapedValue = value;
-
-      if (escapedValue == null) {
-        return "";
-      }
-
-      if (typeof escapedValue === "object") {
-        escapedValue = JSON.stringify(escapedValue);
-      }
-
-      escapedValue = String(escapedValue);
-
-      return /[",\r\n]/.test(escapedValue)
-        ? '"' + escapedValue.replace(/"/g, '""') + '"'
-        : escapedValue;
-    }
-
-    function downloadCsv(keys, rows, filename) {
-      var lines = [keys.join(",")];
-
-      rows.forEach(function (row) {
-        lines.push(keys.map(function (key) {
-          return escapeCsvValue(row[key]);
-        }).join(","));
-      });
-
-      var blob = new Blob(["\uFEFF", lines.join("\r\n")], { type: "text/csv;charset=utf-8;" });
+    function downloadBlob(blob, filename) {
       var url = URL.createObjectURL(blob);
       var anchor = document.createElement("a");
 
@@ -612,112 +585,21 @@
       }, 0, false);
     }
 
-    function getOrderLineExportKeys(orders) {
-      return ["rowType"].concat(Object.keys(orders[0]), [
-        "orderLineKey",
-        "productSku",
-        "productTitle",
-        "variantSku",
-        "variantTitle",
-        "quantity",
-        "unitPrice",
-        "vat",
-        "discount",
-        "lineTotal"
-      ]);
-    }
-
-    function getEmptyOrderLineExportData() {
-      return {
-        orderLineKey: "",
-        productSku: "",
-        productTitle: "",
-        variantSku: "",
-        variantTitle: "",
-        quantity: "",
-        unitPrice: "",
-        vat: "",
-        discount: "",
-        lineTotal: ""
-      };
-    }
-
-    function getOrderLineExportData(orderLine) {
-      return {
-        orderLineKey: orderLine.key,
-        productSku: orderLine.product && orderLine.product.sku,
-        productTitle: orderLine.product && orderLine.product.title,
-        variantSku: orderLine.variant && orderLine.variant.sku,
-        variantTitle: orderLine.variant && orderLine.variant.title,
-        quantity: orderLine.quantity,
-        unitPrice: orderLine.product && orderLine.product.price && orderLine.product.price.withVat && orderLine.product.price.withVat.currencyString,
-        vat: orderLine.amount && orderLine.amount.vat && orderLine.amount.vat.currencyString,
-        discount: orderLine.amount && orderLine.amount.discountAmount && orderLine.amount.discountAmount.currencyString,
-        lineTotal: orderLine.amount && orderLine.amount.withVat && orderLine.amount.withVat.currencyString
-      };
-    }
-
-    function getOrderLineRow(order, orderLine) {
-      return angular.extend({
-        rowType: "OrderLine",
-        referenceId: order.referenceId,
-        uniqueId: order.uniqueId
-      }, getEmptyOrderLineExportData(), getOrderLineExportData(orderLine));
-    }
-
-    function getOrderLineExportRows(orders) {
-      return $q.all(orders.map(function (order) {
-        return resources.OrderInfo(order.uniqueId)
-          .then(function (result) {
-            var orderInfo = result.data || {};
-            var orderLines = orderInfo.orderLines || [];
-            var rows = [angular.extend({ rowType: "Order" }, order, getEmptyOrderLineExportData())];
-
-            orderLines.forEach(function (orderLine) {
-              rows.push(getOrderLineRow(order, orderLine));
-            });
-
-            return rows;
-          });
-      })).then(function (orderLineRows) {
-        return [].concat.apply([], orderLineRows);
-      });
-    }
-
-    function getExportOrders() {
-      if (!$scope.result.count) {
-        return $q.when([]);
-      }
-
-      return resources.SearchOrders(buildExportOrdersQuery())
-        .then(function (result) {
-          var data = result.data || {};
-
-          return data.orders || [];
-        });
-    }
-
     $scope.ExportCsv = function (filename, includeOrderLines) {
       if (!$scope.result.count) {
         return;
       }
 
+      var query = buildExportOrdersQuery();
+      query.includeOrderLines = !!includeOrderLines;
+
       $scope.exportOptions.exporting = true;
 
-      return getExportOrders()
-        .then(function (orders) {
-          if (!orders.length) {
-            return;
-          }
+      return resources.ExportOrders(query)
+        .then(function (result) {
+          var exportFilename = filename || (includeOrderLines ? "orders-with-orderlines.csv" : "orders.csv");
 
-          if (!includeOrderLines) {
-            return downloadCsv(Object.keys(orders[0]), orders, filename);
-          }
-
-          return getOrderLineExportRows(orders)
-            .then(function (rows) {
-              return downloadCsv(getOrderLineExportKeys(orders), rows, filename || "orders-with-orderlines.csv");
-            });
+          return downloadBlob(result.data, exportFilename);
         })
         .then(function () {
           $scope.CloseModal();

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Manager/resources/ekmManager.resources.js
@@ -54,6 +54,13 @@ angular.module("umbraco.resources").factory("Ekom.Manager.Resources", [
       SearchOrders: function (query) {
         return get(backofficeBaseUrl + "SearchOrders", query);
       },
+      ExportOrders: function (query) {
+        return $http({
+          method: "GET",
+          url: backofficeBaseUrl + "ExportOrders" + buildQueryString(query),
+          responseType: "blob"
+        });
+      },
       StatusList: function () {
         return get(backofficeBaseUrl + "StatusList");
       },


### PR DESCRIPTION
## Summary
- Add a manager backend CSV export endpoint for filtered orders.
- Generate order-line export rows server-side instead of calling `OrderInfo` once per order from the browser.
- Update the manager and sample manager frontend to download the returned CSV blob.

## Test Plan
- Ran `node --check` for the manager controller/resource files in both Web and Sample.
- Ran `dotnet build "Ekom/Ekom/Ekom.csproj"`.
- Ran `git diff --cached --check` before committing.