### PR TITLE
fix(import): skip recycle bin products

### DIFF
--- a/Ekom/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.U10/Services/ImportService.cs
@@ -647,10 +647,16 @@ public class ImportService : IImportService
                 for (int i = allUmbracoProducts.Count - 1; i >= 0; i--)
                 {
                     var umbracoProduct = allUmbracoProducts[i];
-                    if (umbracoProduct.HasProperty("ekmDisableSync") && umbracoProduct.GetValue<bool>("ekmDisableSync"))
+
+                    if (recycleBinNode != null && recycleBinNode.Id == umbracoProduct.ParentId)
+                    {
                         continue;
+                    }
 
                     var productIdentifier = umbracoProduct.GetValue<string>(Configuration.ImportAliasIdentifier) ?? "";
+
+                    if (umbracoProduct.HasProperty("ekmDisableSync") && umbracoProduct.GetValue<bool>("ekmDisableSync"))
+                        continue;
 
                     // Not in import? Delete.
                     if (!importProductIdentifiers.Contains(productIdentifier))


### PR DESCRIPTION
## Summary
- Skip products that are already in the recycle bin during import cleanup.
- Avoid evaluating sync identifiers and delete logic for recycled products.

## Test Plan
- Not run; change is limited to import cleanup guard logic.
