### PR TITLE
fix(coupons): allow event settings when removing coupon

### DIFF
--- a/Ekom/Ekom/API/Order.Discounts.cs
+++ b/Ekom/Ekom/API/Order.Discounts.cs
@@ -66,27 +66,28 @@ public partial class Order
     /// 
     /// </summary>
     /// <exception cref="ArgumentException"></exception>
-    public async Task RemoveCouponFromOrderAsync(CancellationToken ct = default)
+    public async Task RemoveCouponFromOrderAsync(DiscountOrderSettings? settings = null, CancellationToken ct = default)
     {
         var storeAlias = _storeSvc.GetStoreFromCache()?.Alias;
 
-        await RemoveCouponFromOrderAsync(storeAlias, ct).ConfigureAwait(false);
+        await RemoveCouponFromOrderAsync(storeAlias, settings, ct).ConfigureAwait(false);
     }
 
     /// <summary>
     /// 
     /// </summary>
     /// <param name="storeAlias"></param>
+    /// <param name="settings"></param>
     /// <param name="ct">CancellationToken</param>
     /// <exception cref="ArgumentException"></exception>
-    public async Task RemoveCouponFromOrderAsync(string? storeAlias, CancellationToken ct = default)
+    public async Task RemoveCouponFromOrderAsync(string? storeAlias, DiscountOrderSettings? settings, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(storeAlias))
         {
             throw new ArgumentException("string.IsNullOrEmpty", nameof(storeAlias));
         }
 
-        await _orderService.RemoveCouponFromOrderAsync(storeAlias, ct: ct)
+        await _orderService.RemoveCouponFromOrderAsync(storeAlias, settings: settings, ct: ct)
             .ConfigureAwait(false);
     }
 

--- a/Ekom/Ekom/Controllers/EkomOrderController.cs
+++ b/Ekom/Ekom/Controllers/EkomOrderController.cs
@@ -563,7 +563,7 @@ public partial class EkomOrderController : ControllerBase
     [EnableRateLimiting("order-coupon")]
     public async Task<IActionResult> RemoveCouponFromOrder(string storeAlias, CancellationToken ct = default)
     {
-        await Order.Instance.RemoveCouponFromOrderAsync(storeAlias, ct);
+        await Order.Instance.RemoveCouponFromOrderAsync(storeAlias, null, ct);
 
         return Ok();
     }

--- a/Ekom/Ekom/Services/OrderService.Discounts.cs
+++ b/Ekom/Ekom/Services/OrderService.Discounts.cs
@@ -144,6 +144,7 @@ partial class OrderService
         try
         {
             RemoveDiscountFromOrder(orderInfo);
+            
             if (settings.UpdateOrder)
             {
                 await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
@@ -174,10 +175,10 @@ partial class OrderService
             settings = new DiscountOrderSettings();
         }
 
-        var orderInfo = await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
+        var orderInfo = settings.OrderInfo as OrderInfo ?? await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
 
         SemaphoreSlim semaphore = GetOrderLock(orderInfo);
-        if (!settings.IsEventHandler)
+        if (!settings.IsEventHandler)   
         {
             await semaphore.WaitAsync(ct).ConfigureAwait(false);
         }
@@ -509,9 +510,12 @@ partial class OrderService
             settings = new DiscountOrderSettings();
         }
 
-        OrderInfo orderInfo = await GetOrderAsync(storeAlias).ConfigureAwait(false);
+        var orderInfo = settings.OrderInfo as OrderInfo ?? await GetOrderAsync(storeAlias, ct: ct).ConfigureAwait(false);
 
+        ArgumentNullException.ThrowIfNull(orderInfo);
+        
         SemaphoreSlim semaphore = GetOrderLock(orderInfo);
+        
         if (!settings.IsEventHandler)
         {
             await semaphore.WaitAsync(ct).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Allow `RemoveCouponFromOrderAsync` to receive `DiscountOrderSettings`.
- Pass event handler settings through to the order service so coupon removal can operate on the current in-flight order.
- Update controller call site for the new overload.

## Test Plan
- Not run; API/service overload change only.
