### PR TITLE
fix(checkout): add VAT to payment order item

### DIFF
--- a/Ekom/Ekom/Services/CheckoutControllerService.cs
+++ b/Ekom/Ekom/Services/CheckoutControllerService.cs
@@ -575,6 +575,7 @@ public class CheckoutControllerService
             {
                 GrandTotal = amount,
                 Price = amount,
+                VAT = order.Vat.Value,
                 Title = orderTitle,
                 Quantity = 1,
             }


### PR DESCRIPTION
## Summary
- Include the order VAT value on the payment `OrderItem` created during checkout.
- Keeps the payment order item amount fields aligned with the order totals passed to payment providers.

## Test Plan
- Not run; one-field checkout payment order item mapping change only.
