### PR TITLE
fix(product): use variants for availability

### DIFF
--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -96,7 +96,29 @@ public class Product : PerStoreNodeEntity, IProduct
     /// <summary>
     /// Get the availability of the product and the variants
     /// </summary>
-    public virtual bool Available => Stock > 0 || Backorder || AllVariants.Any(x => x.Available);
+    public virtual bool Available
+    {
+        get
+        {
+            if (Backorder)
+            {
+                return true;
+            }
+
+            bool hasVariants = false;
+            foreach (IVariant variant in AllVariants)
+            {
+                hasVariants = true;
+
+                if (variant.Available)
+                {
+                    return true;
+                }
+            }
+
+            return !hasVariants && Stock > 0;
+        }
+    }
 
     private string _backorderValue = "";
     /// <summary>


### PR DESCRIPTION
## Summary
- Update product availability so variant products use variant availability instead of product stock.
- Keep product-level backorder behavior unchanged.
- Preserve stock-based availability for products without variants.
- Short-circuit variant checks on the first available variant.

## Test Plan
- `dotnet build "Ekom/Ekom/Ekom.csproj" --no-restore`
- `git diff --check`
