### PR TITLE
fix(coupons): add mark used action

### DIFF
--- a/Ekom/Ekom/Controllers/EkomOrderDiscountsController.cs
+++ b/Ekom/Ekom/Controllers/EkomOrderDiscountsController.cs
@@ -1,4 +1,5 @@
 using Ekom.Models;
+using Ekom.Repositories;
 using Ekom.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -14,13 +15,16 @@ public class EkomOrderDiscountsController : ControllerBase
 {
     private const string ApiKeyHeaderName = "X-Ekom-Api-Key";
 
+    private readonly CouponRepository _couponRepository;
     private readonly IOrderDiscountCalculationService _orderDiscountCalculationService;
     private readonly IOptions<OrderDiscountCalculationOptions> _options;
 
     public EkomOrderDiscountsController(
+        CouponRepository couponRepository,
         IOrderDiscountCalculationService orderDiscountCalculationService,
         IOptions<OrderDiscountCalculationOptions> options)
     {
+        _couponRepository = couponRepository;
         _orderDiscountCalculationService = orderDiscountCalculationService;
         _options = options;
     }
@@ -46,6 +50,27 @@ public class EkomOrderDiscountsController : ControllerBase
             .ConfigureAwait(false);
 
         return Ok(result);
+    }
+
+    [HttpPost]
+    [Route("coupon/mark-used")]
+    [EnableRateLimiting("order-coupon")]
+    public async Task<IActionResult> MarkCouponUsedAsync([FromBody] CouponRequest request)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.coupon))
+        {
+            return BadRequest("Coupon code can not be empty");
+        }
+
+        if (!IsAuthorized())
+        {
+            return Unauthorized();
+        }
+
+        await _couponRepository.MarkUsedAsync(request.coupon)
+            .ConfigureAwait(false);
+
+        return Ok();
     }
 
     private bool IsAuthorized()

--- a/Ekom/Ekom/Repositories/CouponRepository.cs
+++ b/Ekom/Ekom/Repositories/CouponRepository.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Ekom.Repositories;
 
-class CouponRepository
+public class CouponRepository
 {
     readonly ILogger _logger;
     readonly DatabaseFactory _databaseFactory;


### PR DESCRIPTION
## Summary
- Add an API-key-protected order discounts action to mark a coupon as used.
- Reuse the existing coupon request model and order coupon rate limit.
- Make the coupon repository injectable by the public controller.

## Test Plan
- Ran `dotnet build "Ekom/Ekom/Ekom.csproj"` successfully.