### PR TITLE
fix(klaviyo): resolve feed URLs by request culture

### DIFF
--- a/Ekom/Ekom.U10/Services/UrlService.cs
+++ b/Ekom/Ekom.U10/Services/UrlService.cs
@@ -3,6 +3,7 @@ using Ekom.Models.Umbraco;
 using Ekom.Services;
 using Ekom.Utilities;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System.Globalization;
@@ -335,7 +336,13 @@ class UrlService : IUrlService
         using var cref = _context.EnsureUmbracoContext();
         var pubReq = cref.UmbracoContext.PublishedRequest;
 
-        var culture = pubReq?.Culture ?? CultureInfo.CurrentCulture.Name;
+        var requestCulture = _httpContextAccessor.HttpContext?
+            .Features.Get<IRequestCultureFeature>()?
+            .RequestCulture
+            .Culture
+            .Name;
+
+        var culture = requestCulture ?? pubReq?.Culture ?? CultureInfo.CurrentCulture.Name;
         var uri = pubReq?.Domain?.Uri ?? CookieHelper.GetUmbracoDomain(_httpContextAccessor?.HttpContext?.Request.Cookies);
 
         var urlsWithContext = node.UrlsWithContext;

--- a/Plugins/Ekom.Klaviyo/Controllers/KlaviyoProductController.cs
+++ b/Plugins/Ekom.Klaviyo/Controllers/KlaviyoProductController.cs
@@ -112,6 +112,9 @@ internal class KlaviyoProductController : ControllerBase
                             },
                             ct);
 
+                        if (!HasProductLink(item))
+                            continue;
+
                         feed.Add(item);
                     }
                 }
@@ -289,6 +292,11 @@ internal class KlaviyoProductController : ControllerBase
     private static bool HasProductImage(IProduct product)
     {
         return !string.IsNullOrWhiteSpace(product.Images?.FirstOrDefault()?.Url);
+    }
+
+    private static bool HasProductLink(KlaviyoProductFeedItem item)
+    {
+        return !string.IsNullOrWhiteSpace(item.Link);
     }
 
     private bool IsAuthorized(HttpRequest request, string expectedUser, string expectedPassword)


### PR DESCRIPTION
## Summary
- Prefer the current request culture feature when resolving Ekom product URLs.
- Ensure Klaviyo product feed requests can resolve localized product links for cultures such as `is-IS`.
- Skip Klaviyo feed items when the resolved link is still blank after mapping and enrichment.

## Test Plan
- Ran `dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj"`.
- Confirmed the build succeeds; existing analyzer warnings remain.
