### PR TITLE
fix(stock): use configured stock buffer fallback

### DIFF
--- a/Ekom/Ekom.U10/EnsureNodesExist.cs
+++ b/Ekom/Ekom.U10/EnsureNodesExist.cs
@@ -600,17 +600,23 @@ class EnsureNodesExist : IComponent
                                         Name = "Stock",
                                         SortOrder = 5
                                     },
+                                    new PropertyType(_shortStringHelper, propertyNumericDt, "ekmStockBuffer")
+                                    {
+                                        Name = "Stock Buffer",
+                                        Description = "Reduces the available stock by this amount",
+                                        SortOrder = 6
+                                    },
                                     new PropertyType(_shortStringHelper, booleanDt, "enableBackorder")
                                     {
                                         Name = "Enable Backorder",
                                         Description = "If set then the variant can be sold indefinitely",
-                                        SortOrder = 6
+                                        SortOrder = 7
                                     },
                                     new PropertyType(_shortStringHelper, decimalDt, "vat")
                                     {
                                         Name = "VAT",
                                         Description = "%, override store VAT.",
-                                        SortOrder = 7
+                                        SortOrder = 8
                                     },
                                 }))
                             {

--- a/Ekom/Ekom/Models/IVariant.cs
+++ b/Ekom/Ekom/Models/IVariant.cs
@@ -27,7 +27,7 @@ public interface IVariant : IPerStoreNodeEntity
     /// Gets the Vat.
     /// </summary>
     /// <value>
-    /// The stock.
+    /// The vat.
     /// </value>
     decimal Vat { get; }
 
@@ -81,6 +81,15 @@ public interface IVariant : IPerStoreNodeEntity
     /// The stock.
     /// </value>
     decimal Stock { get; }
+    
+    /// <summary>
+    /// Sets the stock buffer for the product
+    /// </summary>
+    /// <returns></returns>
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Xml.Serialization.XmlIgnore]
+    decimal? StockBuffer { get; }
 
     /// <summary>
     /// 

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -91,7 +91,7 @@ public class Product : PerStoreNodeEntity, IProduct
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public virtual decimal? StockBuffer { get; set; }
+    public decimal? StockBuffer { get; set; }
 
     /// <summary>
     /// Get the availability of the product and the variants

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -33,6 +33,14 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     public virtual decimal Stock => API.Stock.Instance.GetStock(Key, Store.Alias);
 
     /// <summary>
+    /// Get the current product Stock
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [XmlIgnore]
+    public decimal? StockBuffer { get; set; }
+    
+    /// <summary>
     /// Get the backorder status
     /// </summary>
     public virtual bool Backorder
@@ -322,6 +330,11 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
         OriginalPrice = CreateOriginalPrice();
 
         SKU = string.IsNullOrEmpty(GetValue("sku")) ? Product?.SKU ?? "" : GetValue("sku");
+        
+        if (decimal.TryParse(GetValue("ekmStockBuffer", store.Alias), out var stockBuffer))
+        {
+            StockBuffer = stockBuffer;
+        }
     }
 
     private IPrice CreateOriginalPrice()

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -1995,8 +1995,11 @@ partial class OrderService
     private void VerifyStock(decimal quantity, decimal existingStock, IProduct product, IVariant? variant = null)
     {
         var bufferStock =
-            product.StockBuffer
-            ?? product.CategoryAncestors?.FirstOrDefault(c => c.StockBuffer.HasValue)?.StockBuffer
+            GetConfiguredStockBuffer(variant?.StockBuffer)
+            ?? GetConfiguredStockBuffer(product.StockBuffer)
+            ?? product.CategoryAncestors?
+                .Select(c => GetConfiguredStockBuffer(c.StockBuffer))
+                .FirstOrDefault(x => x.HasValue)
             ?? 0;
 
         existingStock -= bufferStock;
@@ -2010,6 +2013,11 @@ partial class OrderService
             throw new NotEnoughStockException(
                 $"Stock not available for product {product.Key} and variant {variant?.Key}. ExistingStock: {existingStock}. Quantity: {quantity} BufferStock: {bufferStock}");
         }
+    }
+
+    private static decimal? GetConfiguredStockBuffer(decimal? stockBuffer)
+    {
+        return stockBuffer > 0 ? stockBuffer : null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add stock buffer support for variants.
- Resolve stock buffer from the lowest configured level first: variant, then product, then category ancestor.
- Treat zero as not configured so fallback continues to higher levels.

## Test Plan
- `dotnet build "Ekom/Ekom/Ekom.csproj"`
