### PR TITLE
fix(import): handle recycle bin product sync

### DIFF
--- a/Ekom/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.U10/Services/ImportService.cs
@@ -647,10 +647,16 @@ public class ImportService : IImportService
                 for (int i = allUmbracoProducts.Count - 1; i >= 0; i--)
                 {
                     var umbracoProduct = allUmbracoProducts[i];
-                    if (umbracoProduct.HasProperty("ekmDisableSync") && umbracoProduct.GetValue<bool>("ekmDisableSync"))
+
+                    if (recycleBinNode != null && recycleBinNode.Id == umbracoProduct.ParentId)
+                    {
                         continue;
+                    }
 
                     var productIdentifier = umbracoProduct.GetValue<string>(Configuration.ImportAliasIdentifier) ?? "";
+
+                    if (umbracoProduct.HasProperty("ekmDisableSync") && umbracoProduct.GetValue<bool>("ekmDisableSync"))
+                        continue;
 
                     // Not in import? Delete.
                     if (!importProductIdentifiers.Contains(productIdentifier))

--- a/Ekom/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.U10/Services/ImportService.cs
@@ -648,11 +648,6 @@ public class ImportService : IImportService
                 {
                     var umbracoProduct = allUmbracoProducts[i];
 
-                    if (recycleBinNode != null && recycleBinNode.Id == umbracoProduct.ParentId)
-                    {
-                        continue;
-                    }
-
                     var productIdentifier = umbracoProduct.GetValue<string>(Configuration.ImportAliasIdentifier) ?? "";
 
                     if (umbracoProduct.HasProperty("ekmDisableSync") && umbracoProduct.GetValue<bool>("ekmDisableSync"))
@@ -661,6 +656,11 @@ public class ImportService : IImportService
                     // Not in import? Delete.
                     if (!importProductIdentifiers.Contains(productIdentifier))
                     {
+                        if (recycleBinNode != null && recycleBinNode.Id == umbracoProduct.ParentId)
+                        {
+                            continue;
+                        }
+
                         _logger.LogInformation($"Product deleted Id: {umbracoProduct.Id} Name: {umbracoProduct.Name} Parent: {umbracoProduct.ParentId} ProductIdentifier: {productIdentifier}");
 
                         if (recycleBinNode != null)
@@ -686,6 +686,12 @@ public class ImportService : IImportService
                             continue;
 
                         var isInRecycleBin = recycleBinNode != null && umbracoProduct.ParentId == recycleBinNode.Id;
+                        var recycleBinIdentifier = recycleBinNode?.GetValue<string>(Configuration.ImportAliasIdentifier) ?? "";
+
+                        if (newCategoryIdentifier.InvariantEquals(recycleBinIdentifier))
+                        {
+                            continue;
+                        }
 
                         // Only read current category identifier if parent is actually a category (not recycle bin)
                         var currentCategoryIdentifier = "";


### PR DESCRIPTION
## Summary
- Keep recycle bin products eligible for restore checks when they are present in an import.
- Continue skipping deletion for products already under the recycle bin.
- Avoid moving products into the recycle bin category when the import category matches the recycle bin identifier.

## Test Plan
- Not run; change is limited to import recycle bin handling.
