### PR TITLE
fix(klaviyo): add sms and push subscription helpers

### DIFF
--- a/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileLookupResult.cs
+++ b/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileLookupResult.cs
@@ -18,4 +18,8 @@ public sealed class KlaviyoProfileLookupResult
 
     public bool IsEmailSubscribed
         => SubscribedChannels.Contains(KlaviyoProfileConsentChannel.Email);
+    public bool IsSmsSubscribed
+        => SubscribedChannels.Contains(KlaviyoProfileConsentChannel.Sms);
+    public bool IsPushSubscribed
+        => SubscribedChannels.Contains(KlaviyoProfileConsentChannel.Push);
 }


### PR DESCRIPTION
## Summary
- Add helper properties for SMS and push subscription state on Klaviyo profile lookup results.
- Keep the existing email helper pattern for easier channel checks.

## Test Plan
- Not run; source-only helper change.