### PR TITLE
fix(order): deserialize top-level discount amounts

### DIFF
--- a/Ekom/Ekom.Tests/Tests/OrderInfoTests.cs
+++ b/Ekom/Ekom.Tests/Tests/OrderInfoTests.cs
@@ -8,6 +8,30 @@ namespace Ekom.Tests.Tests;
 public class OrderInfoTests
 {
     [Fact]
+    public void Constructor_PreservesLegacyTopLevelDiscountObjectAmountValue()
+    {
+        JObject orderInfoJson = new JObject
+        {
+            [nameof(OrderInfo.Culture)] = "en-US",
+            [nameof(OrderInfo.OrderLines)] = new JArray(),
+            [nameof(OrderInfo.Discount)] = CreateDiscountJson(),
+        };
+        ((JObject)orderInfoJson[nameof(OrderInfo.Discount)]!)[nameof(OrderedDiscount.Amount)] = new JObject
+        {
+            ["Value"] = 12.34m,
+        };
+        var orderData = new OrderData
+        {
+            OrderInfo = orderInfoJson.ToString(),
+        };
+
+        var orderInfo = new OrderInfo(orderData);
+
+        Assert.NotNull(orderInfo.Discount);
+        Assert.Equal(12.34m, orderInfo.Discount.Amount);
+    }
+
+    [Fact]
     public void CreateOrderedDiscountFromJson_PreservesDecimalAmount()
     {
         JObject discountJson = CreateDiscountJson();

--- a/Ekom/Ekom/Models/OrderInfo.cs
+++ b/Ekom/Ekom/Models/OrderInfo.cs
@@ -45,7 +45,7 @@ public class OrderInfo : IOrderInfo
             CustomerInformation = CreateCustomerInformationFromJson(orderInfoJObject);
             Consent = CreateConsentFromJson(orderInfoJObject);
             Tracking = CreateTrackingFromJson(orderInfoJObject);
-            Discount = orderInfoJObject[nameof(Discount)]?.ToObject<OrderedDiscount>();
+            Discount = CreateOrderedDiscountFromJson(orderInfoJObject[nameof(Discount)]);
             Coupon = orderInfoJObject[nameof(Coupon)]?.ToObject<string>();
             _hangfireJobs = orderInfoJObject[nameof(HangfireJobs)]?.ToObject<List<string>>();
         }


### PR DESCRIPTION
## Summary
- Use the existing safe ordered discount parser for top-level order discounts.
- Preserve legacy object-shaped `Discount.Amount` values during order loading and export.
- Add a regression test for top-level legacy discount amount deserialization.

## Test Plan
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~OrderInfoTests"`
- `git diff --check`
