### PR TITLE
feat(algolia): add federated search

### DIFF
--- a/Ekom/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -30,7 +30,12 @@ public class AlgoliaSearchTests
                 ["Ekom:Algolia:Search:MaxHitsPerPage"] = "50",
                 ["Ekom:Algolia:Search:Cache:Enabled"] = "true",
                 ["Ekom:Algolia:Search:Cache:DurationMinutes"] = "15",
-                ["Ekom:Algolia:Search:Cache:CacheEmptyResults"] = "false"
+                ["Ekom:Algolia:Search:Cache:CacheEmptyResults"] = "false",
+                ["Ekom:Algolia:ContentIndexing:Enabled"] = "true",
+                ["Ekom:Algolia:ContentIndexing:Indexes:0:IndexName"] = "SearchIndex",
+                ["Ekom:Algolia:ContentIndexing:Indexes:0:ContentTypes:0:Alias"] = "article",
+                ["Ekom:Algolia:ContentIndexing:Indexes:0:ContentTypes:0:Properties:0"] = "title",
+                ["Ekom:Algolia:ContentIndexing:Indexes:0:ContentTypes:0:Properties:1"] = "publishedAt|unix"
             })
             .Build();
 
@@ -49,6 +54,10 @@ public class AlgoliaSearchTests
         Assert.Equal(50, options.Search.MaxHitsPerPage);
         Assert.Equal(15, options.Search.Cache.DurationMinutes);
         Assert.False(options.Search.Cache.CacheEmptyResults);
+        Assert.True(options.ContentIndexing.Enabled);
+        Assert.Equal("SearchIndex", options.ContentIndexing.Indexes.Single().IndexName);
+        Assert.Equal("article", options.ContentIndexing.Indexes.Single().ContentTypes.Single().Alias);
+        Assert.Equal(["title", "publishedAt|unix"], options.ContentIndexing.Indexes.Single().ContentTypes.Single().Properties);
     }
 
     [Fact]
@@ -187,5 +196,70 @@ public class AlgoliaSearchTests
         var key = builder.BuildCategoriesKey(request, request.Query, "primary.store.categories.en-us");
 
         Assert.Contains("categories", key);
+    }
+
+    [Fact]
+    public void Content_Cache_Key_Changes_When_Query_Changes()
+    {
+        var versions = new AlgoliaSearchCacheVersionProvider();
+        var builder = new AlgoliaSearchCacheKeyBuilder(versions);
+
+        var first = builder.BuildContentKey(
+            new AlgoliaContentSearchRequest
+            {
+                IndexName = "SearchIndex",
+                Culture = "en-US",
+                Query = new SearchForHits
+                {
+                    Query = "chair",
+                    HitsPerPage = 20,
+                    Page = 0
+                }
+            },
+            new SearchForHits
+            {
+                Query = "chair",
+                HitsPerPage = 20,
+                Page = 0
+            },
+            "searchindex.prod.en-us");
+
+        var second = builder.BuildContentKey(
+            new AlgoliaContentSearchRequest
+            {
+                IndexName = "SearchIndex",
+                Culture = "en-US",
+                Query = new SearchForHits
+                {
+                    Query = "table",
+                    HitsPerPage = 20,
+                    Page = 0
+                }
+            },
+            new SearchForHits
+            {
+                Query = "table",
+                HitsPerPage = 20,
+                Page = 0
+            },
+            "searchindex.prod.en-us");
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Content_Index_Name_Uses_Base_Environment_And_Culture()
+    {
+        var resolver = new ContentIndexNameResolver(Options.Create(new AlgoliaOptions
+        {
+            ApplicationId = "app-id",
+            AdminApiKey = "admin-key",
+            SearchApiKey = "search-key",
+            Environment = "Staging"
+        }));
+
+        var indexName = resolver.Resolve("SearchIndex", "en-US");
+
+        Assert.Equal("searchindex.staging.en-us", indexName);
     }
 }

--- a/Ekom/Ekom.U10/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.U10/ApplicationBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<IImportService, ImportService>();
         services.AddTransient<ImportMediaService>();
         services.AddTransient<NodeService>();
+        services.AddTransient<IEkomRichTextResolver, EkomRichTextResolver>();
         services.AddTransient<IMetafieldService, MetafieldService>();
         services.AddTransient<IUmbracoService, UmbracoService>();
         services.AddTransient<IUrlService, UrlService>();

--- a/Ekom/Ekom.U10/Models/Umbraco10Content.cs
+++ b/Ekom/Ekom.U10/Models/Umbraco10Content.cs
@@ -1,5 +1,7 @@
 using Ekom.Models;
+using Ekom.Umb.Services;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -8,7 +10,7 @@ namespace Ekom.Umb.Models;
 
 class Umbraco10Content : UmbracoContent
 {
-    public Umbraco10Content(IPublishedContent content, string? urlOverride = null)
+    public Umbraco10Content(IPublishedContent content, string? urlOverride = null, IEkomRichTextResolver? richTextResolver = null)
         : base(
             new Dictionary<string, string>
             {
@@ -26,11 +28,11 @@ class Umbraco10Content : UmbracoContent
                 ["__VariesByCulture"] = content.Cultures.Count > 1 ? "y" : "n",
                 ["url"] = urlOverride ?? "#"
             },
-            GetContentProperties(content)
+            GetContentProperties(content, richTextResolver)
         )
     { }
 
-    private static Dictionary<string, string> GetContentProperties(IPublishedContent content)
+    private static Dictionary<string, string> GetContentProperties(IPublishedContent content, IEkomRichTextResolver? richTextResolver)
     {
         string? firstCulture = content.Cultures.FirstOrDefault().Value?.Culture;
 
@@ -56,7 +58,7 @@ class Umbraco10Content : UmbracoContent
                                 ? prop.GetSourceValue(firstCulture)?.ToString() ?? string.Empty
                                 : prop.GetSourceValue()?.ToString() ?? string.Empty;
                             
-                            return value;
+                            return ResolveLocalLinks(value, richTextResolver);
                         }
                     }
                     catch (Exception ex)
@@ -69,7 +71,7 @@ class Umbraco10Content : UmbracoContent
 
 
 
-    public Umbraco10Content(IContent content, Guid parentKey)
+    public Umbraco10Content(IContent content, Guid parentKey, IEkomRichTextResolver? richTextResolver = null)
         : base(
             new Dictionary<string, string>
             {
@@ -89,12 +91,12 @@ class Umbraco10Content : UmbracoContent
             },
             content.Properties.ToDictionary(
                 x => x.Alias,
-                x => TransformPropertyValue(content, x.Alias)
+                x => TransformPropertyValue(content, x.Alias, richTextResolver)
             )
         )
     { }
 
-    private static string TransformPropertyValue(IContent content, string alias)
+    private static string TransformPropertyValue(IContent content, string alias, IEkomRichTextResolver? richTextResolver)
     {
         var prop = content.Properties.FirstOrDefault(x => x.Alias == alias);
 
@@ -109,15 +111,95 @@ class Umbraco10Content : UmbracoContent
                 // Extract the "markup" value
                 string markup = doc.RootElement.GetProperty("markup").GetString() ?? "";
 
-                return markup;
+                return ResolveLocalLinks(markup, richTextResolver);
             } else
             {
-                return rteValue;
+                return ResolveLocalLinks(rteValue, richTextResolver);
             }
 
         }
 
-        return content.GetValue<string>(alias) ?? string.Empty;
+        return ResolveLocalLinks(content.GetValue<string>(alias) ?? string.Empty, richTextResolver);
 
+    }
+
+    private static string ResolveLocalLinks(string value, IEkomRichTextResolver? richTextResolver)
+    {
+        if (richTextResolver == null || string.IsNullOrEmpty(value) || !value.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+        {
+            return value;
+        }
+
+        var trimmed = value.TrimStart();
+
+        if (trimmed.StartsWith('{') || trimmed.StartsWith('['))
+        {
+            return ResolveJsonLocalLinks(value, richTextResolver);
+        }
+
+        return richTextResolver.ResolveLocalLinks(value);
+    }
+
+    private static string ResolveJsonLocalLinks(string value, IEkomRichTextResolver richTextResolver)
+    {
+        try
+        {
+            var node = JsonNode.Parse(value);
+
+            if (node == null)
+            {
+                return value;
+            }
+
+            ResolveJsonNodeLocalLinks(node, richTextResolver);
+
+            return node.ToJsonString();
+        }
+        catch (JsonException)
+        {
+            return value;
+        }
+    }
+
+    private static void ResolveJsonNodeLocalLinks(JsonNode node, IEkomRichTextResolver richTextResolver)
+    {
+        if (node is JsonObject jsonObject)
+        {
+            foreach (var property in jsonObject.ToList())
+            {
+                if (property.Value is JsonValue jsonValue
+                    && jsonValue.TryGetValue<string>(out var stringValue)
+                    && stringValue.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+                {
+                    jsonObject[property.Key] = richTextResolver.ResolveLocalLinks(stringValue);
+                    continue;
+                }
+
+                if (property.Value != null)
+                {
+                    ResolveJsonNodeLocalLinks(property.Value, richTextResolver);
+                }
+            }
+        }
+        else if (node is JsonArray jsonArray)
+        {
+            for (var i = 0; i < jsonArray.Count; i++)
+            {
+                var item = jsonArray[i];
+
+                if (item is JsonValue jsonValue
+                    && jsonValue.TryGetValue<string>(out var stringValue)
+                    && stringValue.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+                {
+                    jsonArray[i] = richTextResolver.ResolveLocalLinks(stringValue);
+                    continue;
+                }
+
+                if (item != null)
+                {
+                    ResolveJsonNodeLocalLinks(item, richTextResolver);
+                }
+            }
+        }
     }
 }

--- a/Ekom/Ekom.U10/Services/EkomRichTextResolver.cs
+++ b/Ekom/Ekom.U10/Services/EkomRichTextResolver.cs
@@ -1,0 +1,35 @@
+using Umbraco.Cms.Core.Templates;
+using Umbraco.Cms.Core.Web;
+
+namespace Ekom.Umb.Services;
+
+interface IEkomRichTextResolver
+{
+    string ResolveLocalLinks(string value);
+}
+
+internal sealed class EkomRichTextResolver : IEkomRichTextResolver
+{
+    private readonly IUmbracoContextFactory _contextFactory;
+    private readonly HtmlLocalLinkParser _linkParser;
+
+    public EkomRichTextResolver(
+        IUmbracoContextFactory contextFactory,
+        HtmlLocalLinkParser linkParser)
+    {
+        _contextFactory = contextFactory;
+        _linkParser = linkParser;
+    }
+
+    public string ResolveLocalLinks(string value)
+    {
+        if (string.IsNullOrEmpty(value) || !value.Contains("{localLink:", StringComparison.OrdinalIgnoreCase))
+        {
+            return value;
+        }
+
+        using var cref = _contextFactory.EnsureUmbracoContext();
+
+        return _linkParser.EnsureInternalLinks(value, preview: false);
+    }
+}

--- a/Ekom/Ekom.U10/Services/NodeService.cs
+++ b/Ekom/Ekom.U10/Services/NodeService.cs
@@ -14,13 +14,16 @@ class NodeService : INodeService
 {
     readonly ILogger<NodeService> _logger;
     readonly IUmbracoContextFactory _context;
+    readonly IEkomRichTextResolver _richTextResolver;
     public NodeService(
         IUmbracoContextFactory context,
-        ILogger<NodeService> logger
+        ILogger<NodeService> logger,
+        IEkomRichTextResolver richTextResolver
         )
     {
         _context = context;
         _logger = logger;
+        _richTextResolver = richTextResolver;
     }
 
     public IEnumerable<UmbracoContent> NodesByTypes(string contentTypeAlias)
@@ -43,7 +46,7 @@ class NodeService : INodeService
 
             var results = rootNode.DescendantsOfType(contentTypeAlias).ToList();
 
-            var content = results.Select(x => new Umbraco10Content(x)).ToList();
+            var content = results.Select(CreateContent).ToList();
 
             return content;
         }
@@ -59,7 +62,7 @@ class NodeService : INodeService
 
             var results = cache.GetByContentType(contentType);
 
-            var content = results.Select(x => new Umbraco10Content(x));
+            var content = results.Select(CreateContent);
 
             return content;
         }
@@ -76,7 +79,7 @@ class NodeService : INodeService
                 return null;
             }
 
-            var ancestors = node.Ancestors().Select(x => new Umbraco10Content(x)).ToList();
+            var ancestors = node.Ancestors().Select(CreateContent).ToList();
 
             return ancestors;
         }
@@ -92,7 +95,7 @@ class NodeService : INodeService
                 throw new ArgumentNullException(nameof(node));
             }
 
-            var ancestors = node.AncestorsOrSelf().Where(x => x.IsDocumentType("ekmCategory") || x.IsDocumentType("ekmProduct")).Select(x => new Umbraco10Content(x));
+            var ancestors = node.AncestorsOrSelf().Where(x => x.IsDocumentType("ekmCategory") || x.IsDocumentType("ekmProduct")).Select(CreateContent);
 
             ancestors.Reverse();
 
@@ -110,7 +113,7 @@ class NodeService : INodeService
                 throw new ArgumentNullException(nameof(node));
             }
 
-            var ancestors = node.Children.Select(x => new Umbraco10Content(x)).ToList();
+            var ancestors = node.Children.Select(CreateContent).ToList();
 
             return ancestors;
         }
@@ -154,7 +157,7 @@ class NodeService : INodeService
 
             ancestors.Reverse();
 
-            return ancestors.Select(x => new Umbraco10Content(x)).ToList();
+            return ancestors.Select(CreateContent).ToList();
         }
 
     }
@@ -225,7 +228,7 @@ class NodeService : INodeService
 
             if (node != null)
             {
-                return new Umbraco10Content(node);
+                return CreateContent(node);
             }
         }
 
@@ -248,7 +251,7 @@ class NodeService : INodeService
 
             if (node != null)
             {
-                return new Umbraco10Content(node);
+                return CreateContent(node);
             }
             
         }
@@ -273,7 +276,7 @@ class NodeService : INodeService
 
             if (node != null)
             {
-                return new Umbraco10Content(node);
+                return CreateContent(node);
             } 
         }
 
@@ -448,6 +451,11 @@ class NodeService : INodeService
             return "#";
         }
 
+    }
+
+    private Umbraco10Content CreateContent(IPublishedContent content)
+    {
+        return new Umbraco10Content(content, richTextResolver: _richTextResolver);
     }
 
 

--- a/Ekom/Ekom.U10/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.U10/UmbracoEventListeners.cs
@@ -4,6 +4,7 @@ using Ekom.Models;
 using Ekom.Repositories;
 using Ekom.Services;
 using Ekom.Umb.Models;
+using Ekom.Umb.Services;
 using Ekom.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -46,6 +47,7 @@ class UmbracoEventListeners :
     private CouponRepository _couponRepository;
     private INodeService _nodeService;
     private RevalidateService _revalidateService;
+    private IEkomRichTextResolver _richTextResolver;
     /// <summary>
     /// Initializes a new instance of the <see cref="UmbracoEventListeners"/> class.
     /// </summary>
@@ -62,7 +64,8 @@ class UmbracoEventListeners :
         AppCaches appCaches,
         CouponRepository couponRepository,
         INodeService nodeService,
-        RevalidateService revalidateService)
+        RevalidateService revalidateService,
+        IEkomRichTextResolver richTextResolver)
     {
         _logger = logger;
         _config = config;
@@ -77,6 +80,7 @@ class UmbracoEventListeners :
         _couponRepository = couponRepository;
         _nodeService = nodeService;
         _revalidateService = revalidateService;
+        _richTextResolver = richTextResolver;
     }
     public async Task HandleAsync(ContentSavingNotification e, CancellationToken ct)
     {
@@ -158,7 +162,7 @@ class UmbracoEventListeners :
 
                 if (parentNode == null) { continue; }
 
-                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode.Key));
+                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode.Key, _richTextResolver));
                 //Fire and forget
                 RevalidateAsync(node, cancellationToken).ConfigureAwait(false);
 
@@ -194,7 +198,7 @@ class UmbracoEventListeners :
 
                 var parentNode = _nodeService.NodeById(node.Id);
 
-                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode != null ? parentNode.Key : Guid.Empty));
+                cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode != null ? parentNode.Key : Guid.Empty, _richTextResolver));
 
                 if (node.ContentType.Alias == "ekmCategory")
                 {
@@ -402,7 +406,7 @@ class UmbracoEventListeners :
         if (ekmStoreContent != null)
         {
             // Update cached IStore
-            _storeCache.AddReplace(new Umbraco10Content(ekmStoreContent, Guid.Empty));
+            _storeCache.AddReplace(new Umbraco10Content(ekmStoreContent, Guid.Empty, _richTextResolver));
         }
     }
 
@@ -487,7 +491,7 @@ class UmbracoEventListeners :
             }
             else
             {
-                cacheEntryForDesc?.AddReplace(new Umbraco10Content(descendant));
+                cacheEntryForDesc?.AddReplace(new Umbraco10Content(descendant, richTextResolver: _richTextResolver));
             }
 
         }
@@ -496,7 +500,7 @@ class UmbracoEventListeners :
         {
             var cacheEntryForDesc = FindMatchingCache(ancestor.ContentType.Alias);
 
-            cacheEntryForDesc?.AddReplace(new Umbraco10Content(ancestor));
+            cacheEntryForDesc?.AddReplace(new Umbraco10Content(ancestor, richTextResolver: _richTextResolver));
         }
     }
     

--- a/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
+++ b/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ public static class AlgoliaServiceCollectionExtensions
         });
 
         services.AddSingleton<IndexNameBuilder>();
+        services.AddSingleton<ContentIndexNameResolver>();
         services.AddSingleton<AlgoliaStoreResolver>();
         services.AddSingleton<AlgoliaSearchCacheVersionProvider>();
         services.AddSingleton<AlgoliaSearchCacheKeyBuilder>();
@@ -68,6 +69,12 @@ public static class AlgoliaServiceCollectionExtensions
         services.AddSingleton<IAlgoliaCategoryIndexService, AlgoliaCategoryIndexService>();
         services.AddSingleton<AlgoliaCategoryIndexWorker>();
         services.AddHostedService(sp => sp.GetRequiredService<AlgoliaCategoryIndexWorker>());
+
+        services.AddSingleton<IAlgoliaContentIndexQueue, AlgoliaContentIndexQueue>();
+        services.AddSingleton<AlgoliaContentIndexExecutor>();
+        services.AddSingleton<IAlgoliaContentIndexService, AlgoliaContentIndexService>();
+        services.AddSingleton<AlgoliaContentIndexWorker>();
+        services.AddHostedService(sp => sp.GetRequiredService<AlgoliaContentIndexWorker>());
 
         services.AddSingleton<IAlgoliaUserTokenProvider, DefaultAlgoliaUserTokenProvider>();
         services.AddSingleton<IAlgoliaEventService, AlgoliaEventService>();

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -15,6 +15,7 @@ public sealed class AlgoliaOptions
     public string Environment { get; init; } = "prod";
 
     public AlgoliaIndexingOptions Indexing { get; set; } = new();
+    public AlgoliaContentIndexingOptions ContentIndexing { get; set; } = new();
     public AlgoliaEventsOptions Events { get; set; } = new();
     public AlgoliaSearchOptions Search { get; set; } = new();
 
@@ -33,6 +34,34 @@ public sealed class AlgoliaIndexingOptions
     public IReadOnlyCollection<AlgoliaSortedReplicaOptions> SortedReplicas { get; init; } = [];
 
     public AlgoliaDispatcherOptions Dispatching { get; init; } = new();
+}
+
+public sealed class AlgoliaContentIndexingOptions
+{
+    public bool Enabled { get; set; }
+    public bool EnforcePublisherOnly { get; set; } = true;
+    public int BatchSize { get; set; } = 1000;
+    public AlgoliaDispatcherOptions Dispatching { get; init; } = new();
+    public IReadOnlyCollection<AlgoliaContentIndexOptions> Indexes { get; init; } = [];
+}
+
+public sealed class AlgoliaContentIndexOptions
+{
+    public required string IndexName { get; set; }
+    public IReadOnlyCollection<AlgoliaContentTypeOptions> ContentTypes { get; init; } = [];
+}
+
+public sealed class AlgoliaContentTypeOptions
+{
+    public required string Alias { get; set; }
+    public IReadOnlyCollection<string> Properties { get; init; } = [];
+}
+
+public enum AlgoliaContentFieldTransform
+{
+    None,
+    UnixSeconds,
+    UnixMilliseconds
 }
 
 public sealed class AlgoliaEventsOptions

--- a/Plugins/Ekom.Algolia/Controllers/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Controllers/AlgoliaBackofficeController.cs
@@ -9,15 +9,18 @@ public class EkomAlgoliaBackofficeController : UmbracoAuthorizedApiController
 {
     private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
     private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
+    private readonly IAlgoliaContentIndexService _algoliaContentIndexService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
         IAlgoliaProductIndexService algoliaProductIndexService,
         IAlgoliaCategoryIndexService algoliaCategoryIndexService,
+        IAlgoliaContentIndexService algoliaContentIndexService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
         _algoliaProductIndexService = algoliaProductIndexService;
         _algoliaCategoryIndexService = algoliaCategoryIndexService;
+        _algoliaContentIndexService = algoliaContentIndexService;
         _logger = logger;
     }
 
@@ -27,10 +30,11 @@ public class EkomAlgoliaBackofficeController : UmbracoAuthorizedApiController
     {
         await _algoliaProductIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
         await _algoliaCategoryIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
+        await _algoliaContentIndexService.RebuildAsync(ct: ct).ConfigureAwait(false);
 
-        _logger.LogInformation("Algolia manual reindex requested for all configured stores.");
+        _logger.LogInformation("Algolia manual reindex requested for all configured stores and content indexes.");
 
-        return Ok(new { message = "Algolia product and category reindex initiated for all configured stores." });
+        return Ok(new { message = "Algolia product, category, and content reindex initiated." });
     }
 
     [HttpGet]

--- a/Plugins/Ekom.Algolia/Events/AlgoliaUmbracoNotifications.cs
+++ b/Plugins/Ekom.Algolia/Events/AlgoliaUmbracoNotifications.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Sync;
 
 namespace Ekom.Algolia.Events;
 
@@ -31,17 +32,23 @@ internal sealed class AlgoliaUmbracoNotifications :
 
     private readonly IAlgoliaProductIndexService _productIndexer;
     private readonly IAlgoliaCategoryIndexService _categoryIndexer;
+    private readonly IAlgoliaContentIndexService _contentIndexer;
+    private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly AlgoliaOptions _options;
     private readonly ILogger<AlgoliaUmbracoNotifications> _logger;
 
     public AlgoliaUmbracoNotifications(
         IAlgoliaProductIndexService productIndexer,
         IAlgoliaCategoryIndexService categoryIndexer,
+        IAlgoliaContentIndexService contentIndexer,
+        IServerRoleAccessor serverRoleAccessor,
         IOptions<AlgoliaOptions> options,
         ILogger<AlgoliaUmbracoNotifications> logger)
     {
         _productIndexer = productIndexer;
         _categoryIndexer = categoryIndexer;
+        _contentIndexer = contentIndexer;
+        _serverRoleAccessor = serverRoleAccessor;
         _options = options.Value;
         _logger = logger;
     }
@@ -85,6 +92,9 @@ internal sealed class AlgoliaUmbracoNotifications :
 
         if (string.Equals(entity.ContentType.Alias, CategoryAlias, StringComparison.OrdinalIgnoreCase))
             return EnqueueCategoryAsync(entity, isPublished, ct);
+
+        if (IsConfiguredContentType(entity.ContentType.Alias))
+            return EnqueueContentAsync(entity, isPublished, ct);
 
         _logger.LogDebug(
             "Algolia skipping content {Id} because alias {Alias} is not supported.",
@@ -169,4 +179,28 @@ internal sealed class AlgoliaUmbracoNotifications :
             }
         }
     }
+
+    private Task EnqueueContentAsync(IContent entity, bool isPublished, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.ContentIndexing.Enabled)
+        {
+            _logger.LogDebug("Algolia disabled; skipping standard content {Id}.", entity.Id);
+            return Task.CompletedTask;
+        }
+
+        if (_options.ContentIndexing.EnforcePublisherOnly && _serverRoleAccessor.CurrentServerRole is ServerRole.Subscriber or ServerRole.Unknown)
+        {
+            _logger.LogDebug("Algolia standard content indexing skipped on server role {ServerRole}.", _serverRoleAccessor.CurrentServerRole);
+            return Task.CompletedTask;
+        }
+
+        return isPublished
+            ? _contentIndexer.UpdateByIdsAsync([entity.Id], ct)
+            : _contentIndexer.DeleteByKeysAsync([entity.Key], ct);
+    }
+
+    private bool IsConfiguredContentType(string alias)
+        => _options.ContentIndexing.Indexes
+            .SelectMany(x => x.ContentTypes)
+            .Any(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
 }

--- a/Plugins/Ekom.Algolia/Helpers/ContentIndexNameResolver.cs
+++ b/Plugins/Ekom.Algolia/Helpers/ContentIndexNameResolver.cs
@@ -1,0 +1,17 @@
+namespace Ekom.Algolia;
+
+internal sealed class ContentIndexNameResolver
+{
+    private readonly AlgoliaOptions _options;
+
+    public ContentIndexNameResolver(Microsoft.Extensions.Options.IOptions<AlgoliaOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public string Resolve(string indexName, string culture)
+    {
+        var env = string.IsNullOrWhiteSpace(_options.Environment) ? "prod" : _options.Environment.Trim();
+        return $"{indexName.Trim()}.{env}.{culture.Trim()}".ToLowerInvariant();
+    }
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexExecutor.cs
@@ -1,0 +1,504 @@
+using Algolia.Search.Clients;
+using Ekom.Algolia.Mappers;
+using Ekom.Algolia.Models.Indexing;
+using Ekom.Algolia.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Globalization;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.Persistence.Querying;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Extensions;
+
+namespace Ekom.Algolia.Indexing;
+
+internal sealed class AlgoliaContentIndexExecutor
+{
+    private readonly ISearchClient _client;
+    private readonly AlgoliaOptions _options;
+    private readonly IReadOnlyList<IAlgoliaContentEnricher> _enrichers;
+    private readonly IReadOnlyList<IAlgoliaContentPropertyValueConverter> _propertyConverters;
+    private readonly IContentService _contentService;
+    private readonly ILocalizationService _languageService;
+    private readonly PropertyEditorCollection _propertyEditors;
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IPublishedUrlProvider _urlProvider;
+    private readonly IUmbracoContextFactory _umbracoContextFactory;
+    private readonly IScopeProvider _scopeProvider;
+    private readonly IMemoryCache _cache;
+    private readonly ContentIndexNameResolver _indexNameResolver;
+    private readonly AlgoliaSearchCacheVersionProvider _searchCacheVersions;
+    private readonly ILogger<AlgoliaContentIndexExecutor> _logger;
+
+    public AlgoliaContentIndexExecutor(
+        ISearchClient client,
+        IOptions<AlgoliaOptions> options,
+        IContentService contentService,
+        ILocalizationService languageService,
+        PropertyEditorCollection propertyEditors,
+        IContentTypeService contentTypeService,
+        IPublishedUrlProvider urlProvider,
+        IUmbracoContextFactory umbracoContextFactory,
+        IScopeProvider scopeProvider,
+        IMemoryCache cache,
+        ContentIndexNameResolver indexNameResolver,
+        AlgoliaSearchCacheVersionProvider searchCacheVersions,
+        ILogger<AlgoliaContentIndexExecutor> logger,
+        IEnumerable<IAlgoliaContentEnricher>? enrichers = null,
+        IEnumerable<IAlgoliaContentPropertyValueConverter>? propertyConverters = null)
+    {
+        _client = client;
+        _options = options.Value;
+        _contentService = contentService;
+        _languageService = languageService;
+        _propertyEditors = propertyEditors;
+        _contentTypeService = contentTypeService;
+        _urlProvider = urlProvider;
+        _umbracoContextFactory = umbracoContextFactory;
+        _scopeProvider = scopeProvider;
+        _cache = cache;
+        _indexNameResolver = indexNameResolver;
+        _searchCacheVersions = searchCacheVersions;
+        _logger = logger;
+        _enrichers = (enrichers ?? []).OrderBy(x => x.Order).ToList();
+        _propertyConverters = (propertyConverters ?? []).OrderBy(x => x.Order).ToList();
+    }
+
+    public async Task HandleAsync(IReadOnlyCollection<AlgoliaContentIndexJob> jobs, CancellationToken ct)
+    {
+        if (jobs.Count == 0 || !_options.Enabled || !_options.ContentIndexing.Enabled)
+            return;
+
+        if (jobs.Any(x => x.Type == AlgoliaContentIndexJobType.Rebuild))
+        {
+            foreach (var indexName in jobs.Where(x => x.Type == AlgoliaContentIndexJobType.Rebuild).Select(x => x.IndexName).Distinct(StringComparer.OrdinalIgnoreCase))
+                await RebuildAsync(indexName, ct).ConfigureAwait(false);
+
+            return;
+        }
+
+        var upsertIds = jobs
+            .Where(x => x.Type == AlgoliaContentIndexJobType.Upsert)
+            .SelectMany(x => x.NodeIds)
+            .Distinct()
+            .ToArray();
+
+        var deleteKeys = jobs
+            .Where(x => x.Type == AlgoliaContentIndexJobType.Delete)
+            .SelectMany(x => x.NodeKeys)
+            .Distinct()
+            .ToArray();
+
+        if (upsertIds.Length > 0)
+            await UpdateByIdsAsync(upsertIds, ct).ConfigureAwait(false);
+
+        if (deleteKeys.Length > 0)
+            await DeleteByKeysAsync(deleteKeys, ct).ConfigureAwait(false);
+    }
+
+    private async Task RebuildAsync(string? indexName, CancellationToken ct)
+    {
+        var indexes = string.IsNullOrWhiteSpace(indexName)
+            ? _options.ContentIndexing.Indexes
+            : _options.ContentIndexing.Indexes.Where(x => x.IndexName.Equals(indexName, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var allCultures = await GetAllCulturesAsync().ConfigureAwait(false);
+        var contentTypes = await GetContentTypesAsync().ConfigureAwait(false);
+        var documentsByIndex = new Dictionary<string, List<AlgoliaContentRecord>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var index in indexes)
+        {
+            foreach (var contentTypeAlias in GetConfiguredAliases(index))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
+                var publishedContentType = ctx.UmbracoContext.Content?.GetContentType(contentTypeAlias);
+                if (publishedContentType is null)
+                    continue;
+
+                var entities = GetAllOfType(publishedContentType.Id);
+                var (upsertsByCulture, _) = BuildPerCultureBuckets(entities, allCultures);
+
+                foreach (var (culture, content) in upsertsByCulture)
+                {
+                    var resolvedIndexName = _indexNameResolver.Resolve(index.IndexName, culture);
+                    if (!documentsByIndex.TryGetValue(resolvedIndexName, out var documents))
+                    {
+                        documents = [];
+                        documentsByIndex[resolvedIndexName] = documents;
+                    }
+
+                    documents.AddRange(MapMany(content, culture, index, allCultures, contentTypes));
+                }
+            }
+        }
+
+        foreach (var (resolvedIndexName, documents) in documentsByIndex)
+        {
+            ct.ThrowIfCancellationRequested();
+            var batchSize = _options.ContentIndexing.BatchSize <= 0 ? 1000 : _options.ContentIndexing.BatchSize;
+            await _client.ReplaceAllObjectsAsync(resolvedIndexName, documents, batchSize, cancellationToken: ct).ConfigureAwait(false);
+            _logger.LogInformation("Rebuilt Algolia content index {IndexName} with {Count} documents.", resolvedIndexName, documents.Count);
+        }
+
+        _searchCacheVersions.InvalidateStore("content");
+    }
+
+    private async Task UpdateByIdsAsync(IReadOnlyCollection<int> nodeIds, CancellationToken ct)
+    {
+        var entities = _contentService.GetByIds(nodeIds).Where(x => !x.Trashed).ToList();
+        if (entities.Count == 0)
+            return;
+
+        var allCultures = await GetAllCulturesAsync().ConfigureAwait(false);
+        var contentTypes = await GetContentTypesAsync().ConfigureAwait(false);
+
+        foreach (var index in _options.ContentIndexing.Indexes)
+        {
+            var configuredAliases = GetConfiguredAliases(index);
+            var indexEntities = entities.Where(x => configuredAliases.Contains(x.ContentType.Alias)).DistinctBy(x => x.Id).ToList();
+            if (indexEntities.Count == 0)
+                continue;
+
+            var (upsertsByCulture, deletesByCulture) = BuildPerCultureBuckets(indexEntities, allCultures);
+
+            foreach (var (culture, content) in upsertsByCulture)
+            {
+                var documents = MapMany(content, culture, index, allCultures, contentTypes).ToList();
+                if (documents.Count == 0)
+                    continue;
+
+                var indexName = _indexNameResolver.Resolve(index.IndexName, culture);
+                await _client.SaveObjectsAsync(indexName, documents, batchSize: 1000, waitForTasks: true, cancellationToken: ct).ConfigureAwait(false);
+            }
+
+            foreach (var (culture, keys) in deletesByCulture)
+                await DeleteAsync(keys, culture, index, ct).ConfigureAwait(false);
+        }
+
+        _searchCacheVersions.InvalidateStore("content");
+    }
+
+    private async Task DeleteByKeysAsync(IReadOnlyCollection<Guid> keys, CancellationToken ct)
+    {
+        if (keys.Count == 0)
+            return;
+
+        var allCultures = await GetAllCulturesAsync().ConfigureAwait(false);
+        var objectIds = keys.Select(x => x.ToString()).ToArray();
+
+        foreach (var index in _options.ContentIndexing.Indexes)
+        {
+            foreach (var culture in allCultures)
+                await DeleteAsync(objectIds, culture, index, ct).ConfigureAwait(false);
+        }
+
+        _searchCacheVersions.InvalidateStore("content");
+    }
+
+    private async Task DeleteAsync(IEnumerable<string> objectIds, string culture, AlgoliaContentIndexOptions index, CancellationToken ct)
+    {
+        var ids = objectIds.ToArray();
+        if (ids.Length == 0 || string.IsNullOrWhiteSpace(culture))
+            return;
+
+        var indexName = _indexNameResolver.Resolve(index.IndexName, culture);
+        await _client.DeleteObjectsAsync(indexName, ids, batchSize: 1000, waitForTasks: false, cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    private List<IContent> GetAllOfType(int contentTypeId)
+    {
+        var entities = new List<IContent>();
+        const int pageSize = 250;
+        var page = 0;
+        long total;
+        var filter = new Query<IContent>(_scopeProvider.SqlContext).Where(x => !x.Trashed);
+
+        do
+        {
+            var pageItems = _contentService.GetPagedOfType(contentTypeId, page, pageSize, out total, filter).Where(x => !x.Trashed);
+            entities.AddRange(pageItems);
+            page++;
+        } while (entities.Count < total);
+
+        return entities;
+    }
+
+    private IEnumerable<AlgoliaContentRecord> MapMany(
+        IEnumerable<IContent> content,
+        string culture,
+        AlgoliaContentIndexOptions index,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypes)
+    {
+        foreach (var item in content)
+        {
+            var allowedProperties = GetAllowedProperties(index, item);
+            var record = MapAndEnrich(item, culture, index.IndexName, allowedProperties, availableCultures, contentTypes);
+            if (record is not null)
+                yield return record;
+        }
+    }
+
+    private AlgoliaContentRecord? MapAndEnrich(
+        IContent content,
+        string? culture,
+        string baseIndexName,
+        Dictionary<string, AlgoliaContentFieldTransform> allowedProperties,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypes)
+    {
+        var record = Map(content, culture, baseIndexName, allowedProperties, availableCultures, contentTypes);
+        if (record is null)
+            return null;
+
+        var ctx = new AlgoliaContentEnrichmentContext(content, culture, baseIndexName, allowedProperties);
+        foreach (var enricher in _enrichers)
+            enricher.Enrich(record, ctx);
+
+        record.RemoveReservedFields();
+        return record;
+    }
+
+    private AlgoliaContentRecord? Map(
+        IContent content,
+        string? culture,
+        string baseIndexName,
+        Dictionary<string, AlgoliaContentFieldTransform> allowedProperties,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypes)
+    {
+        using var contextReference = _umbracoContextFactory.EnsureUmbracoContext();
+        var variesByCulture = content.ContentType.Variations.VariesByCulture();
+        var name = variesByCulture && culture != null ? content.GetCultureName(culture) ?? string.Empty : content.Name ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        var url = variesByCulture && culture != null ? _urlProvider.GetUrl(content.Id, culture: culture) : _urlProvider.GetUrl(content.Id);
+        var record = new AlgoliaContentRecord
+        {
+            ObjectID = content.Key.ToString(),
+            NodeId = content.Id,
+            ContentTypeAlias = content.ContentType.Alias,
+            Url = url,
+            Name = name,
+            UpdateDate = content.UpdateDate,
+            CreateDate = content.CreateDate,
+            Data = new Dictionary<string, object>()
+        };
+
+        foreach (var (alias, transform) in allowedProperties)
+        {
+            var property = content.Properties.FirstOrDefault(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+            if (property is null)
+                continue;
+
+            var propertyCulture = property.PropertyType.Variations.VariesByCulture() ? culture : null;
+            var value = ReadPropertyValue(property, propertyCulture, availableCultures, contentTypes);
+            var converted = ConvertProperty(new AlgoliaContentPropertyContext(content, property, propertyCulture, culture, baseIndexName), value);
+
+            if (!HasIndexableValue(converted))
+                continue;
+
+            record.TryAddField(alias, converted!);
+
+            var unixValue = transform switch
+            {
+                AlgoliaContentFieldTransform.UnixSeconds => TryToUnix(converted, unixMilliseconds: false),
+                AlgoliaContentFieldTransform.UnixMilliseconds => TryToUnix(converted, unixMilliseconds: true),
+                _ => null
+            };
+
+            if (unixValue is not null)
+                record.TryAddField($"{alias}Unix", unixValue);
+        }
+
+        return record;
+    }
+
+    private object? ConvertProperty(AlgoliaContentPropertyContext ctx, object? value)
+    {
+        foreach (var converter in _propertyConverters)
+        {
+            if (converter.CanHandle(ctx))
+                value = converter.Convert(ctx, value);
+        }
+
+        return value;
+    }
+
+    private object? ReadPropertyValue(
+        IProperty property,
+        string? culture,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypes)
+    {
+        var propertyEditor = _propertyEditors.FirstOrDefault(x => x.Alias == property.PropertyType.PropertyEditorAlias);
+        if (propertyEditor is null)
+            return null;
+
+        var indexValues = propertyEditor.PropertyIndexValueFactory.GetIndexValues(property, culture, null, true, availableCultures, contentTypes);
+        return indexValues?.FirstOrDefault().Value.FirstOrDefault()?.ToString() ?? string.Empty;
+    }
+
+    private Dictionary<string, AlgoliaContentFieldTransform> GetAllowedProperties(AlgoliaContentIndexOptions index, IContent content)
+    {
+        var configured = index.ContentTypes
+            .FirstOrDefault(x => x.Alias.Equals(content.ContentType.Alias, StringComparison.OrdinalIgnoreCase))
+            ?.Properties
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(ParseConfiguredField)
+            .Where(x => !string.IsNullOrWhiteSpace(x.Alias))
+            .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.Last().Transform, StringComparer.OrdinalIgnoreCase);
+
+        if (configured is not null && configured.Count > 0)
+            return configured;
+
+        return content.Properties
+            .Select(x => x.Alias)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x, _ => AlgoliaContentFieldTransform.None, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static HashSet<string> GetConfiguredAliases(AlgoliaContentIndexOptions index)
+        => index.ContentTypes
+            .Select(x => x.Alias)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static (Dictionary<string, List<IContent>> UpsertsByCulture, Dictionary<string, HashSet<string>> DeletesByCulture) BuildPerCultureBuckets(
+        IEnumerable<IContent> entities,
+        IEnumerable<string> allCultures)
+    {
+        var upserts = new Dictionary<string, List<IContent>>(StringComparer.OrdinalIgnoreCase);
+        var deletes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entity in entities)
+        {
+            if (entity.ContentType.Variations.VariesByCulture())
+            {
+                var cultures = entity.CultureInfos?.Values.Select(x => x.Culture).Where(x => !string.IsNullOrWhiteSpace(x)) ?? [];
+                foreach (var culture in cultures)
+                {
+                    if (entity.IsCulturePublished(culture))
+                        AddList(upserts, culture, entity);
+                    else
+                        AddSet(deletes, culture, entity.Key.ToString());
+                }
+            }
+            else
+            {
+                foreach (var culture in allCultures.Where(x => !string.IsNullOrWhiteSpace(x)))
+                {
+                    if (entity.Published)
+                        AddList(upserts, culture, entity);
+                    else
+                        AddSet(deletes, culture, entity.Key.ToString());
+                }
+            }
+        }
+
+        return (upserts, deletes);
+
+        static void AddList(Dictionary<string, List<IContent>> dict, string culture, IContent content)
+        {
+            if (!dict.TryGetValue(culture, out var list))
+            {
+                list = [];
+                dict[culture] = list;
+            }
+
+            list.Add(content);
+        }
+
+        static void AddSet(Dictionary<string, HashSet<string>> dict, string culture, string key)
+        {
+            if (!dict.TryGetValue(culture, out var set))
+            {
+                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                dict[culture] = set;
+            }
+
+            set.Add(key);
+        }
+    }
+
+    private async Task<string[]> GetAllCulturesAsync()
+        => await _cache.GetOrCreateAsync("algolia:content:languages", entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+            var cultures = _languageService.GetAllLanguages().Select(x => x.IsoCode).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+            return Task.FromResult<string[]?>(cultures);
+        }).ConfigureAwait(false) ?? [];
+
+    private Task<Dictionary<Guid, IContentType>> GetContentTypesAsync()
+        => _cache.GetOrCreateAsync("algolia:content:contenttypes", entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+            return Task.FromResult(_contentTypeService.GetAll().ToDictionary(x => x.Key));
+        })!;
+
+    private static bool HasIndexableValue(object? value)
+        => value switch
+        {
+            null => false,
+            string text => !string.IsNullOrWhiteSpace(text),
+            _ => true
+        };
+
+    private static (string Alias, AlgoliaContentFieldTransform Transform) ParseConfiguredField(string raw)
+    {
+        var parts = raw.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+            return (string.Empty, AlgoliaContentFieldTransform.None);
+
+        var transform = parts.Length < 2
+            ? AlgoliaContentFieldTransform.None
+            : parts[1].ToLowerInvariant() switch
+            {
+                "unix" => AlgoliaContentFieldTransform.UnixSeconds,
+                "unixms" => AlgoliaContentFieldTransform.UnixMilliseconds,
+                _ => AlgoliaContentFieldTransform.None
+            };
+
+        return (parts[0], transform);
+    }
+
+    private static object? TryToUnix(object? value, bool unixMilliseconds)
+    {
+        if (value is null)
+            return null;
+
+        DateTimeOffset dto;
+        switch (value)
+        {
+            case DateTimeOffset dateTimeOffset:
+                dto = dateTimeOffset;
+                break;
+            case DateTime dateTime:
+                dto = dateTime.Kind switch
+                {
+                    DateTimeKind.Utc => new DateTimeOffset(dateTime, TimeSpan.Zero),
+                    DateTimeKind.Local => new DateTimeOffset(dateTime),
+                    _ => new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Local))
+                };
+                break;
+            case string text when !string.IsNullOrWhiteSpace(text):
+                if (!DateTimeOffset.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out dto) && !DateTimeOffset.TryParse(text, out dto))
+                    return null;
+                break;
+            default:
+                return null;
+        }
+
+        return unixMilliseconds ? dto.ToUnixTimeMilliseconds() : dto.ToUnixTimeSeconds();
+    }
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexJob.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexJob.cs
@@ -1,0 +1,14 @@
+namespace Ekom.Algolia.Indexing;
+
+internal sealed record AlgoliaContentIndexJob(
+    AlgoliaContentIndexJobType Type,
+    IReadOnlyCollection<int> NodeIds,
+    IReadOnlyCollection<Guid> NodeKeys,
+    string? IndexName = null);
+
+internal enum AlgoliaContentIndexJobType
+{
+    Upsert,
+    Delete,
+    Rebuild
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexQueue.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexQueue.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Threading.Channels;
+
+namespace Ekom.Algolia.Indexing;
+
+internal interface IAlgoliaContentIndexQueue
+{
+    ChannelReader<AlgoliaContentIndexJob> Reader { get; }
+    bool TryEnqueue(AlgoliaContentIndexJob job);
+    ValueTask EnqueueAsync(AlgoliaContentIndexJob job, CancellationToken ct = default);
+}
+
+internal sealed class AlgoliaContentIndexQueue : IAlgoliaContentIndexQueue
+{
+    private readonly Channel<AlgoliaContentIndexJob> _channel;
+    private readonly ILogger<AlgoliaContentIndexQueue> _logger;
+
+    public AlgoliaContentIndexQueue(
+        ILogger<AlgoliaContentIndexQueue> logger,
+        IOptions<AlgoliaOptions> options)
+    {
+        _logger = logger;
+        var capacity = options.Value.ContentIndexing.Dispatching.MaxQueueSize <= 0
+            ? 10_000
+            : options.Value.ContentIndexing.Dispatching.MaxQueueSize;
+
+        _channel = Channel.CreateBounded<AlgoliaContentIndexJob>(new BoundedChannelOptions(capacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait
+        });
+    }
+
+    public ChannelReader<AlgoliaContentIndexJob> Reader => _channel.Reader;
+
+    public bool TryEnqueue(AlgoliaContentIndexJob job)
+    {
+        var accepted = _channel.Writer.TryWrite(job);
+        if (!accepted)
+            _logger.LogWarning("Algolia content index queue full. Dropped {Type} job with {Count} nodes.", job.Type, job.NodeIds.Count + job.NodeKeys.Count);
+
+        return accepted;
+    }
+
+    public ValueTask EnqueueAsync(AlgoliaContentIndexJob job, CancellationToken ct = default)
+        => _channel.Writer.WriteAsync(job, ct);
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexQueue.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexQueue.cs
@@ -39,8 +39,7 @@ internal sealed class AlgoliaContentIndexQueue : IAlgoliaContentIndexQueue
     {
         var accepted = _channel.Writer.TryWrite(job);
         if (!accepted)
-            _logger.LogWarning("Algolia content index queue full. Dropped {Type} job with {Count} nodes.", job.Type, job.NodeIds.Count + job.NodeKeys.Count);
-
+            _logger.LogWarning("Algolia content index queue full. TryEnqueue failed for {Type} job with {Count} nodes.", job.Type, job.NodeIds.Count + job.NodeKeys.Count);
         return accepted;
     }
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexService.cs
@@ -1,0 +1,45 @@
+namespace Ekom.Algolia.Indexing;
+
+public interface IAlgoliaContentIndexService
+{
+    Task UpdateByIdsAsync(IReadOnlyCollection<int> nodeIds, CancellationToken ct = default);
+    Task DeleteByKeysAsync(IReadOnlyCollection<Guid> nodeKeys, CancellationToken ct = default);
+    Task RebuildAsync(string? indexName = null, CancellationToken ct = default);
+}
+
+internal sealed class AlgoliaContentIndexService : IAlgoliaContentIndexService
+{
+    private readonly IAlgoliaContentIndexQueue _queue;
+
+    public AlgoliaContentIndexService(IAlgoliaContentIndexQueue queue)
+    {
+        _queue = queue;
+    }
+
+    public Task UpdateByIdsAsync(IReadOnlyCollection<int> nodeIds, CancellationToken ct = default)
+    {
+        if (nodeIds.Count == 0)
+            return Task.CompletedTask;
+
+        return EnqueueAsync(new AlgoliaContentIndexJob(AlgoliaContentIndexJobType.Upsert, nodeIds, []), ct);
+    }
+
+    public Task DeleteByKeysAsync(IReadOnlyCollection<Guid> nodeKeys, CancellationToken ct = default)
+    {
+        if (nodeKeys.Count == 0)
+            return Task.CompletedTask;
+
+        return EnqueueAsync(new AlgoliaContentIndexJob(AlgoliaContentIndexJobType.Delete, [], nodeKeys), ct);
+    }
+
+    public Task RebuildAsync(string? indexName = null, CancellationToken ct = default)
+        => EnqueueAsync(new AlgoliaContentIndexJob(AlgoliaContentIndexJobType.Rebuild, [], [], indexName), ct);
+
+    private async Task EnqueueAsync(AlgoliaContentIndexJob job, CancellationToken ct)
+    {
+        if (_queue.TryEnqueue(job))
+            return;
+
+        await _queue.EnqueueAsync(job, ct).ConfigureAwait(false);
+    }
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexWorker.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexWorker.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Ekom.Algolia.Indexing;
+
+internal sealed class AlgoliaContentIndexWorker : BackgroundService
+{
+    private readonly IAlgoliaContentIndexQueue _queue;
+    private readonly AlgoliaDispatcherOptions _dispatch;
+    private readonly AlgoliaContentIndexExecutor _executor;
+    private readonly ILogger<AlgoliaContentIndexWorker> _logger;
+
+    public AlgoliaContentIndexWorker(
+        IAlgoliaContentIndexQueue queue,
+        IOptions<AlgoliaOptions> options,
+        AlgoliaContentIndexExecutor executor,
+        ILogger<AlgoliaContentIndexWorker> logger)
+    {
+        _queue = queue;
+        _dispatch = options.Value.ContentIndexing.Dispatching;
+        _executor = executor;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var flushDelay = TimeSpan.FromSeconds(Math.Max(1, _dispatch.FlushIntervalSeconds));
+        var maxBatch = _dispatch.MaxBatchSize <= 0 ? 100 : _dispatch.MaxBatchSize;
+
+        _logger.LogInformation("Algolia Content Indexer started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var hasItem = await _queue.Reader.WaitToReadAsync(stoppingToken).ConfigureAwait(false);
+                if (!hasItem)
+                    continue;
+
+                await Task.Delay(flushDelay, stoppingToken).ConfigureAwait(false);
+
+                var drained = Drain(maxBatch * 10);
+                foreach (var chunk in drained.Chunk(maxBatch))
+                    await _executor.HandleAsync(chunk, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Algolia Content Indexer loop crashed; retrying in 2 seconds.");
+                await Task.Delay(TimeSpan.FromSeconds(2), stoppingToken).ConfigureAwait(false);
+            }
+        }
+
+        _logger.LogInformation("Algolia Content Indexer stopped.");
+    }
+
+    private List<AlgoliaContentIndexJob> Drain(int maxDrain)
+    {
+        var list = new List<AlgoliaContentIndexJob>(Math.Min(maxDrain, 1024));
+        while (list.Count < maxDrain && _queue.Reader.TryRead(out var job))
+            list.Add(job);
+
+        return list;
+    }
+}

--- a/Plugins/Ekom.Algolia/Mappers/AlgoliaContentMappingContracts.cs
+++ b/Plugins/Ekom.Algolia/Mappers/AlgoliaContentMappingContracts.cs
@@ -1,0 +1,30 @@
+using Ekom.Algolia.Models.Indexing;
+using Umbraco.Cms.Core.Models;
+
+namespace Ekom.Algolia.Mappers;
+
+public sealed record AlgoliaContentEnrichmentContext(
+    IContent Content,
+    string? Culture,
+    string BaseIndexName,
+    IReadOnlyDictionary<string, AlgoliaContentFieldTransform>? AllowedPropertyAliases);
+
+public interface IAlgoliaContentEnricher
+{
+    void Enrich(AlgoliaContentRecord record, AlgoliaContentEnrichmentContext ctx);
+    int Order => 0;
+}
+
+public sealed record AlgoliaContentPropertyContext(
+    IContent Content,
+    IProperty Property,
+    string? PropertyCulture,
+    string? TargetCulture,
+    string BaseIndexName);
+
+public interface IAlgoliaContentPropertyValueConverter
+{
+    bool CanHandle(AlgoliaContentPropertyContext ctx);
+    object? Convert(AlgoliaContentPropertyContext ctx, object? source);
+    int Order => 0;
+}

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaContentRecord.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaContentRecord.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace Ekom.Algolia.Models.Indexing;
+
+public sealed class AlgoliaContentRecord
+{
+    private static readonly HashSet<string> ReservedFieldNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "objectID",
+        "nodeId",
+        "contentTypeAlias",
+        "url",
+        "name",
+        "updateDate",
+        "updateDateUnixSecond",
+        "createDate",
+        "createDateUnixSecond"
+    };
+
+    public required string ObjectID { get; set; }
+    public required int NodeId { get; set; }
+    public required string ContentTypeAlias { get; set; }
+    public required string Url { get; set; }
+    public required string Name { get; set; }
+    public required DateTime UpdateDate { get; set; }
+    public long UpdateDateUnixSecond => new DateTimeOffset(UpdateDate).ToUnixTimeSeconds();
+    public required DateTime CreateDate { get; set; }
+    public long CreateDateUnixSecond => new DateTimeOffset(CreateDate).ToUnixTimeSeconds();
+
+    [JsonExtensionData]
+    public IDictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
+
+    public bool TryAddField(string fieldName, object value)
+    {
+        if (string.IsNullOrWhiteSpace(fieldName) || ReservedFieldNames.Contains(fieldName))
+            return false;
+
+        Data[fieldName] = value;
+        return true;
+    }
+
+    public void RemoveReservedFields()
+    {
+        foreach (var fieldName in ReservedFieldNames)
+            Data.Remove(fieldName);
+    }
+}

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaInt32Converter.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaInt32Converter.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ekom.Algolia.Models.Indexing;
+
+internal sealed class AlgoliaInt32Converter : JsonConverter<int>
+{
+    public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Number => reader.GetInt32(),
+            JsonTokenType.True => 1,
+            JsonTokenType.False => 0,
+            JsonTokenType.String => ReadString(reader.GetString()),
+            _ => 0
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+        => writer.WriteNumberValue(value);
+
+    private static int ReadString(string? value)
+    {
+        if (int.TryParse(value, out var intValue))
+            return intValue;
+
+        if (bool.TryParse(value, out var boolValue))
+            return boolValue ? 1 : 0;
+
+        return 0;
+    }
+}

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
@@ -43,6 +43,7 @@ public sealed class AlgoliaProductRecord
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Currency { get; init; }
 
+    [JsonConverter(typeof(AlgoliaInt32Converter))]
     public int Available { get; init; }
 
     public int ProductRanking { get; init; }

--- a/Plugins/Ekom.Algolia/Models/Search/AlgoliaContentSearchRequest.cs
+++ b/Plugins/Ekom.Algolia/Models/Search/AlgoliaContentSearchRequest.cs
@@ -1,0 +1,11 @@
+using Algolia.Search.Models.Search;
+
+namespace Ekom.Algolia.Models.Search;
+
+public sealed class AlgoliaContentSearchRequest
+{
+    public required string IndexName { get; init; }
+    public required string Culture { get; init; }
+    public bool BypassCache { get; init; }
+    public required SearchForHits Query { get; init; }
+}

--- a/Plugins/Ekom.Algolia/Models/Search/AlgoliaFederatedSearchRequest.cs
+++ b/Plugins/Ekom.Algolia/Models/Search/AlgoliaFederatedSearchRequest.cs
@@ -1,0 +1,38 @@
+using Algolia.Search.Models.Search;
+using Ekom.Algolia.Models.Indexing;
+
+namespace Ekom.Algolia.Models.Search;
+
+public sealed class AlgoliaFederatedSearchRequest
+{
+    public required string StoreAlias { get; init; }
+    public string? Locale { get; init; }
+    public string? Currency { get; init; }
+    public bool BypassCache { get; init; }
+    public IReadOnlyCollection<AlgoliaFederatedSearchTarget> Targets { get; init; } = [];
+}
+
+public sealed class AlgoliaFederatedSearchTarget
+{
+    public required string Key { get; init; }
+    public AlgoliaFederatedSearchTargetKind Kind { get; init; }
+    public required SearchForHits Query { get; init; }
+    public string? ContentIndexName { get; init; }
+    public string? Culture { get; init; }
+}
+
+public enum AlgoliaFederatedSearchTargetKind
+{
+    Products,
+    Categories,
+    QuerySuggestions,
+    Content
+}
+
+public sealed class AlgoliaFederatedSearchResponse
+{
+    public AlgoliaSearchResponse<AlgoliaQuerySuggestionRecord>? Suggestions { get; init; }
+    public AlgoliaSearchResponse<AlgoliaProductRecord>? Products { get; init; }
+    public AlgoliaSearchResponse<AlgoliaCategoryRecord>? Categories { get; init; }
+    public IReadOnlyDictionary<string, AlgoliaSearchResponse<AlgoliaContentRecord>> Content { get; init; } = new Dictionary<string, AlgoliaSearchResponse<AlgoliaContentRecord>>();
+}

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -8,8 +8,10 @@ Algolia integration plugin for Ekom (Umbraco).
 ## Features
 - Product indexing with background queue/worker.
 - Category indexing with background queue/worker.
+- Standard Umbraco content indexing with background queue/worker.
 - Product search service with Algolia SDK `SearchForHits` requests.
 - Category search service with Algolia SDK `SearchForHits` requests.
+- Standard content search and federated multi-index search.
 - Algolia Insights events for view, add-to-cart, checkout, purchase.
 - In-memory search result caching with store-scoped invalidation after reindex/update/delete.
 - Index naming convention: `{primary|replica|query_suggestions}.ENVIRONMENT.STORE.ENTITY[_sorted_by_{asc|desc}_ATTRIBUTE][.Locale][.Currency]`.
@@ -96,6 +98,26 @@ public sealed class ProductSearchController
           "MaxConcurrency": 2
         }
       },
+      "ContentIndexing": {
+        "Enabled": true,
+        "EnforcePublisherOnly": true,
+        "BatchSize": 1000,
+        "Indexes": [
+          {
+            "IndexName": "SearchIndex",
+            "ContentTypes": [
+              {
+                "Alias": "article",
+                "Properties": [
+                  "title",
+                  "summary",
+                  "publishedAt|unix"
+                ]
+              }
+            ]
+          }
+        ]
+      },
       "Search": {
         "Enabled": true,
         "Products": true,
@@ -158,6 +180,11 @@ public sealed class ProductSearchController
 | `Indexing:Dispatching:FlushIntervalSeconds` | `int` | `2` | Worker delay between queue flushes. |
 | `Indexing:Dispatching:MaxQueueSize` | `int` | `10000` | Maximum in-memory queue size. |
 | `Indexing:Dispatching:MaxConcurrency` | `int` | `2` | Maximum indexing worker concurrency. |
+| `ContentIndexing:Enabled` | `bool` | `false` | Enables standard Umbraco content indexing. |
+| `ContentIndexing:BatchSize` | `int` | `1000` | Batch size for content index rebuild operations. |
+| `ContentIndexing:Indexes` | `object[]` | `[]` | Content indexes to maintain. Index names resolve as `{IndexName}.{Environment}.{Culture}`. |
+| `ContentIndexing:Indexes[*]:ContentTypes[*]:Alias` | `string` | required | Umbraco content type alias to include in the content index. |
+| `ContentIndexing:Indexes[*]:ContentTypes[*]:Properties` | `string[]` | `[]` | Property aliases to index. Use `|unix` or `|unixms` to add numeric date fields. |
 | `Search:Enabled` | `bool` | `true` | Enables Algolia search services. |
 | `Search:Products` | `bool` | `true` | Enables product search. |
 | `Search:Categories` | `bool` | `true` | Enables category search. |
@@ -192,6 +219,8 @@ public sealed class ProductSearchController
 - Set `AnalyticsRegion` to `us` or `eu` if you know your Algolia analytics region; if omitted, the plugin tries `us` and then `eu`.
 - `IAlgoliaSearchService.SearchProductsAsync(...)` returns hits together with paging metadata, query text, processing time, and raw facets.
 - `IAlgoliaSearchService.SearchCategoriesAsync(...)` searches a dedicated category index scoped by store alias and locale.
+- `IAlgoliaSearchService.SearchContentAsync(...)` searches configured standard content indexes. Content index names resolve as `{IndexName}.{Environment}.{Culture}`.
+- `IAlgoliaSearchService.FederatedSearchAsync(...)` executes products, categories, query suggestions, and content searches in one Algolia multi-search request and returns typed product/category/suggestion results plus keyed content results.
 - The plugin always resolves and sets the Algolia index name from Ekom store alias, locale, and currency; callers should not set `IndexName` themselves.
 - Category indexes omit the currency suffix because category records are scoped by store alias and locale only.
 - Search cache keys include the resolved index name and serialized Algolia query payload so all SDK options affect caching.

--- a/Plugins/Ekom.Algolia/Services/AlgoliaSearchCacheKeyBuilder.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaSearchCacheKeyBuilder.cs
@@ -26,6 +26,23 @@ internal sealed class AlgoliaSearchCacheKeyBuilder
     public string BuildQuerySuggestionsKey(AlgoliaSearchRequest request, SearchForHits query, string indexName)
         => BuildKey("query-suggestions", request, query, indexName);
 
+    public string BuildContentKey(AlgoliaContentSearchRequest request, SearchForHits query, string indexName)
+    {
+        var payload = JsonSerializer.Serialize(query, JsonOptions);
+        var version = _cacheVersions.GetVersion("content");
+
+        var raw = string.Join(
+            '|',
+            "content",
+            version.ToString(),
+            request.IndexName.Trim().ToLowerInvariant(),
+            indexName.Trim().ToLowerInvariant(),
+            request.Culture.Trim().ToLowerInvariant(),
+            ComputeHash(payload));
+
+        return "algolia-search:" + raw;
+    }
+
     private string BuildKey(string entity, AlgoliaSearchRequest request, SearchForHits query, string indexName)
     {
         var payload = JsonSerializer.Serialize(query, JsonOptions);

--- a/Plugins/Ekom.Algolia/Services/AlgoliaSearchService.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaSearchService.cs
@@ -14,10 +14,14 @@ public interface IAlgoliaSearchService
     Task<AlgoliaSearchResponse<AlgoliaProductRecord>> SearchProductsAsync(AlgoliaSearchRequest request, CancellationToken ct = default);
     Task<AlgoliaSearchResponse<AlgoliaCategoryRecord>> SearchCategoriesAsync(AlgoliaSearchRequest request, CancellationToken ct = default);
     Task<AlgoliaSearchResponse<AlgoliaQuerySuggestionRecord>> SearchQuerySuggestionsAsync(AlgoliaSearchRequest request, CancellationToken ct = default);
+    Task<AlgoliaSearchResponse<AlgoliaContentRecord>> SearchContentAsync(AlgoliaContentSearchRequest request, CancellationToken ct = default);
+    Task<AlgoliaFederatedSearchResponse> FederatedSearchAsync(AlgoliaFederatedSearchRequest request, CancellationToken ct = default);
 }
 
 internal sealed class AlgoliaSearchService : IAlgoliaSearchService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     private const string ProductsEntity = "products";
     private const string CategoriesEntity = "categories";
     private const string QuerySuggestionsEntity = "products";
@@ -27,6 +31,7 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
     private readonly AlgoliaOptions _options;
     private readonly AlgoliaStoreResolver _storeResolver;
     private readonly IndexNameBuilder _indexNameBuilder;
+    private readonly ContentIndexNameResolver _contentIndexNameResolver;
     private readonly AlgoliaSearchCacheKeyBuilder _cacheKeyBuilder;
     private readonly IAlgoliaUserTokenProvider _userTokenProvider;
     private readonly ILogger<AlgoliaSearchService> _logger;
@@ -37,6 +42,7 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
         IOptions<AlgoliaOptions> options,
         AlgoliaStoreResolver storeResolver,
         IndexNameBuilder indexNameBuilder,
+        ContentIndexNameResolver contentIndexNameResolver,
         AlgoliaSearchCacheKeyBuilder cacheKeyBuilder,
         IAlgoliaUserTokenProvider userTokenProvider,
         ILogger<AlgoliaSearchService> logger)
@@ -46,6 +52,7 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
         _options = options.Value;
         _storeResolver = storeResolver;
         _indexNameBuilder = indexNameBuilder;
+        _contentIndexNameResolver = contentIndexNameResolver;
         _cacheKeyBuilder = cacheKeyBuilder;
         _userTokenProvider = userTokenProvider;
         _logger = logger;
@@ -237,8 +244,179 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
         return response;
     }
 
+    public async Task<AlgoliaSearchResponse<AlgoliaContentRecord>> SearchContentAsync(AlgoliaContentSearchRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.IndexName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Culture);
+        ArgumentNullException.ThrowIfNull(request.Query);
+
+        if (!_options.Enabled || !_options.Search.Enabled || !_options.ContentIndexing.Enabled)
+        {
+            _logger.LogDebug("Algolia content search skipped because search or content indexing is disabled. Index={IndexName}", request.IndexName);
+            return EmptyResponse<AlgoliaContentRecord>(request.Query.Query, request.Query.Page, request.Query.HitsPerPage);
+        }
+
+        var query = CloneQuery(request.Query);
+        var trimmedQuery = query.Query?.Trim();
+
+        if (_options.Search.MinimumQueryLength > 0 && string.IsNullOrWhiteSpace(trimmedQuery))
+            return EmptyResponse<AlgoliaContentRecord>(trimmedQuery, query.Page, query.HitsPerPage);
+
+        if (_options.Search.MinimumQueryLength > 0 && trimmedQuery!.Length < _options.Search.MinimumQueryLength)
+            return EmptyResponse<AlgoliaContentRecord>(trimmedQuery, query.Page, query.HitsPerPage);
+
+        var indexName = _contentIndexNameResolver.Resolve(request.IndexName, request.Culture);
+        query.IndexName = indexName;
+
+        if (_options.Search.MaxHitsPerPage > 0 && query.HitsPerPage > _options.Search.MaxHitsPerPage)
+            query.HitsPerPage = _options.Search.MaxHitsPerPage;
+
+        var userToken = PrepareUserTokenForCache(query);
+        var useCache = _options.Search.Cache.Enabled && !request.BypassCache;
+        var cacheKey = _cacheKeyBuilder.BuildContentKey(request, query, indexName);
+
+        if (useCache && _cache.TryGetValue(cacheKey, out AlgoliaSearchResponse<AlgoliaContentRecord>? cached) && cached is not null)
+        {
+            _logger.LogDebug("Algolia content search cache hit for index {IndexName}.", indexName);
+            return cached;
+        }
+
+        ApplyUserToken(query, userToken);
+
+        var response = await QueryAsync<AlgoliaContentRecord>(query, ct).ConfigureAwait(false);
+
+        if (!useCache)
+            return response;
+
+        if (response.Hits.Count == 0 && !_options.Search.Cache.CacheEmptyResults)
+            return response;
+
+        var ttlMinutes = _options.Search.Cache.DurationMinutes <= 0 ? 60 : _options.Search.Cache.DurationMinutes;
+        _cache.Set(cacheKey, response, TimeSpan.FromMinutes(ttlMinutes));
+
+        return response;
+    }
+
+    public async Task<AlgoliaFederatedSearchResponse> FederatedSearchAsync(AlgoliaFederatedSearchRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.StoreAlias);
+
+        if (request.Targets.Count == 0 || !_options.Enabled || !_options.Search.Enabled)
+            return new AlgoliaFederatedSearchResponse();
+
+        var store = _storeResolver.Resolve(request.StoreAlias);
+        var preparedTargets = new List<(AlgoliaFederatedSearchTarget Target, SearchForHits Query, string IndexName)>();
+
+        foreach (var target in request.Targets)
+        {
+            ct.ThrowIfCancellationRequested();
+            ArgumentException.ThrowIfNullOrWhiteSpace(target.Key);
+            ArgumentNullException.ThrowIfNull(target.Query);
+
+            if (!TryPrepareFederatedTarget(request, store, target, out var query, out var indexName))
+                continue;
+
+            preparedTargets.Add((target, query, indexName));
+        }
+
+        if (preparedTargets.Count == 0)
+            return new AlgoliaFederatedSearchResponse();
+
+        var response = await _queryClient.SearchAsync<Dictionary<string, object?>>(
+            new SearchMethodParams
+            {
+                Requests = preparedTargets.Select(x => new SearchQuery(x.Query)).ToList()
+            },
+            ct).ConfigureAwait(false);
+
+        AlgoliaSearchResponse<AlgoliaQuerySuggestionRecord>? suggestions = null;
+        AlgoliaSearchResponse<AlgoliaProductRecord>? products = null;
+        AlgoliaSearchResponse<AlgoliaCategoryRecord>? categories = null;
+        var content = new Dictionary<string, AlgoliaSearchResponse<AlgoliaContentRecord>>(StringComparer.OrdinalIgnoreCase);
+        var resultList = response.Results.Select(x => x.AsSearchResponse()).ToList();
+
+        for (var i = 0; i < preparedTargets.Count; i++)
+        {
+            var (target, query, _) = preparedTargets[i];
+            var result = i < resultList.Count ? resultList[i] : null;
+
+            switch (target.Kind)
+            {
+                case AlgoliaFederatedSearchTargetKind.QuerySuggestions:
+                    suggestions = result is null
+                        ? EmptyResponse<AlgoliaQuerySuggestionRecord>(query.Query, query.Page, query.HitsPerPage)
+                        : ToSearchResponse<AlgoliaQuerySuggestionRecord>(result);
+                    break;
+                case AlgoliaFederatedSearchTargetKind.Products:
+                    products = result is null
+                        ? EmptyResponse<AlgoliaProductRecord>(query.Query, query.Page, query.HitsPerPage)
+                        : ToSearchResponse<AlgoliaProductRecord>(result);
+                    break;
+                case AlgoliaFederatedSearchTargetKind.Categories:
+                    categories = result is null
+                        ? EmptyResponse<AlgoliaCategoryRecord>(query.Query, query.Page, query.HitsPerPage)
+                        : ToSearchResponse<AlgoliaCategoryRecord>(result);
+                    break;
+                case AlgoliaFederatedSearchTargetKind.Content:
+                    content[target.Key] = result is null
+                        ? EmptyResponse<AlgoliaContentRecord>(query.Query, query.Page, query.HitsPerPage)
+                        : ToSearchResponse<AlgoliaContentRecord>(result);
+                    break;
+            }
+        }
+
+        return new AlgoliaFederatedSearchResponse
+        {
+            Suggestions = suggestions,
+            Products = products,
+            Categories = categories,
+            Content = content
+        };
+    }
+
     private Task<AlgoliaSearchResponse<AlgoliaProductRecord>> QueryProductsAsync(SearchForHits query, CancellationToken ct)
         => QueryAsync<AlgoliaProductRecord>(query, ct);
+
+    private bool TryPrepareFederatedTarget(
+        AlgoliaFederatedSearchRequest request,
+        AlgoliaResolvedStore store,
+        AlgoliaFederatedSearchTarget target,
+        out SearchForHits query,
+        out string indexName)
+    {
+        query = CloneQuery(target.Query);
+        indexName = string.Empty;
+        var trimmedQuery = query.Query?.Trim();
+
+        if (_options.Search.MinimumQueryLength > 0 && string.IsNullOrWhiteSpace(trimmedQuery))
+            return false;
+
+        if (_options.Search.MinimumQueryLength > 0 && trimmedQuery!.Length < _options.Search.MinimumQueryLength)
+            return false;
+
+        if (_options.Search.MaxHitsPerPage > 0 && query.HitsPerPage > _options.Search.MaxHitsPerPage)
+            query.HitsPerPage = _options.Search.MaxHitsPerPage;
+
+        var contentCulture = target.Culture ?? request.Locale ?? store.Locale;
+        indexName = target.Kind switch
+        {
+            AlgoliaFederatedSearchTargetKind.Products when _options.Search.Products => _indexNameBuilder.BuildPrimary(ProductsEntity, store.WithSelection(request.Locale ?? store.Locale, request.Currency ?? store.Currency)),
+            AlgoliaFederatedSearchTargetKind.Categories when _options.Search.Categories => _indexNameBuilder.BuildPrimary(CategoriesEntity, store.WithSelection(request.Locale ?? store.Locale, currency: null), currencyOverride: string.Empty),
+            AlgoliaFederatedSearchTargetKind.QuerySuggestions when _options.Search.QuerySuggestions => _indexNameBuilder.BuildQuerySuggestions(QuerySuggestionsEntity, store.WithSelection(request.Locale ?? store.Locale, request.Currency ?? store.Currency)),
+            AlgoliaFederatedSearchTargetKind.Content when _options.ContentIndexing.Enabled && !string.IsNullOrWhiteSpace(target.ContentIndexName) && !string.IsNullOrWhiteSpace(contentCulture) => _contentIndexNameResolver.Resolve(target.ContentIndexName, contentCulture),
+            _ => string.Empty
+        };
+
+        if (string.IsNullOrWhiteSpace(indexName))
+            return false;
+
+        query.IndexName = indexName;
+        var userToken = PrepareUserTokenForCache(query);
+        ApplyUserToken(query, userToken);
+        return true;
+    }
 
     private string? PrepareUserTokenForCache(SearchForHits query)
     {
@@ -304,6 +482,46 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
             Query = result.Query,
             Facets = ToFacets(result.Facets)
         };
+    }
+
+    private static AlgoliaSearchResponse<THit> ToSearchResponse<THit>(dynamic result)
+        where THit : class
+    {
+        var hits = new List<THit>();
+        if (result.Hits is not null)
+        {
+            foreach (var hit in result.Hits)
+            {
+                var mapped = MapHit<THit>(hit);
+                if (mapped is not null)
+                    hits.Add(mapped);
+            }
+        }
+
+        return new AlgoliaSearchResponse<THit>
+        {
+            Hits = hits,
+            Page = result.Page ?? 0,
+            HitsPerPage = result.HitsPerPage ?? 0,
+            TotalHits = result.NbHits ?? 0,
+            TotalPages = result.NbPages ?? 0,
+            ProcessingTimeMs = result.ProcessingTimeMS ?? 0,
+            Query = result.Query,
+            Facets = ToFacets(result.Facets)
+        };
+    }
+
+    private static THit? MapHit<THit>(object hit)
+        where THit : class
+    {
+        if (hit is THit typedHit)
+            return typedHit;
+
+        if (hit is JsonElement element)
+            return element.Deserialize<THit>(JsonOptions);
+
+        var json = JsonSerializer.Serialize(hit, JsonOptions);
+        return JsonSerializer.Deserialize<THit>(json, JsonOptions);
     }
 
     private static AlgoliaSearchResponse<THit> EmptyResponse<THit>(string? query, int? page, int? hitsPerPage)

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -170,16 +170,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.76",
-        "contentHash": "UiDRepXvExOwRTxK189ykq7SKB6c+JHsbvsAjPbuU4rqByYXtyYdtyo4aBFlbLIiMIgcckrdeCroe4sT/n+YLw==",
+        "resolved": "0.2.74",
+        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.76"
+          "Ekom.Payments.Core": "0.2.74"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.76",
-        "contentHash": "u0cgpHZ7AySOIrukgNPZCTT2/d0XpQkzK9cBaZydVDFdaBmqH80eeAoUWAbggEG5SfdMVZ5FKwhnzyGdsq886Q==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -190,10 +190,10 @@
       },
       "Ekom.Payments.U10": {
         "type": "Transitive",
-        "resolved": "0.2.76",
-        "contentHash": "6H4WGRltop4xHGYbkoF3G7j+a03Vgrkg8NmnYuLzHJhVxd4eAGNGSNBF4JU6MQbYWXbBNLPp+71DetAEhZkXKA==",
+        "resolved": "0.2.74",
+        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.76",
+          "Ekom.Payments.AspNetCore": "0.2.74",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -3008,7 +3008,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.181, )"
+          "Ekom.Core": "[0.2.170, )"
         }
       },
       "ekom.common": {
@@ -3023,8 +3023,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.181, )",
-          "Ekom.Payments.Core": "[0.2.76, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
@@ -3039,8 +3039,8 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.181, )",
-          "Ekom.Payments.U10": "[0.2.76, )",
+          "Ekom.AspNetCore": "[0.2.170, )",
+          "Ekom.Payments.U10": "[0.2.74, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",
           "Umbraco.Cms.Web.BackOffice": "[13.13.0, )",

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -170,16 +170,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.74",
-        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
+        "resolved": "0.2.76",
+        "contentHash": "UiDRepXvExOwRTxK189ykq7SKB6c+JHsbvsAjPbuU4rqByYXtyYdtyo4aBFlbLIiMIgcckrdeCroe4sT/n+YLw==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.74"
+          "Ekom.Payments.Core": "0.2.76"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.74",
-        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
+        "resolved": "0.2.76",
+        "contentHash": "u0cgpHZ7AySOIrukgNPZCTT2/d0XpQkzK9cBaZydVDFdaBmqH80eeAoUWAbggEG5SfdMVZ5FKwhnzyGdsq886Q==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -190,10 +190,10 @@
       },
       "Ekom.Payments.U10": {
         "type": "Transitive",
-        "resolved": "0.2.74",
-        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
+        "resolved": "0.2.76",
+        "contentHash": "6H4WGRltop4xHGYbkoF3G7j+a03Vgrkg8NmnYuLzHJhVxd4eAGNGSNBF4JU6MQbYWXbBNLPp+71DetAEhZkXKA==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.74",
+          "Ekom.Payments.AspNetCore": "0.2.76",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -3008,7 +3008,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.170, )"
+          "Ekom.Core": "[0.2.181, )"
         }
       },
       "ekom.common": {
@@ -3023,8 +3023,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.170, )",
-          "Ekom.Payments.Core": "[0.2.74, )",
+          "Ekom.Common": "[0.2.181, )",
+          "Ekom.Payments.Core": "[0.2.76, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
@@ -3039,8 +3039,8 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.170, )",
-          "Ekom.Payments.U10": "[0.2.74, )",
+          "Ekom.AspNetCore": "[0.2.181, )",
+          "Ekom.Payments.U10": "[0.2.76, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",
           "Umbraco.Cms.Web.BackOffice": "[13.13.0, )",

--- a/Plugins/Ekom.Klaviyo/packages.lock.json
+++ b/Plugins/Ekom.Klaviyo/packages.lock.json
@@ -122,16 +122,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.76",
-        "contentHash": "UiDRepXvExOwRTxK189ykq7SKB6c+JHsbvsAjPbuU4rqByYXtyYdtyo4aBFlbLIiMIgcckrdeCroe4sT/n+YLw==",
+        "resolved": "0.2.74",
+        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.76"
+          "Ekom.Payments.Core": "0.2.74"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.76",
-        "contentHash": "u0cgpHZ7AySOIrukgNPZCTT2/d0XpQkzK9cBaZydVDFdaBmqH80eeAoUWAbggEG5SfdMVZ5FKwhnzyGdsq886Q==",
+        "resolved": "0.2.74",
+        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -142,10 +142,10 @@
       },
       "Ekom.Payments.U10": {
         "type": "Transitive",
-        "resolved": "0.2.76",
-        "contentHash": "6H4WGRltop4xHGYbkoF3G7j+a03Vgrkg8NmnYuLzHJhVxd4eAGNGSNBF4JU6MQbYWXbBNLPp+71DetAEhZkXKA==",
+        "resolved": "0.2.74",
+        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.76",
+          "Ekom.Payments.AspNetCore": "0.2.74",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -2878,7 +2878,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.181, )"
+          "Ekom.Core": "[0.2.170, )"
         }
       },
       "ekom.common": {
@@ -2893,8 +2893,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.181, )",
-          "Ekom.Payments.Core": "[0.2.76, )",
+          "Ekom.Common": "[0.2.170, )",
+          "Ekom.Payments.Core": "[0.2.74, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
@@ -2909,8 +2909,8 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.181, )",
-          "Ekom.Payments.U10": "[0.2.76, )",
+          "Ekom.AspNetCore": "[0.2.170, )",
+          "Ekom.Payments.U10": "[0.2.74, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",
           "Umbraco.Cms.Web.BackOffice": "[13.13.0, )",

--- a/Plugins/Ekom.Klaviyo/packages.lock.json
+++ b/Plugins/Ekom.Klaviyo/packages.lock.json
@@ -122,16 +122,16 @@
       },
       "Ekom.Payments.AspNetCore": {
         "type": "Transitive",
-        "resolved": "0.2.74",
-        "contentHash": "GXTZUawcVgp+/+/LLanqsPSfa1jqZ4sJsx7BAdh9kyg9KHMAbLdEtL+TpqHNhEqfC8dNCVOOS4l6ypMoScfycA==",
+        "resolved": "0.2.76",
+        "contentHash": "UiDRepXvExOwRTxK189ykq7SKB6c+JHsbvsAjPbuU4rqByYXtyYdtyo4aBFlbLIiMIgcckrdeCroe4sT/n+YLw==",
         "dependencies": {
-          "Ekom.Payments.Core": "0.2.74"
+          "Ekom.Payments.Core": "0.2.76"
         }
       },
       "Ekom.Payments.Core": {
         "type": "Transitive",
-        "resolved": "0.2.74",
-        "contentHash": "qbhnRiW2dNW7qtZBoDsOTdlUYCMLduT6/lrcmVGcS1eb7Os/nceGIFhUQT15DHOLtVVBMJVwOAyLho3FD531HA==",
+        "resolved": "0.2.76",
+        "contentHash": "u0cgpHZ7AySOIrukgNPZCTT2/d0XpQkzK9cBaZydVDFdaBmqH80eeAoUWAbggEG5SfdMVZ5FKwhnzyGdsq886Q==",
         "dependencies": {
           "Azure.Core": "1.51.0",
           "Azure.Identity": "1.17.1",
@@ -142,10 +142,10 @@
       },
       "Ekom.Payments.U10": {
         "type": "Transitive",
-        "resolved": "0.2.74",
-        "contentHash": "9mR5VttkbIslw44sFcL/4OrB6Pa7Ju6nSUeBcm6b8zNCO9fJQdjI0vT0fmI4hVP78iEJ/tHV2Yg7wh3BviCXTw==",
+        "resolved": "0.2.76",
+        "contentHash": "6H4WGRltop4xHGYbkoF3G7j+a03Vgrkg8NmnYuLzHJhVxd4eAGNGSNBF4JU6MQbYWXbBNLPp+71DetAEhZkXKA==",
         "dependencies": {
-          "Ekom.Payments.AspNetCore": "0.2.74",
+          "Ekom.Payments.AspNetCore": "0.2.76",
           "Umbraco.Cms.Core": "13.13.0",
           "Umbraco.Cms.Web.BackOffice": "13.13.0",
           "Umbraco.Cms.Web.Website": "13.13.0"
@@ -2878,7 +2878,7 @@
       "ekom.aspnetcore": {
         "type": "Project",
         "dependencies": {
-          "Ekom.Core": "[0.2.170, )"
+          "Ekom.Core": "[0.2.181, )"
         }
       },
       "ekom.common": {
@@ -2893,8 +2893,8 @@
         "dependencies": {
           "Azure.Identity": "[1.17.1, )",
           "CommonServiceLocator": "[2.0.7, )",
-          "Ekom.Common": "[0.2.170, )",
-          "Ekom.Payments.Core": "[0.2.74, )",
+          "Ekom.Common": "[0.2.181, )",
+          "Ekom.Payments.Core": "[0.2.76, )",
           "Hangfire": "[1.8.18, )",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "[8.0.11, )",
           "Microsoft.Data.SqlClient": "[6.1.2, )",
@@ -2909,8 +2909,8 @@
       "ekom.u10": {
         "type": "Project",
         "dependencies": {
-          "Ekom.AspNetCore": "[0.2.170, )",
-          "Ekom.Payments.U10": "[0.2.74, )",
+          "Ekom.AspNetCore": "[0.2.181, )",
+          "Ekom.Payments.U10": "[0.2.76, )",
           "Umbraco.Cms.Api.Common": "[13.13.0, )",
           "Umbraco.Cms.Core": "[13.13.0, )",
           "Umbraco.Cms.Web.BackOffice": "[13.13.0, )",

--- a/Samples/U10/Ekom.Site/Controllers/SearchController.cs
+++ b/Samples/U10/Ekom.Site/Controllers/SearchController.cs
@@ -185,7 +185,7 @@ public sealed class SearchController : ControllerBase
         if (string.IsNullOrWhiteSpace(request.StoreAlias))
             return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("Store alias is required."));
 
-        if (request.Targets.Count == 0)
+        if (request.Targets is null || request.Targets.Count == 0)
             return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("At least one search target is required."));
 
         foreach (var target in request.Targets)

--- a/Samples/U10/Ekom.Site/Controllers/SearchController.cs
+++ b/Samples/U10/Ekom.Site/Controllers/SearchController.cs
@@ -175,6 +175,34 @@ public sealed class SearchController : ControllerBase
             ct);
     }
 
+    [HttpPost("federated")]
+    public Task<ActionResult<AlgoliaFederatedSearchResponse>> SearchFederatedAsync(
+        [FromBody] AlgoliaFederatedSearchRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.StoreAlias))
+            return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("Store alias is required."));
+
+        if (request.Targets.Count == 0)
+            return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("At least one search target is required."));
+
+        foreach (var target in request.Targets)
+        {
+            if (string.IsNullOrWhiteSpace(target.Key))
+                return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("Each search target requires a key."));
+
+            if (target.Query is null)
+                return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("Each search target requires a query."));
+
+            if (target.Kind == AlgoliaFederatedSearchTargetKind.Content && string.IsNullOrWhiteSpace(target.ContentIndexName))
+                return Task.FromResult<ActionResult<AlgoliaFederatedSearchResponse>>(BadRequest("Content targets require a content index name."));
+        }
+
+        return SearchFederatedCoreAsync(request, ct);
+    }
+
     private async Task<ActionResult<AlgoliaSearchResponse<AlgoliaProductRecord>>> SearchCoreAsync(
         AlgoliaSearchRequest request,
         CancellationToken ct)
@@ -196,6 +224,14 @@ public sealed class SearchController : ControllerBase
         CancellationToken ct)
     {
         var response = await _algoliaSearchService.SearchQuerySuggestionsAsync(request, ct).ConfigureAwait(false);
+        return Ok(response);
+    }
+
+    private async Task<ActionResult<AlgoliaFederatedSearchResponse>> SearchFederatedCoreAsync(
+        AlgoliaFederatedSearchRequest request,
+        CancellationToken ct)
+    {
+        var response = await _algoliaSearchService.FederatedSearchAsync(request, ct).ConfigureAwait(false);
         return Ok(response);
     }
 }

--- a/Samples/U10/Ekom.Site/Views/Partials/ekom/sections/header.cshtml
+++ b/Samples/U10/Ekom.Site/Views/Partials/ekom/sections/header.cshtml
@@ -11,6 +11,7 @@
     var searchStoreAlias = currentStore?.Alias ?? "Store";
     var searchLocale = currentStore?.Culture?.Name ?? string.Empty;
     var searchCurrency = currentStore?.GetCurrentCurrency()?.CurrencyValue ?? currentStore?.Currency?.CurrencyValue ?? string.Empty;
+    var searchContentIndexName = "SearchIndex";
 }
 <!-- Top navigation -->
 <nav aria-label="Top" class="relative z-20 bg-white bg-opacity-90 backdrop-blur-xl backdrop-filter">
@@ -76,7 +77,7 @@
 
                 <div class="ml-4 hidden lg:block lg:w-full lg:max-w-md">
                     <div class="relative"
-                         x-data="searchAutocomplete('@searchStoreAlias', '@searchLocale', '@searchCurrency')"
+                         x-data="searchAutocomplete('@searchStoreAlias', '@searchLocale', '@searchCurrency', '@searchContentIndexName')"
                          @@click.outside="close()"
                          @@keydown.escape.window="close()">
                         <div class="relative">
@@ -84,7 +85,7 @@
                                    x-model="term"
                                    @@input="queueSearch()"
                                    @@focus="openPanel()"
-                                   placeholder="Search products"
+                                    placeholder="Search products, categories and content"
                                    class="w-full rounded-full border border-gray-200 bg-gray-50 py-2.5 pl-11 pr-4 text-sm text-gray-900 shadow-sm outline-none transition focus:border-gray-300 focus:bg-white focus:ring-2 focus:ring-indigo-100"
                                    autocomplete="off">
                             <svg class="pointer-events-none absolute left-3 top-2.5 h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -106,7 +107,7 @@
                                 <div class="px-4 py-3 text-sm text-gray-500">Searching...</div>
                             </template>
 
-                            <div class="max-h-[32rem] overflow-y-auto" x-show="!isLoading && (suggestions.length || products.length)">
+                            <div class="max-h-[32rem] overflow-y-auto" x-show="!isLoading && (suggestions.length || products.length || categories.length || contentResults.length)">
                                 <template x-if="suggestions.length">
                                     <div class="border-b border-gray-100 p-4">
                                         <div class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Suggestions</div>
@@ -122,8 +123,22 @@
                                     </div>
                                 </template>
 
+                                <template x-if="categories.length">
+                                    <div class="border-b border-gray-100 p-4">
+                                        <div class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Categories</div>
+                                        <div class="space-y-2">
+                                            <template x-for="category in categories" :key="category.objectId">
+                                                <a :href="category.url || '#'" class="block rounded-2xl border border-transparent p-2 transition hover:border-gray-200 hover:bg-gray-50">
+                                                    <div class="truncate text-sm font-semibold text-gray-900" x-text="category.title || category.name"></div>
+                                                    <div class="truncate text-sm text-gray-500" x-text="category.summary || 'Category result'"></div>
+                                                </a>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
+
                                 <template x-if="products.length">
-                                    <div class="p-4">
+                                    <div class="border-b border-gray-100 p-4">
                                         <div class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Products</div>
                                         <div class="space-y-3">
                                             <template x-for="product in products" :key="product.objectId">
@@ -144,6 +159,20 @@
                                                         <div class="font-semibold text-gray-900" x-text="formatPrice(product)"></div>
                                                         <div class="text-xs uppercase tracking-[0.2em] text-gray-400" x-text="product.available ? 'In stock' : 'View' "></div>
                                                     </div>
+                                                </a>
+                                            </template>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                <template x-if="contentResults.length">
+                                    <div class="p-4">
+                                        <div class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Content</div>
+                                        <div class="space-y-2">
+                                            <template x-for="content in contentResults" :key="content.objectId">
+                                                <a :href="content.url || '#'" class="block rounded-2xl border border-transparent p-2 transition hover:border-gray-200 hover:bg-gray-50">
+                                                    <div class="truncate text-sm font-semibold text-gray-900" x-text="content.name || content.title"></div>
+                                                    <div class="truncate text-sm text-gray-500" x-text="content.contentTypeAlias || 'Content result'"></div>
                                                 </a>
                                             </template>
                                         </div>
@@ -175,17 +204,20 @@
 </nav>
 
 <script>
-    function searchAutocomplete(storeAlias, locale, currency) {
+    function searchAutocomplete(storeAlias, locale, currency, contentIndexName) {
         return {
             storeAlias,
             locale,
             currency,
+            contentIndexName,
             term: '',
             suggestions: [],
             products: [],
+            categories: [],
+            contentResults: [],
             isLoading: false,
             isOpen: false,
-            message: 'Start typing to query suggestions and product matches.',
+            message: 'Start typing to search suggestions, products, categories and content.',
             debounceHandle: null,
 
             openPanel() {
@@ -206,8 +238,7 @@
                 const term = this.term.trim();
 
                 if (term.length < 2) {
-                    this.suggestions = [];
-                    this.products = [];
+                    this.clearResults();
                     this.isLoading = false;
                     this.message = 'Type at least 2 characters to search.';
                     return;
@@ -217,24 +248,83 @@
                 this.message = '';
 
                 try {
-                    const [suggestionsResponse, productsResponse] = await Promise.all([
-                        this.fetchJson('/ekom/search/suggestions', { query: term, hitsPerPage: 6 }),
-                        this.fetchJson('/ekom/search/products', { query: term, hitsPerPage: 4 })
-                    ]);
-
-                    this.suggestions = suggestionsResponse.hits || [];
-                    this.products = productsResponse.hits || [];
-                    this.message = this.suggestions.length || this.products.length
+                    const response = await this.fetchFederated(term);
+                    this.suggestions = this.hits(response.suggestions).map((hit) => this.normalizeSuggestion(hit));
+                    this.products = this.hits(response.products).map((hit) => this.normalizeProduct(hit));
+                    this.categories = this.hits(response.categories).map((hit) => this.normalizeCategory(hit));
+                    this.contentResults = this.contentHits(response.content).map((hit) => this.normalizeContent(hit));
+                    this.message = this.suggestions.length || this.products.length || this.categories.length || this.contentResults.length
                         ? ''
-                        : 'No suggestions or products matched that search.';
+                        : 'No suggestions, products, categories or content matched that search.';
                 } catch (error) {
                     console.error(error);
-                    this.suggestions = [];
-                    this.products = [];
+                    this.clearResults();
                     this.message = 'Search is unavailable right now.';
                 } finally {
                     this.isLoading = false;
                 }
+            },
+
+            async fetchFederated(term) {
+                const targets = [
+                    {
+                        key: 'suggestions',
+                        kind: 2,
+                        query: {
+                            query: term,
+                            hitsPerPage: 6
+                        }
+                    },
+                    {
+                        key: 'products',
+                        kind: 0,
+                        query: {
+                            query: term,
+                            hitsPerPage: 4
+                        }
+                    },
+                    {
+                        key: 'categories',
+                        kind: 1,
+                        query: {
+                            query: term,
+                            hitsPerPage: 4
+                        }
+                    }
+                ];
+
+                if (this.contentIndexName && this.locale) {
+                    targets.push({
+                        key: 'content',
+                        kind: 3,
+                        contentIndexName: this.contentIndexName,
+                        culture: this.locale,
+                        query: {
+                            query: term,
+                            hitsPerPage: 4
+                        }
+                    });
+                }
+
+                const response = await fetch('/ekom/search/federated', {
+                    method: 'POST',
+                    headers: {
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        storeAlias: this.storeAlias,
+                        locale: this.locale || null,
+                        currency: this.currency || null,
+                        targets
+                    })
+                });
+
+                if (!response.ok) {
+                    throw new Error('Federated search request failed.');
+                }
+
+                return await response.json();
             },
 
             async fetchJson(endpoint, params) {
@@ -266,6 +356,77 @@
                 }
 
                 return await response.json();
+            },
+
+            clearResults() {
+                this.suggestions = [];
+                this.products = [];
+                this.categories = [];
+                this.contentResults = [];
+            },
+
+            hits(result) {
+                return result && Array.isArray(result.hits) ? result.hits : [];
+            },
+
+            contentHits(content) {
+                if (!content) {
+                    return [];
+                }
+
+                return Object.values(content).flatMap((result) => this.hits(result));
+            },
+
+            get(hit, ...keys) {
+                for (const key of keys) {
+                    if (hit && hit[key] !== undefined && hit[key] !== null) {
+                        return hit[key];
+                    }
+                }
+
+                return null;
+            },
+
+            normalizeSuggestion(hit) {
+                return {
+                    objectId: this.get(hit, 'objectId', 'objectID'),
+                    query: this.get(hit, 'query') || ''
+                };
+            },
+
+            normalizeProduct(hit) {
+                return {
+                    objectId: this.get(hit, 'objectId', 'objectID'),
+                    title: this.get(hit, 'title', 'name') || '',
+                    summary: this.get(hit, 'summary'),
+                    sku: this.get(hit, 'sku'),
+                    url: this.get(hit, 'url'),
+                    imageUrl: this.get(hit, 'imageUrl'),
+                    priceWithVat: this.get(hit, 'priceWithVat'),
+                    price: this.get(hit, 'price'),
+                    currency: this.get(hit, 'currency'),
+                    available: this.get(hit, 'available')
+                };
+            },
+
+            normalizeCategory(hit) {
+                return {
+                    objectId: this.get(hit, 'objectId', 'objectID'),
+                    title: this.get(hit, 'title', 'name') || '',
+                    name: this.get(hit, 'name'),
+                    summary: this.get(hit, 'summary'),
+                    url: this.get(hit, 'url')
+                };
+            },
+
+            normalizeContent(hit) {
+                return {
+                    objectId: this.get(hit, 'objectId', 'objectID'),
+                    name: this.get(hit, 'name') || '',
+                    title: this.get(hit, 'title'),
+                    url: this.get(hit, 'url'),
+                    contentTypeAlias: this.get(hit, 'contentTypeAlias')
+                };
             },
 
             applySuggestion(query) {

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -15,21 +15,6 @@
         "umbracoDbDSN": "Server=THOR.intra.vettvangur.is;Initial Catalog=Ekom;Authentication=Active Directory Interactive;Encrypt=True;Trust Server Certificate=True",
         "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
     },
-    "Algolia": {
-        "ApplicationId": "keyvault",
-        "AdminApiKey": "keyvault",
-        "Indexes": [
-            {
-                "IndexName": "SearchIndex",
-                "ContentTypes": [
-                    {
-                        "Alias": "checkout",
-                        "Properties": [ "pageTitle", "content", "multipleContentPicker", "contentPicker", "images", "image", "imageNotVary", "textNoVary" ]
-                    }
-                ]
-            }
-        ]
-    },
     "Ekom": {
         "PerStoreStock": false,
         "ExamineSearchIndex": "ExternalIndex",
@@ -98,6 +83,7 @@
             "Indexing": {
                 "Enabled": true,
                 "Products": true,
+                "Categories": true,
                 "BatchSize": 1000,
                 "ProductProperties": [
                     "brand"
@@ -115,9 +101,36 @@
                     "MaxConcurrency": 2
                 }
             },
+            "ContentIndexing": {
+                "Enabled": true,
+                "EnforcePublisherOnly": true,
+                "BatchSize": 1000,
+                "Indexes": [
+                    {
+                        "IndexName": "SearchIndex",
+                        "ContentTypes": [
+                            {
+                                "Alias": "checkout",
+                                "Properties": [
+                                    "pageTitle",
+                                    "content"
+                                ]
+                            },
+                            {
+                                "Alias": "receipt",
+                                "Properties": [
+                                    "pageTitle",
+                                    "content"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
             "Search": {
                 "Enabled": true,
                 "Products": true,
+                "Categories": true,
                 "QuerySuggestions": true,
                 "MinimumQueryLength": 2,
                 "MaxHitsPerPage": 100,


### PR DESCRIPTION
## Summary
- Add Algolia federated search support across products, categories, query suggestions, and configured content indexes.
- Add content indexing/search models and sample-site federated autocomplete integration.
- Update plugin lock files for current Ekom and payment package dependencies.

## Test Plan
- Not run locally; PR created from the current branch state.
