### PR TITLE
feat(checkout): add payment order items event

### DIFF
--- a/Ekom/Ekom/Events/CheckoutEvents.cs
+++ b/Ekom/Ekom/Events/CheckoutEvents.cs
@@ -1,6 +1,7 @@
 using Ekom.Models;
 using Ekom.Payments;
 using Ekom.Utilities;
+using System.Collections.ObjectModel;
 
 namespace Ekom.Events;
 
@@ -16,6 +17,9 @@ public static class CheckoutEvents
     public static event EventHandler<CompleteCheckoutEventArgs>? CompleteCheckout;
     internal static void OnCompleteCheckout(object sender, CompleteCheckoutEventArgs args) => CompleteCheckout?.Invoke(sender, args);
 
+    public static event EventHandler<PaymentOrderItemsPreparingEventArgs>? PaymentOrderItemsPreparing;
+    internal static void OnPaymentOrderItemsPreparing(object sender, PaymentOrderItemsPreparingEventArgs args) => PaymentOrderItemsPreparing?.Invoke(sender, args);
+
     // Async events (cancellable)
     public static event Func<object, PayEventArgs, CancellationToken, Task>? PayAsync;
     public static Task OnPayAsync(object sender, PayEventArgs args, CancellationToken ct = default)
@@ -28,6 +32,10 @@ public static class CheckoutEvents
     public static event Func<object, CompleteCheckoutEventArgs, CancellationToken, Task>? CompleteCheckoutAsync;
     internal static Task OnCompleteCheckoutAsync(object sender, CompleteCheckoutEventArgs args, CancellationToken ct = default)
         => AsyncEventInvoker.InvokeAsync(CompleteCheckoutAsync, sender, args, ct);
+
+    public static event Func<object, PaymentOrderItemsPreparingEventArgs, CancellationToken, Task>? PaymentOrderItemsPreparingAsync;
+    public static Task OnPaymentOrderItemsPreparingAsync(object sender, PaymentOrderItemsPreparingEventArgs args, CancellationToken ct = default)
+        => AsyncEventInvoker.InvokeAsync(PaymentOrderItemsPreparingAsync, sender, args, ct);
 }
 
 
@@ -43,6 +51,13 @@ public class ProcessingEventArgs : EventArgs
 {
     public IOrderInfo OrderInfo { get; set; }
     public bool StockValidation { get; set; } = true;
+}
+
+public class PaymentOrderItemsPreparingEventArgs : EventArgs
+{
+    public required IOrderInfo OrderInfo { get; set; }
+    public required PaymentRequest PaymentRequest { get; set; }
+    public required Collection<OrderItem> OrderItems { get; set; }
 }
 
 public class CompleteCheckoutEventArgs : EventArgs

--- a/Ekom/Ekom/Services/CheckoutControllerService.cs
+++ b/Ekom/Ekom/Services/CheckoutControllerService.cs
@@ -580,6 +580,17 @@ public class CheckoutControllerService
             }
         };
 
+        var orderItemsPreparingEventArgs = new PaymentOrderItemsPreparingEventArgs
+        {
+            OrderInfo = order,
+            PaymentRequest = paymentRequest,
+            OrderItems = new System.Collections.ObjectModel.Collection<OrderItem>(orderItems),
+        };
+
+        CheckoutEvents.OnPaymentOrderItemsPreparing(this, orderItemsPreparingEventArgs);
+        await CheckoutEvents.OnPaymentOrderItemsPreparingAsync(this, orderItemsPreparingEventArgs, ct);
+        orderItems = orderItemsPreparingEventArgs.OrderItems.ToList();
+
         Logger.LogInformation(
             "Payment Provider: {PaymentProvider}, {Name} offline: {isOfflinePayment}",
             order.PaymentProvider.Key,


### PR DESCRIPTION
## Summary
- add a checkout event for customizing payment order items before payment processing
- include both sync and async event hooks following existing checkout event patterns
- fire the event immediately after default payment order items are created, before offline/online payment handling

## Test Plan
- git diff --check
- dotnet build \"Ekom/Ekom/Ekom.csproj\" --no-restore