### PR TITLE
fix(klaviyo): support phone-only sms subscriptions

### DIFF
--- a/Plugins/Ekom.Klaviyo/Clients/KlaviyoProfilesClient.cs
+++ b/Plugins/Ekom.Klaviyo/Clients/KlaviyoProfilesClient.cs
@@ -19,6 +19,12 @@ internal interface IKlaviyoProfilesClient
         bool includeSubscriptions,
         CancellationToken ct = default);
 
+    Task<string?> GetByPhoneNumberAsync(
+        string phoneNumber,
+        string? storeAlias,
+        bool includeSubscriptions,
+        CancellationToken ct = default);
+
     Task<string?> GetListIdsAsync(
         string profileId,
         string? storeAlias,
@@ -90,6 +96,28 @@ internal sealed class KlaviyoProfilesClient : IKlaviyoProfilesClient
         var path = $"/api/profiles{query}";
 
         _logger.LogDebug("Klaviyo: profiles GET by email for store {StoreAlias}", storeAlias);
+
+        return await _http.GetAsync(path, storeAlias, ct).ConfigureAwait(false);
+    }
+
+    public async Task<string?> GetByPhoneNumberAsync(
+        string phoneNumber,
+        string? storeAlias,
+        bool includeSubscriptions,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(phoneNumber)) return null;
+        if (!_opt.Enabled) return null;
+
+        var sanitizedPhoneNumber = phoneNumber.Replace("\"", "\\\"", StringComparison.Ordinal);
+        var filter = $"equals(phone_number,\"{sanitizedPhoneNumber}\")";
+        var query = $"?filter={Uri.EscapeDataString(filter)}";
+        if (includeSubscriptions)
+            query = $"{query}&{ProfileSubscriptionsAdditionalField}";
+
+        var path = $"/api/profiles{query}";
+
+        _logger.LogDebug("Klaviyo: profiles GET by phone number for store {StoreAlias}", storeAlias);
 
         return await _http.GetAsync(path, storeAlias, ct).ConfigureAwait(false);
     }

--- a/Plugins/Ekom.Klaviyo/Enrichers/ProfilesEnricher/KlaviyoProfilesEnricherRunner.cs
+++ b/Plugins/Ekom.Klaviyo/Enrichers/ProfilesEnricher/KlaviyoProfilesEnricherRunner.cs
@@ -23,5 +23,5 @@ internal sealed class KlaviyoProfilesEnricherRunner : IKlaviyoProfilesEnricherRu
         => _pipeline.ApplyAsync(update.Profile.Customer.Email ?? string.Empty, consents: null, ct);
 
     public ValueTask ApplyAsync(KlaviyoProfileSubscribeRequest update, CancellationToken ct)
-        => _pipeline.ApplyAsync(update.Email, update.Consents, ct);
+        => _pipeline.ApplyAsync(update.Email ?? string.Empty, update.Consents, ct);
 }

--- a/Plugins/Ekom.Klaviyo/Mappers/ProfileMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/ProfileMapper.cs
@@ -140,7 +140,8 @@ public static class ProfileMapper
     {
         var profileAttributes = new JsonObject();
 
-        profileAttributes["email"] = u.Email;
+        if (!string.IsNullOrWhiteSpace(u.Email))
+            profileAttributes["email"] = u.Email;
 
         if (!string.IsNullOrWhiteSpace(u.PhoneNumber))
             profileAttributes["phone_number"] = u.PhoneNumber;

--- a/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileConsentRequest.cs
+++ b/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileConsentRequest.cs
@@ -11,7 +11,7 @@ public sealed record KlaviyoProfileConsentRequest(
 
 public sealed record KlaviyoProfileSubscribeRequest(
     string StoreAlias,
-    string Email,
+    string? Email = null,
     IReadOnlyList<KlaviyoProfileConsentChange>? Consents = null,
     string? ListId = null,
     string? PhoneNumber = null,

--- a/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileLookupResult.cs
+++ b/Plugins/Ekom.Klaviyo/Models/Profiles/KlaviyoProfileLookupResult.cs
@@ -18,4 +18,8 @@ public sealed class KlaviyoProfileLookupResult
 
     public bool IsEmailSubscribed
         => SubscribedChannels.Contains(KlaviyoProfileConsentChannel.Email);
+    public bool IsSmsSubscribed
+        => SubscribedChannels.Contains(KlaviyoProfileConsentChannel.Sms);
+    public bool IsPushSubscribed
+        => SubscribedChannels.Contains(KlaviyoProfileConsentChannel.Push);
 }

--- a/Plugins/Ekom.Klaviyo/Services/KlaviyoProfilesService.cs
+++ b/Plugins/Ekom.Klaviyo/Services/KlaviyoProfilesService.cs
@@ -37,6 +37,12 @@ public interface IKlaviyoProfilesService
         bool includeSubscriptions = false,
         CancellationToken ct = default);
 
+    ValueTask<KlaviyoProfileLookupResult?> GetProfileByPhoneNumberAsync(
+        string phoneNumber,
+        string? storeAlias,
+        bool includeSubscriptions = false,
+        CancellationToken ct = default);
+
     ValueTask<IReadOnlyList<string>?> GetProfileListIdsByProfileIdAsync(
         string profileId,
         string? storeAlias,
@@ -171,6 +177,21 @@ internal sealed class KlaviyoProfilesService : IKlaviyoProfilesService
         return ParseProfileResponse(json);
     }
 
+    public async ValueTask<KlaviyoProfileLookupResult?> GetProfileByPhoneNumberAsync(
+        string phoneNumber,
+        string? storeAlias,
+        bool includeSubscriptions = false,
+        CancellationToken ct = default)
+    {
+        if (!IsEnabled()) return null;
+        if (string.IsNullOrWhiteSpace(phoneNumber)) return null;
+
+        var json = await TryGetByPhoneNumberAsync(phoneNumber, storeAlias, includeSubscriptions, ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        return ParseProfileResponse(json);
+    }
+
     public async ValueTask<IReadOnlyList<string>?> GetProfileListIdsByProfileIdAsync(
         string profileId,
         string? storeAlias,
@@ -261,6 +282,37 @@ internal sealed class KlaviyoProfilesService : IKlaviyoProfilesService
         }
     }
 
+    private async Task<string?> TryGetByPhoneNumberAsync(
+        string phoneNumber,
+        string? storeAlias,
+        bool includeSubscriptions,
+        CancellationToken ct)
+    {
+        if (!includeSubscriptions)
+            return await _client.GetByPhoneNumberAsync(phoneNumber, storeAlias, includeSubscriptions: false, ct).ConfigureAwait(false);
+
+        try
+        {
+            return await _client.GetByPhoneNumberAsync(
+                phoneNumber,
+                storeAlias,
+                includeSubscriptions: true,
+                ct).ConfigureAwait(false);
+        }
+        catch (KlaviyoApiException ex) when (ex.StatusCode == 400)
+        {
+            _logger.LogDebug(
+                "Klaviyo: retrying profile fetch without subscriptions fields. Store={StoreAlias}",
+                storeAlias);
+
+            return await _client.GetByPhoneNumberAsync(
+                phoneNumber,
+                storeAlias,
+                includeSubscriptions: false,
+                ct).ConfigureAwait(false);
+        }
+    }
+
     private static KlaviyoProfileLookupResult? ParseProfileResponse(string json)
     {
         using var doc = JsonDocument.Parse(json);
@@ -292,10 +344,10 @@ internal sealed class KlaviyoProfilesService : IKlaviyoProfilesService
     {
         if (!IsEnabled() || !_opt.Subscriptions.Enabled) return;
 
-        if (string.IsNullOrWhiteSpace(payload.Email))
+        if (string.IsNullOrWhiteSpace(payload.Email) && string.IsNullOrWhiteSpace(payload.PhoneNumber))
         {
             _logger.LogWarning(
-                "Klaviyo: skipping {Type} because no email was provided. Store={StoreAlias}",
+                "Klaviyo: skipping {Type} because no email or phone number was provided. Store={StoreAlias}",
                 KlaviyoProfilesEventType.Subscribe, payload.StoreAlias);
             return;
         }
@@ -323,9 +375,18 @@ internal sealed class KlaviyoProfilesService : IKlaviyoProfilesService
             Payload: request,
             OccurredAt: DateTimeOffset.UtcNow,
             StoreAlias: payload.StoreAlias,
-            CustomerIdentifier: KlaviyoCustomerLoggingExtensions.MaskEmailForLogs(payload.Email));
+            CustomerIdentifier: GetSubscribeIdentifierForLogs(payload));
 
         await _dispatcher.EnqueueAsync(work, ct);
+    }
+
+    private static string GetSubscribeIdentifierForLogs(KlaviyoProfileSubscribeRequest payload)
+    {
+        return new KlaviyoCustomer
+        {
+            Email = payload.Email,
+            PhoneNumber = payload.PhoneNumber
+        }.IdentifierForLogs();
     }
 
     private async ValueTask TryUpsertProfileForSubscribeAsync(KlaviyoProfileSubscribeRequest payload, CancellationToken ct)


### PR DESCRIPTION
## Summary
- Allow Klaviyo subscribe requests to use a phone number without requiring an email address.
- Omit empty email fields from subscription payloads and keep SMS subscription payloads valid for phone-only profiles.
- Add profile lookup by phone number with subscription fields support.
- Add SMS and push subscription helper properties on profile lookup results.

## Test Plan
- Ran `dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj"` successfully.