### PR TITLE
fix(stock): resolve buffer values dynamically

### DIFF
--- a/Ekom/Ekom.AspNetCore/packages.lock.json
+++ b/Ekom/Ekom.AspNetCore/packages.lock.json
@@ -29,8 +29,8 @@
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "QqUBQGl9ft3qIP6liJMXJbt18ZTvYBBn89FRPgOsDF2aWJUT2KKym8i7IQK87xneTA/5KSzl34h9vXZeZAGu+A==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -451,8 +451,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.166, )",
-          "Ekom.Payments.Core": "[0.2.73, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",

--- a/Ekom/Ekom.U10/Ekom.U10.csproj
+++ b/Ekom/Ekom.U10/Ekom.U10.csproj
@@ -50,7 +50,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Ekom.Payments.U10" Version="0.2.73" />
+        <PackageReference Include="Ekom.Payments.U10" Version="0.2.74" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Umbraco.Cms.Api.Common" Version="13.13.0" />
         <PackageReference Include="Umbraco.Cms.Core" Version="13.13.0" />

--- a/Ekom/Ekom.U10/EnsureNodesExist.cs
+++ b/Ekom/Ekom.U10/EnsureNodesExist.cs
@@ -600,17 +600,23 @@ class EnsureNodesExist : IComponent
                                         Name = "Stock",
                                         SortOrder = 5
                                     },
+                                    new PropertyType(_shortStringHelper, propertyNumericDt, "ekmStockBuffer")
+                                    {
+                                        Name = "Stock Buffer",
+                                        Description = "Reduces the available stock by this amount",
+                                        SortOrder = 6
+                                    },
                                     new PropertyType(_shortStringHelper, booleanDt, "enableBackorder")
                                     {
                                         Name = "Enable Backorder",
                                         Description = "If set then the variant can be sold indefinitely",
-                                        SortOrder = 6
+                                        SortOrder = 7
                                     },
                                     new PropertyType(_shortStringHelper, decimalDt, "vat")
                                     {
                                         Name = "VAT",
                                         Description = "%, override store VAT.",
-                                        SortOrder = 7
+                                        SortOrder = 8
                                     },
                                 }))
                             {

--- a/Ekom/Ekom.U10/packages.lock.json
+++ b/Ekom/Ekom.U10/packages.lock.json
@@ -4,11 +4,11 @@
     "net8.0": {
       "Ekom.Payments.U10": {
         "type": "Direct",
-        "requested": "[0.2.73, )",
-        "resolved": "0.2.73",
-        "contentHash": "WRfyMUicAm5AJzYNwLjyWqpUQJvhI2/9XpahnejyvY+5VBjQNLwc2aSsbIhzqshrJKWpSOFcH4WTzOKz2bC9ZQ==",
+        "requested": "[0.2.74, )",
+        "resolved": "0.2.74",
+        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.73",
+          "Ekom.Payments.AspNetCore": "0.2.74",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -159,16 +159,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "4WoxqLpMhWMDGh36ljQM8GwHlUbSgvSDwBhbFiBMPvXjvVMhKR7ljDWf6dyDQNfZ7+5b/O0VzLmgWoQEs7xgVQ==",
+        "resolved": "0.2.74",
+        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.73"
+          "Ekom.Payments.Core": "0.2.74"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "QqUBQGl9ft3qIP6liJMXJbt18ZTvYBBn89FRPgOsDF2aWJUT2KKym8i7IQK87xneTA/5KSzl34h9vXZeZAGu+A==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -2899,7 +2899,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.166, )"
+          "Ekom.Core": "[0.2.170, )"
         }
       },
       "ekom.common": {
@@ -2914,8 +2914,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.166, )",
-          "Ekom.Payments.Core": "[0.2.73, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",

--- a/Ekom/Ekom.Web/packages.lock.json
+++ b/Ekom/Ekom.Web/packages.lock.json
@@ -29,8 +29,8 @@
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "QqUBQGl9ft3qIP6liJMXJbt18ZTvYBBn89FRPgOsDF2aWJUT2KKym8i7IQK87xneTA/5KSzl34h9vXZeZAGu+A==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -435,8 +435,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.166, )",
-          "Ekom.Payments.Core": "[0.2.73, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",

--- a/Ekom/Ekom/Ekom.csproj
+++ b/Ekom/Ekom/Ekom.csproj
@@ -80,7 +80,7 @@
     <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.17.1" />
         <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-        <PackageReference Include="Ekom.Payments.Core" Version="0.2.73" />
+        <PackageReference Include="Ekom.Payments.Core" Version="0.2.74" />
         <PackageReference Include="Hangfire" Version="1.8.18" />
         <PackageReference Include="linq2db" Version="5.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />

--- a/Ekom/Ekom/Models/Category.cs
+++ b/Ekom/Ekom/Models/Category.cs
@@ -192,7 +192,22 @@ public class Category : PerStoreNodeEntity, ICategory
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public decimal? StockBuffer { get; set; }
+    public decimal? StockBuffer {
+        get
+        {
+            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), out var stockBuffer))
+            {
+                if (stockBuffer <= 0)
+                {
+                    return null;
+                }
+                
+                return stockBuffer;
+            }
+
+            return null;
+        }
+    }
 
 
     /// <summary>
@@ -218,11 +233,6 @@ public class Category : PerStoreNodeEntity, ICategory
         Urls = urls.Select(x => x.Url);
 
         VirtualUrl = GetValue("ekmVirtualUrl").IsBoolean();
-
-        if (decimal.TryParse(GetValue("ekmStockBuffer", store.Alias), out var stockBuffer))
-        {
-            StockBuffer = stockBuffer;
-        }
 
         var ancestorCategories = new List<ICategory>();
 

--- a/Ekom/Ekom/Models/Category.cs
+++ b/Ekom/Ekom/Models/Category.cs
@@ -188,7 +188,10 @@ public class Category : PerStoreNodeEntity, ICategory
         var products = await ProductsRecursiveAsync(ct: ct);
         return products.Products.Filters();
     }
-
+    
+    /// <summary>
+    /// Get the current category Stock Buffer
+    /// </summary>
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]

--- a/Ekom/Ekom/Models/Category.cs
+++ b/Ekom/Ekom/Models/Category.cs
@@ -198,7 +198,7 @@ public class Category : PerStoreNodeEntity, ICategory
     public decimal? StockBuffer {
         get
         {
-            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), out var stockBuffer))
+            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out var stockBuffer))
             {
                 if (stockBuffer <= 0)
                 {

--- a/Ekom/Ekom/Models/IVariant.cs
+++ b/Ekom/Ekom/Models/IVariant.cs
@@ -83,9 +83,8 @@ public interface IVariant : IPerStoreNodeEntity
     decimal Stock { get; }
     
     /// <summary>
-    /// Sets the stock buffer for the product
+    /// Gets the configured stock buffer for the variant.
     /// </summary>
-    /// <returns></returns>
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [System.Xml.Serialization.XmlIgnore]

--- a/Ekom/Ekom/Models/IVariant.cs
+++ b/Ekom/Ekom/Models/IVariant.cs
@@ -27,7 +27,7 @@ public interface IVariant : IPerStoreNodeEntity
     /// Gets the Vat.
     /// </summary>
     /// <value>
-    /// The stock.
+    /// The vat.
     /// </value>
     decimal Vat { get; }
 
@@ -81,6 +81,15 @@ public interface IVariant : IPerStoreNodeEntity
     /// The stock.
     /// </value>
     decimal Stock { get; }
+    
+    /// <summary>
+    /// Sets the stock buffer for the product
+    /// </summary>
+    /// <returns></returns>
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Xml.Serialization.XmlIgnore]
+    decimal? StockBuffer { get; }
 
     /// <summary>
     /// 

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -91,7 +91,7 @@ public class Product : PerStoreNodeEntity, IProduct
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public virtual decimal? StockBuffer { get; set; }
+    public decimal? StockBuffer { get; set; }
 
     /// <summary>
     /// Get the availability of the product and the variants

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -86,7 +86,7 @@ public class Product : PerStoreNodeEntity, IProduct
     public virtual decimal Stock => API.Stock.Instance.GetStock(Key, Store.Alias);
 
     /// <summary>
-    /// Get the current product Stock
+    /// Get the current product Stock Buffer
     /// </summary>
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -91,7 +91,22 @@ public class Product : PerStoreNodeEntity, IProduct
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public decimal? StockBuffer { get; set; }
+    public decimal? StockBuffer {
+        get
+        {
+            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), out var stockBuffer))
+            {
+                if (stockBuffer <= 0)
+                {
+                    return null;
+                }
+                
+                return stockBuffer;
+            }
+
+            return null;
+        }
+    }
 
     /// <summary>
     /// Get the availability of the product and the variants
@@ -556,11 +571,6 @@ public class Product : PerStoreNodeEntity, IProduct
 
         OriginalPrice = CreateOriginalPrice();
         SKU = GetValue("sku");
-
-        if (decimal.TryParse(GetValue("ekmStockBuffer", store.Alias), out var stockBuffer))
-        {
-            StockBuffer = stockBuffer;
-        }
     }
 
     public void InvalidateCache()

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -94,7 +94,7 @@ public class Product : PerStoreNodeEntity, IProduct
     public decimal? StockBuffer {
         get
         {
-            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), out var stockBuffer))
+            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out var stockBuffer))
             {
                 if (stockBuffer <= 0)
                 {

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -33,6 +33,14 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     public virtual decimal Stock => API.Stock.Instance.GetStock(Key, Store.Alias);
 
     /// <summary>
+    /// Get the current product Stock
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [XmlIgnore]
+    public decimal? StockBuffer { get; set; }
+    
+    /// <summary>
     /// Get the backorder status
     /// </summary>
     public virtual bool Backorder
@@ -322,6 +330,11 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
         OriginalPrice = CreateOriginalPrice();
 
         SKU = string.IsNullOrEmpty(GetValue("sku")) ? Product?.SKU ?? "" : GetValue("sku");
+        
+        if (decimal.TryParse(GetValue("ekmStockBuffer", store.Alias), out var stockBuffer))
+        {
+            StockBuffer = stockBuffer;
+        }
     }
 
     private IPrice CreateOriginalPrice()

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -41,7 +41,7 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     public decimal? StockBuffer {
         get
         {
-            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), out var stockBuffer))
+            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out var stockBuffer))
             {
                 if (stockBuffer <= 0)
                 {

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -38,7 +38,22 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]
     [XmlIgnore]
-    public decimal? StockBuffer { get; set; }
+    public decimal? StockBuffer {
+        get
+        {
+            if (decimal.TryParse(GetValue("ekmStockBuffer", Store.Alias), out var stockBuffer))
+            {
+                if (stockBuffer <= 0)
+                {
+                    return null;
+                }
+                
+                return stockBuffer;
+            }
+
+            return null;
+        }
+    }
     
     /// <summary>
     /// Get the backorder status
@@ -330,11 +345,6 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
         OriginalPrice = CreateOriginalPrice();
 
         SKU = string.IsNullOrEmpty(GetValue("sku")) ? Product?.SKU ?? "" : GetValue("sku");
-        
-        if (decimal.TryParse(GetValue("ekmStockBuffer", store.Alias), out var stockBuffer))
-        {
-            StockBuffer = stockBuffer;
-        }
     }
 
     private IPrice CreateOriginalPrice()

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -33,7 +33,7 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     public virtual decimal Stock => API.Stock.Instance.GetStock(Key, Store.Alias);
 
     /// <summary>
-    /// Get the current product Stock
+    /// Get the current variant Stock Buffer
     /// </summary>
     [System.Text.Json.Serialization.JsonIgnore]
     [Newtonsoft.Json.JsonIgnore]

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -1995,8 +1995,11 @@ partial class OrderService
     private void VerifyStock(decimal quantity, decimal existingStock, IProduct product, IVariant? variant = null)
     {
         var bufferStock =
-            product.StockBuffer
-            ?? product.CategoryAncestors?.FirstOrDefault(c => c.StockBuffer.HasValue)?.StockBuffer
+            GetConfiguredStockBuffer(variant?.StockBuffer)
+            ?? GetConfiguredStockBuffer(product.StockBuffer)
+            ?? product.CategoryAncestors?
+                .Select(c => GetConfiguredStockBuffer(c.StockBuffer))
+                .FirstOrDefault(x => x.HasValue)
             ?? 0;
 
         existingStock -= bufferStock;
@@ -2010,6 +2013,11 @@ partial class OrderService
             throw new NotEnoughStockException(
                 $"Stock not available for product {product.Key} and variant {variant?.Key}. ExistingStock: {existingStock}. Quantity: {quantity} BufferStock: {bufferStock}");
         }
+    }
+
+    private static decimal? GetConfiguredStockBuffer(decimal? stockBuffer)
+    {
+        return stockBuffer > 0 ? stockBuffer : null;
     }
 
     /// <summary>

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -2017,7 +2017,7 @@ partial class OrderService
 
     private static decimal? GetConfiguredStockBuffer(decimal? stockBuffer)
     {
-        return stockBuffer > 0 ? stockBuffer : null;
+        return stockBuffer is > 0 ? stockBuffer : null;
     }
 
     /// <summary>

--- a/Ekom/Ekom/packages.lock.json
+++ b/Ekom/Ekom/packages.lock.json
@@ -21,9 +21,9 @@
       },
       "Ekom.Payments.Core": {
         "type": "Direct",
-        "requested": "[0.2.73, )",
-        "resolved": "0.2.73",
-        "contentHash": "QqUBQGl9ft3qIP6liJMXJbt18ZTvYBBn89FRPgOsDF2aWJUT2KKym8i7IQK87xneTA/5KSzl34h9vXZeZAGu+A==",
+        "requested": "[0.2.74, )",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -170,16 +170,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "4WoxqLpMhWMDGh36ljQM8GwHlUbSgvSDwBhbFiBMPvXjvVMhKR7ljDWf6dyDQNfZ7+5b/O0VzLmgWoQEs7xgVQ==",
+        "resolved": "0.2.74",
+        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.73"
+          "Ekom.Payments.Core": "0.2.74"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "QqUBQGl9ft3qIP6liJMXJbt18ZTvYBBn89FRPgOsDF2aWJUT2KKym8i7IQK87xneTA/5KSzl34h9vXZeZAGu+A==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -190,10 +190,10 @@
       },
       "Ekom.Payments.U10": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "WRfyMUicAm5AJzYNwLjyWqpUQJvhI2/9XpahnejyvY+5VBjQNLwc2aSsbIhzqshrJKWpSOFcH4WTzOKz2bC9ZQ==",
+        "resolved": "0.2.74",
+        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.73",
+          "Ekom.Payments.AspNetCore": "0.2.74",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -3008,7 +3008,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.166, )"
+          "Ekom.Core": "[0.2.170, )"
         }
       },
       "ekom.common": {
@@ -3023,8 +3023,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.166, )",
-          "Ekom.Payments.Core": "[0.2.73, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
@@ -3039,8 +3039,8 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.166, )",
-          "Ekom.Payments.U10": "[0.2.73, )",
+          "Ekom.AspNetCore": "[0.2.170, )",
+          "Ekom.Payments.U10": "[0.2.74, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",
           "Umbraco.Cms.Web.BackOffice": "[13.13.0, )",

--- a/Plugins/Ekom.Klaviyo/packages.lock.json
+++ b/Plugins/Ekom.Klaviyo/packages.lock.json
@@ -122,16 +122,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "4WoxqLpMhWMDGh36ljQM8GwHlUbSgvSDwBhbFiBMPvXjvVMhKR7ljDWf6dyDQNfZ7+5b/O0VzLmgWoQEs7xgVQ==",
+        "resolved": "0.2.74",
+        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.73"
+          "Ekom.Payments.Core": "0.2.74"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "QqUBQGl9ft3qIP6liJMXJbt18ZTvYBBn89FRPgOsDF2aWJUT2KKym8i7IQK87xneTA/5KSzl34h9vXZeZAGu+A==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -142,10 +142,10 @@
       },
       "Ekom.Payments.U10": {
         "type": "Transitive",
-        "resolved": "0.2.73",
-        "contentHash": "WRfyMUicAm5AJzYNwLjyWqpUQJvhI2/9XpahnejyvY+5VBjQNLwc2aSsbIhzqshrJKWpSOFcH4WTzOKz2bC9ZQ==",
+        "resolved": "0.2.74",
+        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.73",
+          "Ekom.Payments.AspNetCore": "0.2.74",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -2878,7 +2878,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.166, )"
+          "Ekom.Core": "[0.2.170, )"
         }
       },
       "ekom.common": {
@@ -2893,8 +2893,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.166, )",
-          "Ekom.Payments.Core": "[0.2.73, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
@@ -2909,8 +2909,8 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.166, )",
-          "Ekom.Payments.U10": "[0.2.73, )",
+          "Ekom.AspNetCore": "[0.2.170, )",
+          "Ekom.Payments.U10": "[0.2.74, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",
           "Umbraco.Cms.Web.BackOffice": "[13.13.0, )",

--- a/Samples/U10/Ekom.Site/Ekom.Site.csproj
+++ b/Samples/U10/Ekom.Site/Ekom.Site.csproj
@@ -67,9 +67,9 @@
     <ItemGroup>
         <!--<PackageReference Update="Ekom.U10" ExcludeAssets="all" />-->
         <PackageReference Include="Azure.Identity" Version="1.17.1" />
-        <PackageReference Include="Ekom.Payments.Borgun" Version="0.2.73" />
-        <PackageReference Include="Ekom.Payments.Netgiro" Version="0.2.73" />
-        <PackageReference Include="Ekom.Payments.Valitor" Version="0.2.73" />
+        <PackageReference Include="Ekom.Payments.Borgun" Version="0.2.74" />
+        <PackageReference Include="Ekom.Payments.Netgiro" Version="0.2.74" />
+        <PackageReference Include="Ekom.Payments.Valitor" Version="0.2.74" />
         <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
         <PackageReference Include="Umbraco.Cms" Version="13.13.0" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- Resolve stock buffer values dynamically from category, product, and variant properties.
- Keep stock buffer fallback using configured values only.
- Update payment package references and lock files to 0.2.74.

## Test Plan
- Not run after this commit.
