### PR TITLE
perf(u17): optimize node cache mapping

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
@@ -22,6 +22,7 @@ public static class ApplicationBuilderExtensions
         services.AddHttpClient();
 
         services.AddTransient<IMemberService, MemberService>();
+        services.AddSingleton<Umbraco17ContentCache>();
         services.AddTransient<INodeService, NodeService>();
         services.AddTransient<IImportService, ImportService>();
         services.AddTransient<ImportMediaService>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Models/Umbraco17Content.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Models/Umbraco17Content.cs
@@ -8,24 +8,14 @@ namespace Ekom.Umb.Models;
 
 internal class Umbraco17Content : UmbracoContent
 {
-    public Umbraco17Content(IPublishedContent content, string? urlOverride = null)
+    public Umbraco17Content(
+        IPublishedContent content,
+        int? parentId = null,
+        Guid? parentKey = null,
+        string? path = null,
+        string? urlOverride = null)
         : base(
-            new Dictionary<string, string>
-            {
-                ["id"] = content.Id.ToString(),
-                ["parentID"] = content.Parent?.Id.ToString() ?? string.Empty,
-                ["parentKey"] = content.Parent?.Key.ToString() ?? Guid.Empty.ToString(),
-                ["__Key"] = content.Key.ToString(),
-                ["nodeName"] = content.Name ?? string.Empty,
-                ["__NodeTypeAlias"] = content.ContentType?.Alias ?? string.Empty,
-                ["sortOrder"] = content.SortOrder.ToString(),
-                ["level"] = content.Level.ToString(),
-                ["__Path"] = content.Path ?? string.Empty,
-                ["createDate"] = content.CreateDate.ToString("O"),
-                ["updateDate"] = content.UpdateDate.ToString("O"),
-                ["__VariesByCulture"] = content.Cultures.Count > 1 ? "y" : "n",
-                ["url"] = urlOverride ?? "#",
-            },
+            GetDefaultProperties(content, parentId, parentKey, path, urlOverride),
             GetContentProperties(content))
     {
     }
@@ -54,6 +44,45 @@ internal class Umbraco17Content : UmbracoContent
     {
     }
 
+    private static Dictionary<string, string> GetDefaultProperties(
+        IPublishedContent content,
+        int? parentId,
+        Guid? parentKey,
+        string? path,
+        string? urlOverride)
+    {
+        var id = content.Id.ToString();
+        var parent = parentId.HasValue || parentKey.HasValue ? null : content.Parent;
+        var resolvedParentId = parentId ?? parent?.Id;
+        var resolvedParentKey = parentKey ?? parent?.Key;
+        var resolvedPath = path ?? content.Path ?? string.Empty;
+        var key = content.Key.ToString();
+        var name = content.Name ?? string.Empty;
+        var contentTypeAlias = content.ContentType?.Alias ?? string.Empty;
+        var sortOrder = content.SortOrder.ToString();
+        var level = content.Level.ToString();
+        var createDate = content.CreateDate.ToString("O");
+        var updateDate = content.UpdateDate.ToString("O");
+        var variesByCulture = content.Cultures.Count > 1 ? "y" : "n";
+
+        return new Dictionary<string, string>
+        {
+            ["id"] = id,
+            ["parentID"] = resolvedParentId?.ToString() ?? string.Empty,
+            ["parentKey"] = resolvedParentKey?.ToString() ?? Guid.Empty.ToString(),
+            ["__Key"] = key,
+            ["nodeName"] = name,
+            ["__NodeTypeAlias"] = contentTypeAlias,
+            ["sortOrder"] = sortOrder,
+            ["level"] = level,
+            ["__Path"] = resolvedPath,
+            ["createDate"] = createDate,
+            ["updateDate"] = updateDate,
+            ["__VariesByCulture"] = variesByCulture,
+            ["url"] = urlOverride ?? "#",
+        };
+    }
+
     private static Dictionary<string, string> GetContentProperties(IPublishedContent content)
     {
         var firstCulture = content.Cultures.FirstOrDefault().Value?.Culture;
@@ -65,7 +94,10 @@ internal class Umbraco17Content : UmbracoContent
                 prop => GetContentPropertyValue(content, prop, firstCulture));
     }
 
-    private static string GetContentPropertyValue(IPublishedContent content, IPublishedProperty prop, string? firstCulture)
+    private static string GetContentPropertyValue(
+        IPublishedContent content,
+        IPublishedProperty prop,
+        string? firstCulture)
     {
         try
         {

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Models/Umbraco17Media.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Models/Umbraco17Media.cs
@@ -6,7 +6,7 @@ namespace Ekom.Umb.Models;
 internal sealed class Umbraco17Media : Umbraco17Content
 {
     public Umbraco17Media(IPublishedContent content)
-        : base(content, content.Url())
+        : base(content, urlOverride: content.Url())
     {
     }
 }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/NodeService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/NodeService.cs
@@ -3,7 +3,6 @@ using Ekom.Models;
 using Ekom.Services;
 using Ekom.Umb.Models;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -64,17 +63,8 @@ internal sealed class NodeService : INodeService
             return Array.Empty<UmbracoContent>();
         }
 
-        var fetchStopwatch = Stopwatch.StartNew();
         var nodes = _documentCacheService.GetByContentType(contentType).ToList();
-        fetchStopwatch.Stop();
 
-        _logger.LogDebug(
-            "Fetched {Count} Umbraco 17 nodes for {ContentTypeAlias} in {Elapsed}.",
-            nodes.Count,
-            contentTypeAlias,
-            fetchStopwatch.Elapsed);
-
-        var mapStopwatch = Stopwatch.StartNew();
         var metadata = BuildContentMetadata(nodes, rootNode);
         var rootPathValue = rootNode.Id.ToString();
         nodes = nodes
@@ -99,14 +89,6 @@ internal sealed class NodeService : INodeService
         {
             _contentCache.AddOrUpdate(result);
         }
-
-        mapStopwatch.Stop();
-
-        _logger.LogDebug(
-            "Mapped {Count} Umbraco 17 nodes for {ContentTypeAlias} in {Elapsed}.",
-            results.Count,
-            contentTypeAlias,
-            mapStopwatch.Elapsed);
 
         return results;
     }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/NodeService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/NodeService.cs
@@ -3,8 +3,12 @@ using Ekom.Models;
 using Ekom.Services;
 using Ekom.Umb.Models;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
@@ -14,15 +18,30 @@ internal sealed class NodeService : INodeService
 {
     private readonly IUmbracoContextFactory _context;
     private readonly IPublishedContentQuery _publishedContentQuery;
+    private readonly IDocumentCacheService _documentCacheService;
+    private readonly IPublishedContentTypeCache _publishedContentTypeCache;
+    private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IDocumentNavigationQueryService _documentNavigationQueryService;
+    private readonly Umbraco17ContentCache _contentCache;
     private readonly ILogger<NodeService> _logger;
 
     public NodeService(
         IUmbracoContextFactory context,
         IPublishedContentQuery publishedContentQuery,
+        IDocumentCacheService documentCacheService,
+        IPublishedContentTypeCache publishedContentTypeCache,
+        ICoreScopeProvider scopeProvider,
+        IDocumentNavigationQueryService documentNavigationQueryService,
+        Umbraco17ContentCache contentCache,
         ILogger<NodeService> logger)
     {
         _context = context;
         _publishedContentQuery = publishedContentQuery;
+        _documentCacheService = documentCacheService;
+        _publishedContentTypeCache = publishedContentTypeCache;
+        _scopeProvider = scopeProvider;
+        _documentNavigationQueryService = documentNavigationQueryService;
+        _contentCache = contentCache;
         _logger = logger;
     }
 
@@ -36,9 +55,170 @@ internal sealed class NodeService : INodeService
             throw new EkomRootNodeException("Ekom root node not found.");
         }
 
-        return rootNode.DescendantsOfType(contentTypeAlias)
-            .Select(x => new Umbraco17Content(x))
+        using var scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+
+        var contentType = _publishedContentTypeCache.Get(PublishedItemType.Content, contentTypeAlias);
+        if (contentType == null)
+        {
+            _logger.LogWarning("Content type {ContentTypeAlias} not found.", contentTypeAlias);
+            return Array.Empty<UmbracoContent>();
+        }
+
+        var fetchStopwatch = Stopwatch.StartNew();
+        var nodes = _documentCacheService.GetByContentType(contentType).ToList();
+        fetchStopwatch.Stop();
+
+        _logger.LogDebug(
+            "Fetched {Count} Umbraco 17 nodes for {ContentTypeAlias} in {Elapsed}.",
+            nodes.Count,
+            contentTypeAlias,
+            fetchStopwatch.Elapsed);
+
+        var mapStopwatch = Stopwatch.StartNew();
+        var metadata = BuildContentMetadata(nodes, rootNode);
+        var rootPathValue = rootNode.Id.ToString();
+        nodes = nodes
+            .Where(x => metadata.TryGetValue(x.Key, out var itemMetadata)
+                && itemMetadata.Path.Split(',').Contains(rootPathValue))
             .ToList();
+
+        var results = nodes
+            .Select(x =>
+            {
+                metadata.TryGetValue(x.Key, out var itemMetadata);
+
+                return new Umbraco17Content(
+                    x,
+                    itemMetadata?.ParentId,
+                    itemMetadata?.ParentKey,
+                    itemMetadata?.Path);
+            })
+            .ToList();
+
+        foreach (var result in results)
+        {
+            _contentCache.AddOrUpdate(result);
+        }
+
+        mapStopwatch.Stop();
+
+        _logger.LogDebug(
+            "Mapped {Count} Umbraco 17 nodes for {ContentTypeAlias} in {Elapsed}.",
+            results.Count,
+            contentTypeAlias,
+            mapStopwatch.Elapsed);
+
+        return results;
+    }
+
+    private Dictionary<Guid, ContentMetadata> BuildContentMetadata(
+        IReadOnlyCollection<IPublishedContent> nodes,
+        IPublishedContent rootNode)
+    {
+        if (nodes.Count == 0)
+        {
+            return new Dictionary<Guid, ContentMetadata>();
+        }
+
+        var pathsByKey = new Dictionary<Guid, List<Guid>>();
+        var pathCache = new Dictionary<Guid, List<Guid>>();
+
+        foreach (var node in nodes)
+        {
+            pathsByKey[node.Key] = GetPathKeys(node.Key, pathCache);
+        }
+
+        var idsByKey = BuildIdsByKey(nodes, rootNode);
+
+        var metadata = new Dictionary<Guid, ContentMetadata>();
+
+        foreach (var node in nodes)
+        {
+            var pathKeys = pathsByKey[node.Key];
+            var parentKey = pathKeys.Count > 1 ? pathKeys[^2] : (Guid?)null;
+            var pathIds = new List<string> { "-1" };
+
+            foreach (var key in pathKeys)
+            {
+                if (idsByKey.TryGetValue(key, out var id))
+                {
+                    pathIds.Add(id.ToString());
+                }
+            }
+
+            metadata[node.Key] = new ContentMetadata(
+                parentKey.HasValue && idsByKey.TryGetValue(parentKey.Value, out var parentId) ? parentId : null,
+                parentKey,
+                string.Join(',', pathIds));
+        }
+
+        return metadata;
+    }
+
+    private Dictionary<Guid, int> BuildIdsByKey(IReadOnlyCollection<IPublishedContent> nodes, IPublishedContent rootNode)
+    {
+        var idsByKey = new Dictionary<Guid, int>
+        {
+            [rootNode.Key] = rootNode.Id,
+        };
+
+        foreach (var item in _contentCache.Values)
+        {
+            idsByKey[item.Key] = item.Id;
+        }
+
+        foreach (var node in nodes)
+        {
+            idsByKey[node.Key] = node.Id;
+        }
+
+        return idsByKey;
+    }
+
+    private List<Guid> GetPathKeys(Guid key, Dictionary<Guid, List<Guid>> pathCache)
+    {
+        if (pathCache.TryGetValue(key, out var cachedPath))
+        {
+            return cachedPath;
+        }
+
+        var descendantKeys = new List<Guid>();
+        List<Guid>? cachedPrefix = null;
+        var currentKey = key;
+
+        while (true)
+        {
+            if (pathCache.TryGetValue(currentKey, out var currentPath))
+            {
+                cachedPrefix = currentPath;
+                break;
+            }
+
+            descendantKeys.Add(currentKey);
+
+            if (!_documentNavigationQueryService.TryGetParentKey(currentKey, out var parentKey) || !parentKey.HasValue)
+            {
+                break;
+            }
+
+            currentKey = parentKey.Value;
+        }
+
+        descendantKeys.Reverse();
+        var path = cachedPrefix == null
+            ? descendantKeys
+            : cachedPrefix.Concat(descendantKeys).ToList();
+
+        foreach (var cacheKey in descendantKeys)
+        {
+            var index = path.IndexOf(cacheKey);
+            if (index >= 0)
+            {
+                pathCache[cacheKey] = path.GetRange(0, index + 1);
+            }
+        }
+
+        return path;
     }
 
     public IEnumerable<UmbracoContent> NodesByTypesFaster(string contentTypeAlias)
@@ -108,6 +288,12 @@ internal sealed class NodeService : INodeService
             return Array.Empty<UmbracoContent>();
         }
 
+        var cachedAncestors = GetCachedCatalogAncestors(item).ToList();
+        if (cachedAncestors.Count > 0)
+        {
+            return cachedAncestors;
+        }
+
         using var cref = _context.EnsureUmbracoContext();
         var node = GetNodeById(item.Id, true);
 
@@ -119,6 +305,32 @@ internal sealed class NodeService : INodeService
         ancestors.Reverse();
 
         return ancestors.Select(x => new Umbraco17Content(x)).ToList();
+    }
+
+    private IEnumerable<UmbracoContent> GetCachedCatalogAncestors(UmbracoContent item)
+    {
+        if (string.IsNullOrWhiteSpace(item.Path))
+        {
+            yield break;
+        }
+
+        foreach (var value in item.Path.Split(','))
+        {
+            if (!int.TryParse(value, out var id))
+            {
+                continue;
+            }
+
+            if (!_contentCache.TryGetById(id, out var content) || content == null)
+            {
+                continue;
+            }
+
+            if (content.IsDocumentType("ekmCategory") || content.IsDocumentType("ekmProduct"))
+            {
+                yield return content;
+            }
+        }
     }
 
     public IPublishedContent? GetNodeById(int id, bool preview = false)
@@ -306,4 +518,6 @@ internal sealed class NodeService : INodeService
         guid = Guid.Empty;
         return false;
     }
+
+    private sealed record ContentMetadata(int? ParentId, Guid? ParentKey, string Path);
 }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/Umbraco17ContentCache.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/Umbraco17ContentCache.cs
@@ -1,0 +1,15 @@
+using Ekom.Models;
+using System.Collections.Concurrent;
+
+namespace Ekom.Umb.Services;
+
+internal sealed class Umbraco17ContentCache
+{
+    private readonly ConcurrentDictionary<int, UmbracoContent> _contentById = new();
+
+    public IEnumerable<UmbracoContent> Values => _contentById.Values;
+
+    public void AddOrUpdate(UmbracoContent content) => _contentById[content.Id] = content;
+
+    public bool TryGetById(int id, out UmbracoContent? content) => _contentById.TryGetValue(id, out content);
+}


### PR DESCRIPTION
## Summary
- Use Umbraco 17 document cache queries for content type lookups instead of descendant traversal.
- Precompute parent/path metadata with document navigation keys to avoid slow `IPublishedContent.Parent` and `Path` calls during cache mapping.
- Add a singleton mapped content cache so category ancestor resolution can reuse cached content across transient node service instances.
- Keep detailed startup diagnostics out of production logs by using debug-level fetch/map summaries only.

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj"` — passed with existing warnings.
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj"` — 323 passed, 1 failed: existing `PriceTests.ISK_PerUnit_VatIncluded_LineLevelVat_1538x4_24pct` expected 4960, actual 4964.
- Verified Umbraco 17 startup diagnostics locally: category mapping/cache creation and product mapping times dropped substantially after the metadata/cache changes.