### PR TITLE
fix(ci): build Ekom packages before plugins

### DIFF
--- a/.github/workflows/publish-ekom-algolia.yml
+++ b/.github/workflows/publish-ekom-algolia.yml
@@ -23,11 +23,38 @@ jobs:
             8.0.x
             10.0.x
 
+      - name: Read Ekom package version
+        id: ekom-version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          [xml]$props = Get-Content "Ekom/Directory.Build.props"
+          $version = $props.Project.PropertyGroup.Version
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "Could not read Ekom package version." }
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Pack Ekom dependencies locally
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = "${{ steps.ekom-version.outputs.version }}"
+
+          if (Test-Path "local-packages") { Remove-Item "local-packages" -Recurse -Force }
+          New-Item -ItemType Directory -Force -Path local-packages | Out-Null
+
+          dotnet pack "Ekom/Ekom.Core/Ekom.Common/Ekom.Common.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Core/Ekom/Ekom.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Core/Ekom.AspNetCore/Ekom.AspNetCore.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+
+          dotnet nuget add source "$PWD/local-packages" --name local-ekom
+
       - name: Restore (force NuGet references)
-        run: dotnet restore "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -p:UseProjectReferences=false
+        run: dotnet restore "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -p:UseProjectReferences=false -p:EkomPackageVersion=${{ steps.ekom-version.outputs.version }}
 
       - name: Build (Release, force NuGet references)
-        run: dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -c Release --no-restore -p:UseProjectReferences=false
+        run: dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -c Release --no-restore -p:UseProjectReferences=false -p:EkomPackageVersion=${{ steps.ekom-version.outputs.version }}
 
       - name: Pack Ekom.Algolia (force NuGet references)
         shell: pwsh
@@ -52,7 +79,8 @@ jobs:
             --no-build `
             -o artifacts `
             -p:PackageVersion=$version `
-            -p:UseProjectReferences=false
+            -p:UseProjectReferences=false `
+            -p:EkomPackageVersion=${{ steps.ekom-version.outputs.version }}
 
           Get-ChildItem -Path artifacts -Filter "Ekom.Algolia*.nupkg" -File | Format-Table Name,Length
 

--- a/.github/workflows/publish-ekom-klaviyo.yml
+++ b/.github/workflows/publish-ekom-klaviyo.yml
@@ -23,11 +23,38 @@ jobs:
             8.0.x
             10.0.x
 
+      - name: Read Ekom package version
+        id: ekom-version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          [xml]$props = Get-Content "Ekom/Directory.Build.props"
+          $version = $props.Project.PropertyGroup.Version
+          if ([string]::IsNullOrWhiteSpace($version)) { throw "Could not read Ekom package version." }
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Pack Ekom dependencies locally
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = "${{ steps.ekom-version.outputs.version }}"
+
+          if (Test-Path "local-packages") { Remove-Item "local-packages" -Recurse -Force }
+          New-Item -ItemType Directory -Force -Path local-packages | Out-Null
+
+          dotnet pack "Ekom/Ekom.Core/Ekom.Common/Ekom.Common.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Core/Ekom/Ekom.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Core/Ekom.AspNetCore/Ekom.AspNetCore.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -c Release -o local-packages -p:PackageVersion=$version -p:UseProjectReferences=true
+
+          dotnet nuget add source "$PWD/local-packages" --name local-ekom
+
       - name: Restore (force NuGet references)
-        run: dotnet restore "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj" -p:UseProjectReferences=false
+        run: dotnet restore "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj" -p:UseProjectReferences=false -p:EkomPackageVersion=${{ steps.ekom-version.outputs.version }}
 
       - name: Build (Release, force NuGet references)
-        run: dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj" -c Release --no-restore -p:UseProjectReferences=false
+        run: dotnet build "Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj" -c Release --no-restore -p:UseProjectReferences=false -p:EkomPackageVersion=${{ steps.ekom-version.outputs.version }}
 
       - name: Pack Ekom.Klaviyo (force NuGet references)
         shell: pwsh
@@ -52,7 +79,8 @@ jobs:
             --no-build `
             -o artifacts `
             -p:PackageVersion=$version `
-            -p:UseProjectReferences=false
+            -p:UseProjectReferences=false `
+            -p:EkomPackageVersion=${{ steps.ekom-version.outputs.version }}
 
           Get-ChildItem -Path artifacts -Filter "Ekom.Klaviyo*.nupkg" -File | Format-Table Name,Length
 

--- a/.github/workflows/publish-ekom.yml
+++ b/.github/workflows/publish-ekom.yml
@@ -23,13 +23,39 @@ jobs:
             8.0.x
             10.0.x
 
-      - name: Restore
-        run: dotnet restore "./Ekom Build.sln"
+      - name: Restore shared packages
+        shell: pwsh
+        run: |
+          dotnet restore "Ekom/Ekom.Core/Ekom.AspNetCore/Ekom.AspNetCore.csproj"
 
-      - name: Build (Release)
-        run: dotnet build "./Ekom Build.sln" -c Release --no-restore
+      - name: Build shared packages (Release)
+        run: dotnet build "Ekom/Ekom.Core/Ekom.AspNetCore/Ekom.AspNetCore.csproj" -c Release --no-restore
 
-      - name: Pack (Ekom core)
+      - name: Restore U10 packages
+        shell: pwsh
+        run: |
+          dotnet restore "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+          dotnet restore "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+
+      - name: Build U10 packages (Release)
+        shell: pwsh
+        run: |
+          dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -c Release --no-restore -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+          dotnet build "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -c Release --no-restore -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+
+      - name: Restore U17 packages
+        shell: pwsh
+        run: |
+          dotnet restore "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+          dotnet restore "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+
+      - name: Build U17 packages (Release)
+        shell: pwsh
+        run: |
+          dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -c Release --no-restore -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+          dotnet build "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -c Release --no-restore -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+
+      - name: Pack Ekom packages
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -47,13 +73,20 @@ jobs:
 
           Write-Host "Packing Ekom packages with PackageVersion=$version (tag $tag)"
 
-          dotnet pack "Ekom/Ekom.Core/Ekom/Ekom.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
+          dotnet restore "Ekom/Ekom.Core/Ekom.AspNetCore/Ekom.AspNetCore.csproj"
           dotnet pack "Ekom/Ekom.Core/Ekom.Common/Ekom.Common.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
+          dotnet pack "Ekom/Ekom.Core/Ekom/Ekom.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
           dotnet pack "Ekom/Ekom.Core/Ekom.AspNetCore/Ekom.AspNetCore.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
-          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
-          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
-          dotnet pack "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
-          dotnet pack "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version
+
+          dotnet restore "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+          dotnet restore "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+          dotnet pack "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
+
+          dotnet restore "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+          dotnet restore "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+          dotnet pack "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+          dotnet pack "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
 
           Get-ChildItem -Path artifacts -Filter *.nupkg -File | Format-Table Name,Length
 

--- a/Plugins/Ekom.Algolia/Ekom.Algolia.csproj
+++ b/Plugins/Ekom.Algolia/Ekom.Algolia.csproj
@@ -30,6 +30,7 @@
     <!-- Build / docs -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <EkomPackageVersion>0.2.189</EkomPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -86,11 +87,11 @@
 
   <!-- CI / normal: use NuGet packages -->
   <ItemGroup Condition="'$(UseProjectReferences)' != 'true' and '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Ekom.U10" Version="0.2.87" />
+    <PackageReference Include="Ekom.U10" Version="$(EkomPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseProjectReferences)' != 'true' and '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Ekom.U17" Version="0.2.187" />
+    <PackageReference Include="Ekom.U17" Version="$(EkomPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj
+++ b/Plugins/Ekom.Klaviyo/Ekom.Klaviyo.csproj
@@ -32,6 +32,7 @@
         <!-- Build / docs -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <EkomPackageVersion>0.2.189</EkomPackageVersion>
 
     </PropertyGroup>
 
@@ -96,11 +97,11 @@
 
     <!-- CI / normal: use NuGet packages -->
     <ItemGroup Condition="'$(UseProjectReferences)' != 'true' and '$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Ekom.U10" Version="0.2.83" />
+        <PackageReference Include="Ekom.U10" Version="$(EkomPackageVersion)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseProjectReferences)' != 'true' and '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Ekom.U17" Version="0.2.187" />
+        <PackageReference Include="Ekom.U17" Version="$(EkomPackageVersion)" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Splits the Ekom publish workflow so shared, U10, and U17 packages restore/build/package by target version.
- Packs local Ekom dependencies before Klaviyo and Algolia plugin restores so `Ekom.U10` and `Ekom.U17` are available without waiting for NuGet publishing/indexing.
- Lets plugin projects resolve `Ekom.U10` and `Ekom.U17` from an overridable `EkomPackageVersion` during CI.

## Test Plan
- Ran `git diff --check` successfully.
- Verified the new branch was created from `origin/Ekom` and contains only the CI/package dependency changes.