### PR TITLE
fix(order): preserve updated orderline event changes

### DIFF
--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -880,18 +880,18 @@ partial class OrderService
                 throw new OrderLineNotFoundException("Could not find order line with key: " + lineId);
             }
 
+            var updatedEventArgs = new UpdatedOrderlineEventArgs()
+            {
+                OrderInfo = orderInfo
+            };
+
             if (settings.FireEvents)
             {
-                var updatedEventArgs = new UpdatedOrderlineEventArgs()
-                {
-                    OrderInfo = orderInfo
-                };
-
                 OrderEvents.OnUpdatedOrderline(this, updatedEventArgs);
                 await OrderEvents.OnUpdatedOrderlineAsync(this, updatedEventArgs, ct);
             }
 
-            return await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
+            return await UpdateOrderAndOrderInfoAsync(updatedEventArgs.OrderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
                 .ConfigureAwait(false);
         }
         finally


### PR DESCRIPTION
## Summary
- Keep `UpdatedOrderlineEventArgs` available outside the event firing block.
- Persist the `OrderInfo` from the updated orderline event args after handlers run.
- Preserve event-handler modifications when updating an existing order line.

## Test Plan
- Not run; order event flow change only.
