### PR TITLE
fix(order): parse comma decimal vat rates

### DIFF
--- a/Ekom/Ekom.Tests/Tests/StoreVatTests.cs
+++ b/Ekom/Ekom.Tests/Tests/StoreVatTests.cs
@@ -8,9 +8,11 @@ public class StoreVatTests
 {
     [Theory]
     [InlineData("25.5", "0.255")]
+    [InlineData("25,5", "0.255")]
     [InlineData("25", "0.25")]
     [InlineData("", "0")]
-    [InlineData("25,5", "0")]
+    [InlineData("1,000", "0.01")]
+    [InlineData("1,000.5", "0")]
     public void Vat_Parses_With_Invariant_Culture(string vatValue, string expectedValue)
     {
         var store = new TestStore(vatValue);

--- a/Ekom/Ekom/Models/OrderLine.cs
+++ b/Ekom/Ekom/Models/OrderLine.cs
@@ -2,7 +2,6 @@ using Ekom.API;
 using Ekom.Services;
 using Ekom.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using System.Globalization;
 using System.Xml.Serialization;
 
 namespace Ekom.Models;
@@ -140,12 +139,13 @@ public class OrderLine : IOrderLine
             if (variantGroup != null && !string.IsNullOrEmpty(variantGroup.Properties.GetPropertyValue("vat", OrderInfo.StoreInfo.Alias)))
             {
                 string vatVal = variantGroup.Properties.GetPropertyValue("vat", OrderInfo.StoreInfo.Alias);
-                return Convert.ToDecimal(vatVal, CultureInfo.InvariantCulture) / 100;
+                if (VatParser.TryParsePercentageRate(vatVal, out var vat))
+                {
+                    return vat;
+                }
             }
-            else
-            {
-                return Product.Vat;
-            }
+
+            return Product.Vat;
         }
     }
 

--- a/Ekom/Ekom/Models/OrderedObjects/OrderedProduct.cs
+++ b/Ekom/Ekom/Models/OrderedObjects/OrderedProduct.cs
@@ -117,9 +117,9 @@ public class OrderedProduct
             {
                 string value = Properties.GetPropertyValue("vat", StoreInfo.Alias);
 
-                if (!string.IsNullOrEmpty(value) && decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal _val))
+                if (VatParser.TryParsePercentageRate(value, out decimal _val))
                 {
-                    return _val / 100;
+                    return _val;
                 }
             }
 

--- a/Ekom/Ekom/Models/OrderedObjects/OrderedVariant.cs
+++ b/Ekom/Ekom/Models/OrderedObjects/OrderedVariant.cs
@@ -3,7 +3,6 @@ using Ekom.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.Xml.Serialization;
 
 namespace Ekom.Models;
@@ -112,9 +111,9 @@ public class OrderedVariant
             {
                 string value = Properties.GetPropertyValue("vat", StoreInfo.Alias);
 
-                if (!string.IsNullOrEmpty(value) && decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal _val))
+                if (VatParser.TryParsePercentageRate(value, out decimal _val))
                 {
-                    return _val / 100;
+                    return _val;
                 }
             }
 

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -424,9 +424,9 @@ public class Product : PerStoreNodeEntity, IProduct
                     if (Properties.HasPropertyValue("vat", storeAlias))
                     {
                         string value = GetValue("vat", storeAlias);
-                        if (!string.IsNullOrEmpty(value) && decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal _val))
+                        if (VatParser.TryParsePercentageRate(value, out decimal _val))
                         {
-                            return _val / 100;
+                            return _val;
                         }
                     }
 

--- a/Ekom/Ekom/Models/Store.cs
+++ b/Ekom/Ekom/Models/Store.cs
@@ -203,8 +203,8 @@ public class Store : NodeEntity, IStore
         {
             var value = Properties.GetPropertyValue("vat");
 
-            return decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var vat)
-                ? vat / 100
+            return VatParser.TryParsePercentageRate(value, out var vat)
+                ? vat
                 : 0;
         }
     }

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -256,9 +256,9 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
             {
                 string value = GetValue("vat", Store.Alias);
 
-                if (!string.IsNullOrEmpty(value) && decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal _val))
+                if (VatParser.TryParsePercentageRate(value, out decimal _val))
                 {
-                    return _val / 100;
+                    return _val;
                 }
             }
 

--- a/Ekom/Ekom/Utilities/VatParser.cs
+++ b/Ekom/Ekom/Utilities/VatParser.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+
+namespace Ekom.Utilities;
+
+public static class VatParser
+{
+    private const NumberStyles VatNumberStyles = NumberStyles.AllowDecimalPoint
+                                                | NumberStyles.AllowLeadingSign
+                                                | NumberStyles.AllowLeadingWhite
+                                                | NumberStyles.AllowTrailingWhite;
+
+    public static bool TryParsePercentageRate(string? value, out decimal vat)
+    {
+        vat = 0;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (decimal.TryParse(value, VatNumberStyles, CultureInfo.InvariantCulture, out var percentage))
+        {
+            vat = percentage / 100;
+            return true;
+        }
+
+        if (value.Contains('.') || value.Count(x => x == ',') != 1)
+        {
+            return false;
+        }
+
+        var normalizedValue = value.Replace(',', '.');
+        if (!decimal.TryParse(normalizedValue, VatNumberStyles, CultureInfo.InvariantCulture, out percentage))
+        {
+            return false;
+        }
+
+        vat = percentage / 100;
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared VAT percentage parsing that supports dot and comma decimal separators.
- Use the shared parser for store, product, variant, ordered product, ordered variant, and orderline VAT overrides.
- Prevent comma VAT values such as `13,5` from being interpreted as `135%`.
- Update VAT parsing tests to cover comma decimal input and invalid mixed separator input.

## Test Plan
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj" --no-restore --filter "FullyQualifiedName~StoreVatTests"`