### PR TITLE
fix(umbraco): resolve wrapped rte local links

### DIFF
--- a/Ekom/Ekom.U10/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.U10/ApplicationBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<IImportService, ImportService>();
         services.AddTransient<ImportMediaService>();
         services.AddTransient<NodeService>();
+        services.AddTransient<IEkomRichTextResolver, EkomRichTextResolver>();
         services.AddTransient<IMetafieldService, MetafieldService>();
         services.AddTransient<IUmbracoService, UmbracoService>();
         services.AddTransient<IUrlService, UrlService>();

--- a/Ekom/Ekom.U10/Models/Umbraco10Content.cs
+++ b/Ekom/Ekom.U10/Models/Umbraco10Content.cs
@@ -1,5 +1,7 @@
 using Ekom.Models;
+using Ekom.Umb.Services;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -8,7 +10,7 @@ namespace Ekom.Umb.Models;
 
 class Umbraco10Content : UmbracoContent
 {
-    public Umbraco10Content(IPublishedContent content, string? urlOverride = null)
+    public Umbraco10Content(IPublishedContent content, string? urlOverride = null, IEkomRichTextResolver? richTextResolver = null)
         : base(
             new Dictionary<string, string>
             {
@@ -26,11 +28,11 @@ class Umbraco10Content : UmbracoContent
                 ["__VariesByCulture"] = content.Cultures.Count > 1 ? "y" : "n",
                 ["url"] = urlOverride ?? "#"
             },
-            GetContentProperties(content)
+            GetContentProperties(content, richTextResolver)
         )
     { }
 
-    private static Dictionary<string, string> GetContentProperties(IPublishedContent content)
+    private static Dictionary<string, string> GetContentProperties(IPublishedContent content, IEkomRichTextResolver? richTextResolver)
     {
         string? firstCulture = content.Cultures.FirstOrDefault().Value?.Culture;
 
@@ -56,7 +58,7 @@ class Umbraco10Content : UmbracoContent
                                 ? prop.GetSourceValue(firstCulture)?.ToString() ?? string.Empty
                                 : prop.GetSourceValue()?.ToString() ?? string.Empty;
                             
-                            return value;
+                            return ResolveLocalLinks(value, richTextResolver);
                         }
                     }
                     catch (Exception ex)
@@ -69,7 +71,7 @@ class Umbraco10Content : UmbracoContent
 
 
 
-    public Umbraco10Content(IContent content, Guid parentKey)
+    public Umbraco10Content(IContent content, Guid parentKey, IEkomRichTextResolver? richTextResolver = null)
         : base(
             new Dictionary<string, string>
             {
@@ -89,12 +91,12 @@ class Umbraco10Content : UmbracoContent
             },
             content.Properties.ToDictionary(
                 x => x.Alias,
-                x => TransformPropertyValue(content, x.Alias)
+                x => TransformPropertyValue(content, x.Alias, richTextResolver)
             )
         )
     { }
 
-    private static string TransformPropertyValue(IContent content, string alias)
+    private static string TransformPropertyValue(IContent content, string alias, IEkomRichTextResolver? richTextResolver)
     {
         var prop = content.Properties.FirstOrDefault(x => x.Alias == alias);
 
@@ -109,15 +111,95 @@ class Umbraco10Content : UmbracoContent
                 // Extract the "markup" value
                 string markup = doc.RootElement.GetProperty("markup").GetString() ?? "";
 
-                return markup;
+                return ResolveLocalLinks(markup, richTextResolver);
             } else
             {
-                return rteValue;
+                return ResolveLocalLinks(rteValue, richTextResolver);
             }
 
         }
 
-        return content.GetValue<string>(alias) ?? string.Empty;
+        return ResolveLocalLinks(content.GetValue<string>(alias) ?? string.Empty, richTextResolver);
 
+    }
+
+    private static string ResolveLocalLinks(string value, IEkomRichTextResolver? richTextResolver)
+    {
+        if (richTextResolver == null || string.IsNullOrEmpty(value) || !value.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+        {
+            return value;
+        }
+
+        var trimmed = value.TrimStart();
+
+        if (trimmed.StartsWith('{') || trimmed.StartsWith('['))
+        {
+            return ResolveJsonLocalLinks(value, richTextResolver);
+        }
+
+        return richTextResolver.ResolveLocalLinks(value);
+    }
+
+    private static string ResolveJsonLocalLinks(string value, IEkomRichTextResolver richTextResolver)
+    {
+        try
+        {
+            var node = JsonNode.Parse(value);
+
+            if (node == null)
+            {
+                return value;
+            }
+
+            ResolveJsonNodeLocalLinks(node, richTextResolver);
+
+            return node.ToJsonString();
+        }
+        catch (JsonException)
+        {
+            return value;
+        }
+    }
+
+    private static void ResolveJsonNodeLocalLinks(JsonNode node, IEkomRichTextResolver richTextResolver)
+    {
+        if (node is JsonObject jsonObject)
+        {
+            foreach (var property in jsonObject.ToList())
+            {
+                if (property.Value is JsonValue jsonValue
+                    && jsonValue.TryGetValue<string>(out var stringValue)
+                    && stringValue.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+                {
+                    jsonObject[property.Key] = richTextResolver.ResolveLocalLinks(stringValue);
+                    continue;
+                }
+
+                if (property.Value != null)
+                {
+                    ResolveJsonNodeLocalLinks(property.Value, richTextResolver);
+                }
+            }
+        }
+        else if (node is JsonArray jsonArray)
+        {
+            for (var i = 0; i < jsonArray.Count; i++)
+            {
+                var item = jsonArray[i];
+
+                if (item is JsonValue jsonValue
+                    && jsonValue.TryGetValue<string>(out var stringValue)
+                    && stringValue.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+                {
+                    jsonArray[i] = richTextResolver.ResolveLocalLinks(stringValue);
+                    continue;
+                }
+
+                if (item != null)
+                {
+                    ResolveJsonNodeLocalLinks(item, richTextResolver);
+                }
+            }
+        }
     }
 }

--- a/Ekom/Ekom.U10/Services/EkomRichTextResolver.cs
+++ b/Ekom/Ekom.U10/Services/EkomRichTextResolver.cs
@@ -1,0 +1,35 @@
+using Umbraco.Cms.Core.Templates;
+using Umbraco.Cms.Core.Web;
+
+namespace Ekom.Umb.Services;
+
+interface IEkomRichTextResolver
+{
+    string ResolveLocalLinks(string value);
+}
+
+internal sealed class EkomRichTextResolver : IEkomRichTextResolver
+{
+    private readonly IUmbracoContextFactory _contextFactory;
+    private readonly HtmlLocalLinkParser _linkParser;
+
+    public EkomRichTextResolver(
+        IUmbracoContextFactory contextFactory,
+        HtmlLocalLinkParser linkParser)
+    {
+        _contextFactory = contextFactory;
+        _linkParser = linkParser;
+    }
+
+    public string ResolveLocalLinks(string value)
+    {
+        if (string.IsNullOrEmpty(value) || !value.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+        {
+            return value;
+        }
+
+        using var cref = _contextFactory.EnsureUmbracoContext();
+
+        return _linkParser.EnsureInternalLinks(value, preview: false);
+    }
+}

--- a/Ekom/Ekom.U10/Services/NodeService.cs
+++ b/Ekom/Ekom.U10/Services/NodeService.cs
@@ -14,13 +14,16 @@ class NodeService : INodeService
 {
     readonly ILogger<NodeService> _logger;
     readonly IUmbracoContextFactory _context;
+    readonly IEkomRichTextResolver _richTextResolver;
     public NodeService(
         IUmbracoContextFactory context,
-        ILogger<NodeService> logger
+        ILogger<NodeService> logger,
+        IEkomRichTextResolver richTextResolver
         )
     {
         _context = context;
         _logger = logger;
+        _richTextResolver = richTextResolver;
     }
 
     public IEnumerable<UmbracoContent> NodesByTypes(string contentTypeAlias)
@@ -43,7 +46,7 @@ class NodeService : INodeService
 
             var results = rootNode.DescendantsOfType(contentTypeAlias).ToList();
 
-            var content = results.Select(x => new Umbraco10Content(x)).ToList();
+            var content = results.Select(CreateContent).ToList();
 
             return content;
         }
@@ -59,7 +62,7 @@ class NodeService : INodeService
 
             var results = cache.GetByContentType(contentType);
 
-            var content = results.Select(x => new Umbraco10Content(x));
+            var content = results.Select(CreateContent);
 
             return content;
         }
@@ -76,7 +79,7 @@ class NodeService : INodeService
                 return null;
             }
 
-            var ancestors = node.Ancestors().Select(x => new Umbraco10Content(x)).ToList();
+            var ancestors = node.Ancestors().Select(CreateContent).ToList();
 
             return ancestors;
         }
@@ -92,7 +95,7 @@ class NodeService : INodeService
                 throw new ArgumentNullException(nameof(node));
             }
 
-            var ancestors = node.AncestorsOrSelf().Where(x => x.IsDocumentType("ekmCategory") || x.IsDocumentType("ekmProduct")).Select(x => new Umbraco10Content(x));
+            var ancestors = node.AncestorsOrSelf().Where(x => x.IsDocumentType("ekmCategory") || x.IsDocumentType("ekmProduct")).Select(CreateContent);
 
             ancestors.Reverse();
 
@@ -110,7 +113,7 @@ class NodeService : INodeService
                 throw new ArgumentNullException(nameof(node));
             }
 
-            var ancestors = node.Children.Select(x => new Umbraco10Content(x)).ToList();
+            var ancestors = node.Children.Select(CreateContent).ToList();
 
             return ancestors;
         }
@@ -154,7 +157,7 @@ class NodeService : INodeService
 
             ancestors.Reverse();
 
-            return ancestors.Select(x => new Umbraco10Content(x)).ToList();
+            return ancestors.Select(CreateContent).ToList();
         }
 
     }
@@ -225,7 +228,7 @@ class NodeService : INodeService
 
             if (node != null)
             {
-                return new Umbraco10Content(node);
+                return CreateContent(node);
             }
         }
 
@@ -248,7 +251,7 @@ class NodeService : INodeService
 
             if (node != null)
             {
-                return new Umbraco10Content(node);
+                return CreateContent(node);
             }
             
         }
@@ -273,7 +276,7 @@ class NodeService : INodeService
 
             if (node != null)
             {
-                return new Umbraco10Content(node);
+                return CreateContent(node);
             } 
         }
 
@@ -448,6 +451,11 @@ class NodeService : INodeService
             return "#";
         }
 
+    }
+
+    private Umbraco10Content CreateContent(IPublishedContent content)
+    {
+        return new Umbraco10Content(content, richTextResolver: _richTextResolver);
     }
 
 

--- a/Ekom/Ekom.U10/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.U10/UmbracoEventListeners.cs
@@ -4,6 +4,7 @@ using Ekom.Models;
 using Ekom.Repositories;
 using Ekom.Services;
 using Ekom.Umb.Models;
+using Ekom.Umb.Services;
 using Ekom.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -46,6 +47,7 @@ class UmbracoEventListeners :
     private CouponRepository _couponRepository;
     private INodeService _nodeService;
     private RevalidateService _revalidateService;
+    private IEkomRichTextResolver _richTextResolver;
     /// <summary>
     /// Initializes a new instance of the <see cref="UmbracoEventListeners"/> class.
     /// </summary>
@@ -62,7 +64,8 @@ class UmbracoEventListeners :
         AppCaches appCaches,
         CouponRepository couponRepository,
         INodeService nodeService,
-        RevalidateService revalidateService)
+        RevalidateService revalidateService,
+        IEkomRichTextResolver richTextResolver)
     {
         _logger = logger;
         _config = config;
@@ -77,6 +80,7 @@ class UmbracoEventListeners :
         _couponRepository = couponRepository;
         _nodeService = nodeService;
         _revalidateService = revalidateService;
+        _richTextResolver = richTextResolver;
     }
     public async Task HandleAsync(ContentSavingNotification e, CancellationToken ct)
     {
@@ -158,7 +162,7 @@ class UmbracoEventListeners :
 
                 if (parentNode == null) { continue; }
 
-                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode.Key));
+                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode.Key, _richTextResolver));
                 //Fire and forget
                 RevalidateAsync(node, cancellationToken).ConfigureAwait(false);
 
@@ -194,7 +198,7 @@ class UmbracoEventListeners :
 
                 var parentNode = _nodeService.NodeById(node.Id);
 
-                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode != null ? parentNode.Key : Guid.Empty));
+                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode != null ? parentNode.Key : Guid.Empty, _richTextResolver));
 
                 if (node.ContentType.Alias == "ekmCategory")
                 {
@@ -402,7 +406,7 @@ class UmbracoEventListeners :
         if (ekmStoreContent != null)
         {
             // Update cached IStore
-            _storeCache.AddReplace(new Umbraco10Content(ekmStoreContent, Guid.Empty));
+            _storeCache.AddReplace(new Umbraco10Content(ekmStoreContent, Guid.Empty, _richTextResolver));
         }
     }
 
@@ -487,7 +491,7 @@ class UmbracoEventListeners :
             }
             else
             {
-                cacheEntryForDesc?.AddReplace(new Umbraco10Content(descendant));
+                cacheEntryForDesc?.AddReplace(new Umbraco10Content(descendant, richTextResolver: _richTextResolver));
             }
 
         }
@@ -496,7 +500,7 @@ class UmbracoEventListeners :
         {
             var cacheEntryForDesc = FindMatchingCache(ancestor.ContentType.Alias);
 
-            cacheEntryForDesc?.AddReplace(new Umbraco10Content(ancestor));
+            cacheEntryForDesc?.AddReplace(new Umbraco10Content(ancestor, richTextResolver: _richTextResolver));
         }
     }
     


### PR DESCRIPTION
## Summary
- Resolve Umbraco `{localLink:...}` placeholders in RTE values wrapped by the Ekom Property Editor.
- Add an Ekom rich text resolver that delegates to Umbraco's `HtmlLocalLinkParser`.
- Wire the resolver through node/content cache construction paths so existing saved values are fixed on output.

## Test Plan
- `dotnet build "Ekom/Ekom.U10/Ekom.U10.csproj"`
- `dotnet test "Ekom/Ekom.Tests/Ekom.Tests.csproj"` (currently fails on existing `PriceTests.ISK_PerUnit_VatIncluded_LineLevelVat_1538x4_24pct`: expected `4960`, actual `4964`)
