### PR TITLE
fix(klaviyo): support separate image base URL

### DIFF
--- a/Plugins/Ekom.Klaviyo/Config/KlaviyoOptions.cs
+++ b/Plugins/Ekom.Klaviyo/Config/KlaviyoOptions.cs
@@ -20,6 +20,7 @@ public sealed class KlaviyoOptions
 
     public IReadOnlyCollection<KlaviyoStoreOptions> Stores { get; init; } = [];
     public required string SiteBaseUrl { get; init; } = "";
+    public string? ImageBaseUrl { get; init; }
     public bool Testing { get; init; } = false;
 }
 

--- a/Plugins/Ekom.Klaviyo/Controllers/KlaviyoBackofficeController.cs
+++ b/Plugins/Ekom.Klaviyo/Controllers/KlaviyoBackofficeController.cs
@@ -38,7 +38,7 @@ internal class KlaviyoBackofficeController : UmbracoAuthorizedApiController
 
             var productsResponse = await API.Catalog.Instance.GetAllProductsAsync(store.Alias,ct: ct);
 
-            var products = productsResponse.Products.ToKlaviyoCatalogItems(true, _opt.SiteBaseUrl).ToList();
+            var products = productsResponse.Products.ToKlaviyoCatalogItems(true, _opt.SiteBaseUrl, _opt.ImageBaseUrl).ToList();
 
             await _klaviyoClient.BulkCreateCatalogItemsAsync(products, store.Alias, ct);
 

--- a/Plugins/Ekom.Klaviyo/Dispatching/Catalog/KlaviyoCatalogDispatcher.cs
+++ b/Plugins/Ekom.Klaviyo/Dispatching/Catalog/KlaviyoCatalogDispatcher.cs
@@ -140,7 +140,7 @@ internal sealed class KlaviyoCatalogDispatcher : BackgroundService, IKlaviyoCata
                         }
                         else
                         {
-                            item = product?.ToKlaviyoCatalogItem(w.IsPublished, _opt.SiteBaseUrl);
+                            item = product?.ToKlaviyoCatalogItem(w.IsPublished, _opt.SiteBaseUrl, _opt.ImageBaseUrl);
                         }
 
                         if (item is null)

--- a/Plugins/Ekom.Klaviyo/Mappers/OrderLineMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/OrderLineMapper.cs
@@ -16,6 +16,7 @@ public static class OrderLineMapper
 
         var orderlineAmount = ol.Amount;
         var productPrice = ol.Product?.Price;
+        var imageBaseUrl = string.IsNullOrWhiteSpace(opt.ImageBaseUrl) ? opt.SiteBaseUrl : opt.ImageBaseUrl;
 
         var orderLine = new KlaviyoOrderLine
         {
@@ -37,7 +38,7 @@ public static class OrderLineMapper
             DiscountFormatted = ol.Amount.DiscountAmount.CurrencyString,
             Quantity = ol.Quantity,
             ProductUrl = string.IsNullOrWhiteSpace(ol.Product?.Url) ? null : UrlBuilder.Combine(opt.SiteBaseUrl, ol.Product.Url),
-            ImageUrl = string.IsNullOrWhiteSpace(ol.Product?.Images.FirstOrDefault()?.Url) ? null : UrlBuilder.Combine(opt.SiteBaseUrl, ol.Product.Images.FirstOrDefault()?.Url ?? ""),
+            ImageUrl = string.IsNullOrWhiteSpace(ol.Product?.Images.FirstOrDefault()?.Url) ? null : UrlBuilder.Combine(imageBaseUrl, ol.Product.Images.FirstOrDefault()?.Url ?? ""),
             Categories = categories
         };
 
@@ -47,7 +48,7 @@ public static class OrderLineMapper
             {
                 Sku = ol.Variant.SKU,
                 Name = ol.Variant.Title,
-                ImageUrl = string.IsNullOrWhiteSpace(ol.Variant?.Images.FirstOrDefault()?.Url) ? null : UrlBuilder.Combine(opt.SiteBaseUrl, ol.Variant.Images.FirstOrDefault()?.Url ?? ""),
+                ImageUrl = string.IsNullOrWhiteSpace(ol.Variant?.Images.FirstOrDefault()?.Url) ? null : UrlBuilder.Combine(imageBaseUrl, ol.Variant.Images.FirstOrDefault()?.Url ?? ""),
             };
         }
 

--- a/Plugins/Ekom.Klaviyo/Mappers/ProductFeedMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/ProductFeedMapper.cs
@@ -15,11 +15,12 @@ internal static class ProductFeedMapper
         var storeAlias = product.Store?.Alias;
         var language = NullIfWhiteSpace(culture) ?? product.Store?.Culture?.Name ?? "default";
         var link = UrlBuilder.Combine(options.SiteBaseUrl, product.Url);
+        var imageBaseUrl = string.IsNullOrWhiteSpace(options.ImageBaseUrl) ? options.SiteBaseUrl : options.ImageBaseUrl;
 
         var imageUrl = product.Images?.FirstOrDefault()?.Url;
         var imageLink = string.IsNullOrWhiteSpace(imageUrl)
             ? null
-            : UrlBuilder.Combine(options.SiteBaseUrl, imageUrl + options.Catalog.ImageCrop);
+            : UrlBuilder.Combine(imageBaseUrl, imageUrl + options.Catalog.ImageCrop);
 
         var price = options.Catalog.ShowPrice ? product.Price?.WithVat.Value : null;
         var vat = options.Catalog.ShowPrice ? product.Vat : (decimal?)null;

--- a/Plugins/Ekom.Klaviyo/Mappers/ProductMapper.cs
+++ b/Plugins/Ekom.Klaviyo/Mappers/ProductMapper.cs
@@ -6,8 +6,10 @@ namespace Ekom.Klaviyo.Mappers;
 
 public static class ProductMapper
 {
-    public static KlaviyoProductItem ToKlaviyoCatalogItem(this IProduct product, bool isPublished, string host)
+    public static KlaviyoProductItem ToKlaviyoCatalogItem(this IProduct product, bool isPublished, string host, string? imageHost = null)
     {
+        var effectiveImageHost = string.IsNullOrWhiteSpace(imageHost) ? host : imageHost;
+
         return new KlaviyoProductItem
         {
             Id = product.Key,
@@ -19,13 +21,13 @@ public static class ProductMapper
             Url = UrlBuilder.Combine(host, product.Url),
             Description = product.Description,
             Summary = product.Summary,
-            ImageFullUrl = UrlBuilder.Combine(host, product.Images.FirstOrDefault()?.Url ?? ""),
+            ImageFullUrl = UrlBuilder.Combine(effectiveImageHost, product.Images.FirstOrDefault()?.Url ?? ""),
             Published = isPublished,
         };
     }
 
-    public static IEnumerable<KlaviyoProductItem> ToKlaviyoCatalogItems(this IEnumerable<IProduct> products, bool isPublished, string host)
+    public static IEnumerable<KlaviyoProductItem> ToKlaviyoCatalogItems(this IEnumerable<IProduct> products, bool isPublished, string host, string? imageHost = null)
     {
-        return products.Select(x => x.ToKlaviyoCatalogItem(isPublished, host));
+        return products.Select(x => x.ToKlaviyoCatalogItem(isPublished, host, imageHost));
     }
 }

--- a/Plugins/Ekom.Klaviyo/README.md
+++ b/Plugins/Ekom.Klaviyo/README.md
@@ -24,6 +24,7 @@ The configuration is typically placed in `appsettings.json` or an environment-sp
   "Revision": "2026-01-15",
   "ProfileExternalIdProperty": "email",
   "SiteBaseUrl": "https://vettvangur.is",
+  "ImageBaseUrl": "https://images.vettvangur.is",
   "Testing": false,
   "Stores": [],
   "Orders": {},
@@ -41,6 +42,7 @@ The configuration is typically placed in `appsettings.json` or an environment-sp
 | `Revision` | `string` | Klaviyo API revision header (required). |
 | `ProfileExternalIdProperty` | `string` | Default Email property used as the external ID for profiles. Other options: , `phone`, `username`, any property on customer `customerExternalId` . |
 | `SiteBaseUrl` | `string` | Public site base URL used to generate product and checkout URLs. |
+| `ImageBaseUrl` | `string` | Optional public image base URL used to generate product image URLs. Falls back to `SiteBaseUrl` when empty. |
 | `Testing` | `bool` | If `true`, enables testing mode (Events will be sent to same event but with Test at the end. "Placed Order Test"). |
 | `Stores` | `array` | Optional per-store configuration. If empty the first store will be used. |
 | `Orders` | `object` | Orders tracking configuration. |
@@ -392,6 +394,7 @@ public sealed class ConsentAuditEnricher : IKlaviyoProfilesEnricher
   "ApiBaseUrl": "https://a.klaviyo.com",
   "Revision": "2023-10-15",
   "SiteBaseUrl": "https://example.com",
+  "ImageBaseUrl": "https://images.example.com",
   "Orders": {
     "Enabled": true,
     "TrackingPlacedOrders": true,


### PR DESCRIPTION
## Summary
- Add an optional `ImageBaseUrl` Klaviyo setting for product image URLs.
- Keep product and checkout links on `SiteBaseUrl` while allowing image links to use a separate domain.
- Fall back to `SiteBaseUrl` when `ImageBaseUrl` is not configured.
- Document the new setting in the Klaviyo README.

## Test Plan
- Ran `dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj"`.
- Confirmed the build succeeds; existing analyzer/package warnings remain.
