### PR TITLE
fix(manager): handle order search and legacy discounts

### DIFF
--- a/Ekom/Ekom.Tests/Tests/ManagerRepositoryTests.cs
+++ b/Ekom/Ekom.Tests/Tests/ManagerRepositoryTests.cs
@@ -1,0 +1,73 @@
+using Ekom;
+using Ekom.Repositories;
+using Ekom.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Reflection;
+using Moq;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class ManagerRepositoryTests
+{
+    [Fact]
+    public void GenerateWhereClause_IncludesUniqueIdForFullGuidQuery()
+    {
+        var repository = CreateRepository();
+        string query = Guid.NewGuid().ToString();
+
+        string whereClause = GenerateWhereClause(repository, query);
+
+        Assert.Contains("UniqueId = @queryUniqueId", whereClause, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GenerateWhereClause_DoesNotIncludeUniqueIdForPartialGuidQuery()
+    {
+        var repository = CreateRepository();
+
+        string whereClause = GenerateWhereClause(repository, "abc123");
+
+        Assert.DoesNotContain("UniqueId = @queryUniqueId", whereClause, StringComparison.Ordinal);
+    }
+
+    private static string GenerateWhereClause(ManagerRepository repository, string query)
+    {
+        MethodInfo method = typeof(ManagerRepository).GetMethod(
+            "GenerateWhereClause",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        return (string)method.Invoke(repository, new object[]
+        {
+            string.Empty,
+            query,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+        })!;
+    }
+
+    private static ManagerRepository CreateRepository()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:umbracoDbDSN"] = "Data Source=:memory:",
+                ["ConnectionStrings:umbracoDbDSN_ProviderName"] = "Microsoft.Data.Sqlite",
+            })
+            .Build();
+
+        return new ManagerRepository(
+            NullLogger<ManagerRepository>.Instance,
+            new Configuration(configuration),
+            new DatabaseFactory(configuration),
+            Mock.Of<IStoreService>());
+    }
+}

--- a/Ekom/Ekom.Tests/Tests/OrderInfoTests.cs
+++ b/Ekom/Ekom.Tests/Tests/OrderInfoTests.cs
@@ -1,0 +1,75 @@
+using Ekom.Models;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class OrderInfoTests
+{
+    [Fact]
+    public void CreateOrderedDiscountFromJson_PreservesDecimalAmount()
+    {
+        JObject discountJson = CreateDiscountJson();
+
+        OrderedDiscount? discount = CreateOrderedDiscountFromJson(discountJson);
+
+        Assert.NotNull(discount);
+        Assert.Equal(10m, discount.Amount);
+    }
+
+    [Fact]
+    public void CreateOrderedDiscountFromJson_PreservesLegacyObjectAmountValue()
+    {
+        JObject discountJson = CreateDiscountJson();
+        discountJson[nameof(OrderedDiscount.Amount)] = new JObject
+        {
+            ["Value"] = 12.34m,
+        };
+
+        OrderedDiscount? discount = CreateOrderedDiscountFromJson(discountJson);
+
+        Assert.NotNull(discount);
+        Assert.Equal(12.34m, discount.Amount);
+    }
+
+    [Fact]
+    public void CreateOrderedDiscountFromJson_ReturnsNullForUnreadableObjectAmount()
+    {
+        JObject discountJson = CreateDiscountJson();
+        discountJson[nameof(OrderedDiscount.Amount)] = new JObject
+        {
+            ["Currency"] = "ISK",
+        };
+
+        OrderedDiscount? discount = CreateOrderedDiscountFromJson(discountJson);
+
+        Assert.Null(discount);
+    }
+
+    private static OrderedDiscount? CreateOrderedDiscountFromJson(JToken discountJson)
+    {
+        MethodInfo method = typeof(OrderInfo).GetMethod(
+            "CreateOrderedDiscountFromJson",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return (OrderedDiscount?)method.Invoke(null, new object[] { discountJson });
+    }
+
+    private static JObject CreateDiscountJson()
+    {
+        return new JObject
+        {
+            [nameof(OrderedDiscount.Key)] = Guid.NewGuid(),
+            [nameof(OrderedDiscount.Title)] = "Test discount",
+            [nameof(OrderedDiscount.Stackable)] = true,
+            [nameof(OrderedDiscount.Amount)] = 10m,
+            [nameof(OrderedDiscount.Type)] = DiscountType.Fixed.ToString(),
+            [nameof(OrderedDiscount.DiscountItems)] = new JArray(),
+            [nameof(OrderedDiscount.ExcludeDiscountItems)] = new JArray(),
+            [nameof(OrderedDiscount.Constraints)] = null,
+            [nameof(OrderedDiscount.HasMasterStock)] = false,
+            [nameof(OrderedDiscount.GlobalDiscount)] = false,
+        };
+    }
+}

--- a/Ekom/Ekom/Models/OrderInfo.cs
+++ b/Ekom/Ekom/Models/OrderInfo.cs
@@ -1,5 +1,6 @@
 using Ekom.Services;
 using Ekom.Utilities;
+using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -376,7 +377,7 @@ public class OrderInfo : IOrderInfo
             var quantity = (decimal)line[nameof(OrderLine.Quantity)];
             OrderLineSettings? settings = line[nameof(OrderLine.Settings)]?.ToObject<OrderLineSettings>();
             string productJson = line[nameof(OrderLine.Product)].ToString();
-            OrderedDiscount? discount = line[nameof(OrderLine.Discount)]?.ToObject<OrderedDiscount>();
+            OrderedDiscount? discount = CreateOrderedDiscountFromJson(line[nameof(OrderLine.Discount)]);
             OrderLineInfo? orderLineInfo = line[nameof(OrderLine.OrderLineInfo)]?.ToObject<OrderLineInfo>();
             OrderLine orderLine = new OrderLine(
                 lineId,
@@ -391,6 +392,67 @@ public class OrderInfo : IOrderInfo
         }
 
         return orderLines;
+    }
+
+    private static OrderedDiscount? CreateOrderedDiscountFromJson(JToken? discountToken)
+    {
+        if (discountToken == null || discountToken.Type == JTokenType.Null)
+        {
+            return null;
+        }
+
+        JToken? amountToken = discountToken.Type == JTokenType.Object
+            ? discountToken[nameof(OrderedDiscount.Amount)]
+            : null;
+        if (amountToken?.Type == JTokenType.Object
+            && TryGetDecimalAmount(amountToken, out decimal amount))
+        {
+            JObject discountObject = (JObject)discountToken.DeepClone();
+            discountObject[nameof(OrderedDiscount.Amount)] = amount;
+
+            discountToken = discountObject;
+        }
+
+        try
+        {
+            return discountToken.ToObject<OrderedDiscount>();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryGetDecimalAmount(JToken amountToken, out decimal amount)
+    {
+        foreach (string propertyName in new[] { "Value", "Amount", "value", "amount" })
+        {
+            if (TryReadDecimal(amountToken[propertyName], out amount))
+            {
+                return true;
+            }
+        }
+
+        amount = 0;
+        return false;
+    }
+
+    private static bool TryReadDecimal(JToken? token, out decimal amount)
+    {
+        if (token?.Type == JTokenType.Integer || token?.Type == JTokenType.Float)
+        {
+            amount = token.Value<decimal>();
+            return true;
+        }
+
+        if (token?.Type == JTokenType.String
+            && decimal.TryParse(token.Value<string>(), NumberStyles.Number, CultureInfo.InvariantCulture, out amount))
+        {
+            return true;
+        }
+
+        amount = 0;
+        return false;
     }
 
     private OrderedShippingProvider? CreateShippingProviderFromJson(JObject orderInfoJObject)

--- a/Ekom/Ekom/Repositories/ManagerRepository.cs
+++ b/Ekom/Ekom/Repositories/ManagerRepository.cs
@@ -97,11 +97,16 @@ public class ManagerRepository
             paymentProviderValue = parsedPaymentProvider.ToString();
         }
 
+        Guid? queryUniqueId = Guid.TryParse(query?.Trim(), out Guid parsedQueryUniqueId)
+            ? parsedQueryUniqueId
+            : null;
+
         var param = new
         {
             startDate = start.Date,
             endDate = end.Date.AddDays(1).AddTicks(-1),
             query = "%" + query + "%",
+            queryUniqueId,
             orderStatus,
             store,
             paymentProvider = paymentProviderValue,
@@ -148,11 +153,16 @@ public class ManagerRepository
             paymentProviderValue = parsedPaymentProvider.ToString();
         }
 
+        Guid? queryUniqueId = Guid.TryParse(query?.Trim(), out Guid parsedQueryUniqueId)
+            ? parsedQueryUniqueId
+            : null;
+
         var param = new
         {
             startDate = start.Date,
             endDate = end.Date.AddDays(1).AddTicks(-1),
             query = "%" + query + "%",
+            queryUniqueId,
             orderStatus,
             store,
             paymentProvider = paymentProviderValue,
@@ -217,7 +227,14 @@ ORDER BY {bucketDateExpression}";
 
         if (!string.IsNullOrEmpty(query))
         {
-            whereClause.Append(" AND (CustomerName LIKE @query OR ReferenceId LIKE @query OR OrderNumber LIKE @query OR CustomerEmail LIKE @query OR CustomerId LIKE @query OR CustomerUsername LIKE @query)");
+            whereClause.Append(" AND (CustomerName LIKE @query OR ReferenceId LIKE @query OR OrderNumber LIKE @query OR CustomerEmail LIKE @query OR CustomerId LIKE @query OR CustomerUsername LIKE @query");
+
+            if (Guid.TryParse(query.Trim(), out _))
+            {
+                whereClause.Append(" OR UniqueId = @queryUniqueId");
+            }
+
+            whereClause.Append(")");
         }
 
         if (!string.IsNullOrEmpty(paymentProvider) && Guid.TryParse(paymentProvider, out _))


### PR DESCRIPTION
## Summary
- Preserve legacy order line discounts when `Discount.Amount` was stored as a JSON object with a numeric amount value.
- Gracefully skip only unreadable malformed line discounts so manager exports can continue.
- Support manager order search and export filtering by full order `UniqueId` values, without partial GUID matching.
- Add focused tests for legacy discount parsing and full UniqueId search behavior.

## Test Plan
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~OrderInfoTests|FullyQualifiedName~ManagerRepositoryTests"`
- `git diff --check`
