### PR TITLE
fix(import): preserve product category picker

### DIFF
--- a/Ekom/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.U10/Services/ImportService.cs
@@ -1086,22 +1086,25 @@ public class ImportService : IImportService
                 }
             }
 
-            if (importProduct.Categories.Count > 1 && allUmbracoCategories != null)
+            if (!importProduct.PreserveExistingValues || create)
             {
-                var categoryIdentifiers = new HashSet<string>(importProduct.Categories.Skip(1));
+                if (importProduct.Categories.Count > 1 && allUmbracoCategories != null)
+                {
+                    var categoryIdentifiers = new HashSet<string>(importProduct.Categories.Skip(1));
 
-                var umbracoCategories = allUmbracoCategories
-                    .Where(x => categoryIdentifiers.Contains(x.GetValue<string>(Configuration.ImportAliasIdentifier) ?? ""))
-                    .ToList();
+                    var umbracoCategories = allUmbracoCategories
+                        .Where(x => categoryIdentifiers.Contains(x.GetValue<string>(Configuration.ImportAliasIdentifier) ?? ""))
+                        .ToList();
 
-                var udis = umbracoCategories.Select(x => x.GetUdi());
+                    var udis = umbracoCategories.Select(x => x.GetUdi());
 
-                var stringUdis = string.Join(",", udis.Select(x => x.ToString()));
+                    var stringUdis = string.Join(",", udis.Select(x => x.ToString()));
 
-                productContent.SetValue("categories", stringUdis);
-            } else
-            {
-                productContent.SetValue("categories", "");
+                    productContent.SetValue("categories", stringUdis);
+                } else
+                {
+                    productContent.SetValue("categories", "");
+                }
             }
 
             if (importProduct.EnableBackorder)


### PR DESCRIPTION
## Summary
- Preserve the product `categories` picker when importing existing products with `PreserveExistingValues` enabled.
- Keep primary category selection and product move behavior unchanged.
- Continue setting imported extra categories for newly created products.

## Test Plan
- Built `Ekom/Ekom.U10/Ekom.U10.csproj` successfully.
- Confirm existing product imports with `PreserveExistingValues` do not clear or replace the extra Product Categories picker.
