### PR TITLE
fix(stock): apply buffer to non-variant products

### DIFF
--- a/Ekom/Ekom/API/Stock.cs
+++ b/Ekom/Ekom/API/Stock.cs
@@ -3,6 +3,7 @@ using Ekom.Exceptions;
 using Ekom.Models;
 using Ekom.Repositories;
 using Ekom.Services;
+using Ekom.Utilities;
 using Hangfire.States;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -151,6 +152,13 @@ public partial class Stock
                 continue;
             }
 
+            IProduct? product = await Catalog.Instance.GetProductAsync(orderLine.ProductKey, orderInfo.StoreInfo.Alias, raiseEvent: false, ct: ct);
+
+            if (product == null)
+            {
+                throw new ArgumentNullException(nameof(product));
+            }
+
             if (orderLine.Product.VariantGroups.Any())
             {
                 foreach (OrderedVariant? orderedVariant in orderLine.Product.VariantGroups.SelectMany(x => x.Variants))
@@ -162,7 +170,7 @@ public partial class Stock
                         throw new ArgumentNullException(nameof(variant));
                     }
 
-                    decimal variantStock = variant.Stock;
+                    decimal variantStock = StockBufferHelper.GetEffectiveStock(variant.Stock, product, variant);
 
                     if (variantStock < orderLine.Quantity)
                     {
@@ -176,14 +184,7 @@ public partial class Stock
             }
             else
             {
-                IProduct? product = await  Catalog.Instance.GetProductAsync(orderLine.ProductKey, orderInfo.StoreInfo.Alias, raiseEvent: false, ct: ct);
-
-                if (product == null)
-                {
-                    throw new ArgumentNullException(nameof(product));
-                }
-
-                decimal productStock = product.Stock;
+                decimal productStock = StockBufferHelper.GetEffectiveStock(product.Stock, product);
 
                 if (productStock < orderLine.Quantity)
                 {

--- a/Ekom/Ekom/Models/Product.cs
+++ b/Ekom/Ekom/Models/Product.cs
@@ -131,7 +131,7 @@ public class Product : PerStoreNodeEntity, IProduct
                 }
             }
 
-            return !hasVariants && Stock > 0;
+            return !hasVariants && StockBufferHelper.GetEffectiveStock(Stock, this) > 0;
         }
     }
 

--- a/Ekom/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom/Models/Variant.cs
@@ -76,7 +76,22 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     /// <summary>
     /// Get the availability of the variant
     /// </summary>
-    public virtual bool Available => Stock > 0 || Backorder;
+    public virtual bool Available
+    {
+        get
+        {
+            if (Backorder)
+            {
+                return true;
+            }
+
+            IProduct? product = Product;
+
+            return product != null
+                ? StockBufferHelper.GetEffectiveStock(Stock, product, this) > 0
+                : Stock - (StockBuffer ?? 0) > 0;
+        }
+    }
 
     /// <summary>
     /// Parent <see cref="IProduct"/> of Variant

--- a/Ekom/Ekom/Services/CheckoutService.cs
+++ b/Ekom/Ekom/Services/CheckoutService.cs
@@ -200,11 +200,26 @@ class CheckoutService
         {
             if (!line.Product.Backorder)
             {
+                IProduct? product = await Catalog.Instance.GetProductAsync(line.ProductKey, storeAlias, raiseEvent: false)
+                    .ConfigureAwait(false);
+
+                if (product == null)
+                {
+                    throw new ArgumentNullException(nameof(product));
+                }
+
                 if (line.Product.VariantGroups.Any())
                 {
                     foreach (OrderedVariant? variant in line.Product.VariantGroups.SelectMany(x => x.Variants))
                     {
-                        decimal variantStock = Stock.Instance.GetStock(variant.Key, storeAlias);
+                        IVariant? catalogVariant = Catalog.Instance.GetVariant(variant.Key, storeAlias);
+
+                        if (catalogVariant == null)
+                        {
+                            throw new ArgumentNullException(nameof(catalogVariant));
+                        }
+
+                        decimal variantStock = StockBufferHelper.GetEffectiveStock(Stock.Instance.GetStock(variant.Key, storeAlias), product, catalogVariant);
 
                         if (variantStock >= line.Quantity)
                         {
@@ -224,7 +239,7 @@ class CheckoutService
                 }
                 else
                 {
-                    decimal productStock = Stock.Instance.GetStock(line.ProductKey, storeAlias);
+                    decimal productStock = StockBufferHelper.GetEffectiveStock(Stock.Instance.GetStock(line.ProductKey, storeAlias), product);
 
                     if (productStock >= line.Quantity)
                     {

--- a/Ekom/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom/Services/OrderService.cs
@@ -2002,9 +2002,26 @@ partial class OrderService
             {
                 if (line.Product.VariantGroups.Any())
                 {
+                    IProduct? product = Catalog.Instance.GetProduct(line.ProductKey, orderInfo.StoreInfo.Alias, raiseEvent: false);
+
+                    if (product == null)
+                    {
+                        return false;
+                    }
+
                     foreach (OrderedVariant? variant in line.Product.VariantGroups.SelectMany(x => x.Variants))
                     {
-                        decimal variantStock = Stock.Instance.GetStock(variant.Key);
+                        IVariant? catalogVariant = Catalog.Instance.GetVariant(variant.Key, orderInfo.StoreInfo.Alias);
+
+                        if (catalogVariant == null)
+                        {
+                            return false;
+                        }
+
+                        decimal variantStock = StockBufferHelper.GetEffectiveStock(
+                            Stock.Instance.GetStock(variant.Key, orderInfo.StoreInfo.Alias),
+                            product,
+                            catalogVariant);
 
                         if (variantStock < line.Quantity)
                         {
@@ -2014,7 +2031,16 @@ partial class OrderService
                 }
                 else
                 {
-                    decimal productStock = Stock.Instance.GetStock(line.ProductKey);
+                    IProduct? product = Catalog.Instance.GetProduct(line.ProductKey, orderInfo.StoreInfo.Alias, raiseEvent: false);
+
+                    if (product == null)
+                    {
+                        return false;
+                    }
+
+                    decimal productStock = StockBufferHelper.GetEffectiveStock(
+                        Stock.Instance.GetStock(line.ProductKey, orderInfo.StoreInfo.Alias),
+                        product);
 
                     if (productStock < line.Quantity)
                     {
@@ -2029,17 +2055,8 @@ partial class OrderService
 
     private void VerifyStock(decimal quantity, decimal existingStock, IProduct product, IVariant? variant = null)
     {
-        var bufferStock =
-            GetConfiguredStockBuffer(variant?.StockBuffer)
-            ?? GetConfiguredStockBuffer(product.StockBuffer)
-            ?? product.CategoryAncestors?
-                .Select(c => GetConfiguredStockBuffer(c.StockBuffer))
-                .FirstOrDefault(x => x.HasValue)
-            ?? 0;
-
-        existingStock -= bufferStock;
-
-        existingStock = Math.Max(0, existingStock);
+        var bufferStock = StockBufferHelper.GetConfiguredStockBuffer(product, variant);
+        existingStock = StockBufferHelper.GetEffectiveStock(existingStock, product, variant);
 
         if (!_config.DisableStock
         && !product.Backorder
@@ -2048,11 +2065,6 @@ partial class OrderService
             throw new NotEnoughStockException(
                 $"Stock not available for product {product.Key} and variant {variant?.Key}. ExistingStock: {existingStock}. Quantity: {quantity} BufferStock: {bufferStock}");
         }
-    }
-
-    private static decimal? GetConfiguredStockBuffer(decimal? stockBuffer)
-    {
-        return stockBuffer is > 0 ? stockBuffer : null;
     }
 
     /// <summary>

--- a/Ekom/Ekom/Utilities/StockBufferHelper.cs
+++ b/Ekom/Ekom/Utilities/StockBufferHelper.cs
@@ -1,0 +1,28 @@
+using Ekom.Models;
+
+namespace Ekom.Utilities;
+
+internal static class StockBufferHelper
+{
+    public static decimal GetEffectiveStock(decimal stock, IProduct product, IVariant? variant = null)
+    {
+        var bufferStock = GetConfiguredStockBuffer(product, variant);
+
+        return Math.Max(0, stock - bufferStock);
+    }
+
+    public static decimal GetConfiguredStockBuffer(IProduct product, IVariant? variant = null)
+    {
+        return GetConfiguredStockBuffer(variant?.StockBuffer)
+            ?? GetConfiguredStockBuffer(product.StockBuffer)
+            ?? product.CategoryAncestors?
+                .Select(c => GetConfiguredStockBuffer(c.StockBuffer))
+                .FirstOrDefault(x => x.HasValue)
+            ?? 0;
+    }
+
+    private static decimal? GetConfiguredStockBuffer(decimal? stockBuffer)
+    {
+        return stockBuffer is > 0 ? stockBuffer : null;
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared stock buffer helper for effective stock calculations.
- Apply stock buffers to non-variant product availability and checkout validation.
- Keep variant, product, and category buffer precedence consistent across stock checks.

## Test Plan
- Ran `dotnet build "Ekom/Ekom/Ekom.csproj" --no-restore`.