### PR TITLE
feat(u17): port Ekom manager UI

### DIFF
--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/analytics-section-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/analytics-section-view.element.js
@@ -1,0 +1,178 @@
+var u = Object.defineProperty;
+var h = (s, r, t) => r in s ? u(s, r, { enumerable: !0, configurable: !0, writable: !0, value: t }) : s[r] = t;
+var d = (s, r, t) => h(s, typeof r != "symbol" ? r + "" : r, t);
+import { UmbElementMixin as v } from "@umbraco-cms/backoffice/element-api";
+import { E as m, m as e, a as g, e as o, g as p, p as b, r as n } from "./manager-shared.js";
+class f extends v(HTMLElement) {
+  constructor() {
+    super(...arguments);
+    d(this, "api", new m());
+    d(this, "loading", !0);
+    d(this, "loadingMostSoldProducts", !0);
+    d(this, "error", "");
+    d(this, "chartData");
+    d(this, "mostSoldProducts", { products: [], count: 0, totalPages: 0, page: 1 });
+    d(this, "pageMostSoldProducts", 1);
+  }
+  connectedCallback() {
+    super.connectedCallback(), this.render(), this.initialize();
+  }
+  async initialize() {
+    try {
+      const [t, a] = await Promise.all([
+        this.api.statusList(),
+        this.api.stores()
+      ]);
+      e.statusList = t || [], e.stores = a || [], !e.filters.store && e.stores.length && (e.filters.store = e.stores[0].alias), await this.loadAnalytics();
+    } catch (t) {
+      this.error = c(t, "Error loading Ekom analytics."), this.loading = !1, this.loadingMostSoldProducts = !1, this.render();
+    }
+  }
+  async loadAnalytics() {
+    await Promise.all([
+      this.loadCharts(),
+      this.loadMostSoldProducts()
+    ]);
+  }
+  async loadCharts() {
+    if (!e.filters.store) {
+      this.loading = !1;
+      return;
+    }
+    this.loading = !0, this.error = "", this.render();
+    try {
+      this.chartData = await this.api.charts(e.filters);
+    } catch (t) {
+      this.error = c(t, "Error on chart data.");
+    } finally {
+      this.loading = !1, this.render(), this.renderCharts();
+    }
+  }
+  async loadMostSoldProducts() {
+    if (!e.filters.store) {
+      this.loadingMostSoldProducts = !1;
+      return;
+    }
+    this.loadingMostSoldProducts = !0, this.render();
+    try {
+      this.mostSoldProducts = await this.api.mostSoldProducts(e.filters, this.pageMostSoldProducts), this.mostSoldProducts.products = this.mostSoldProducts.products || [], this.pageMostSoldProducts = this.mostSoldProducts.page || this.pageMostSoldProducts;
+    } catch (t) {
+      this.error = c(t, "Error on most sold products data.");
+    } finally {
+      this.loadingMostSoldProducts = !1, this.render(), this.renderCharts();
+    }
+  }
+  render() {
+    this.innerHTML = `
+      <style>${g}</style>
+      <section class="ekmManager">
+        <div class="ekmManager__body">
+          ${this.renderToolbar()}
+          ${this.error ? `<p class="status status--error">${o(this.error)}</p>` : ""}
+          ${this.renderAnalytics()}
+        </div>
+      </section>
+    `, this.bindEvents(), this.renderCharts();
+  }
+  renderToolbar() {
+    const t = e.filters;
+    return `
+      <div class="umb-sub-header">
+        <div class="ekmManager__filters">
+          <label class="ekmManager__filter">Order Status:
+            <select data-field="orderStatus">
+              <option value="CompletedOrders" ${t.orderStatus === "CompletedOrders" ? "selected" : ""}>Completed Orders</option>
+              <option value="AllOrders" ${t.orderStatus === "AllOrders" ? "selected" : ""}>All Orders</option>
+              ${e.statusList.map((a) => {
+      const i = p(a);
+      return `<option value="${o(i)}" ${t.orderStatus === i ? "selected" : ""}>${o(a.label)}</option>`;
+    }).join("")}
+            </select>
+          </label>
+          <label class="ekmManager__filter">Date From:
+            <input type="date" data-field="dateFrom" value="${o(t.dateFrom)}">
+          </label>
+          <label class="ekmManager__filter">Date To:
+            <input type="date" data-field="dateTo" value="${o(t.dateTo)}">
+          </label>
+          <label class="ekmManager__filter">Store:
+            <select data-field="store">
+              ${e.stores.map((a) => `<option value="${o(a.alias)}" ${t.store === a.alias ? "selected" : ""}>${o(a.title)}</option>`).join("")}
+            </select>
+          </label>
+        </div>
+      </div>
+    `;
+  }
+  renderAnalytics() {
+    return `
+      <div class="ekmGrid">
+        <div class="card ekmChartCard"><h3>Sales Revenue</h3><div class="ekmChartCard__canvas">${this.loading ? "<p>Loading chart...</p>" : '<canvas id="chartRevenue"></canvas>'}</div></div>
+        <div class="card ekmChartCard"><h3>Total Orders</h3><div class="ekmChartCard__canvas">${this.loading ? "<p>Loading chart...</p>" : '<canvas id="chartOrders"></canvas>'}</div></div>
+        <div class="card ekmChartCard"><h3>Average Order Value</h3><div class="ekmChartCard__canvas">${this.loading ? "<p>Loading chart...</p>" : '<canvas id="chartAvarage"></canvas>'}</div></div>
+      </div>
+      <div class="card ekmChartCard">
+        <h3>Most Sold Products</h3>
+        ${this.loadingMostSoldProducts ? "<p>Loading most sold products...</p>" : this.renderMostSoldProducts()}
+      </div>
+    `;
+  }
+  renderMostSoldProducts() {
+    return this.mostSoldProducts.products.length ? `
+      <div class="umb-table">
+        <div class="umb-table-head"><div class="umb-table-row"><div class="umb-table-cell">Product</div><div class="umb-table-cell">Sku</div><div class="umb-table-cell">Quantity</div><div class="umb-table-cell">Total</div></div></div>
+        <div class="umb-table-body">
+          ${this.mostSoldProducts.products.map((t) => `<div class="umb-table-row"><div class="umb-table-cell">${o(l(t, "title", "productTitle", "name"))}</div><div class="umb-table-cell">${o(l(t, "sku", "productSku"))}</div><div class="umb-table-cell">${o(l(t, "quantity", "count"))}</div><div class="umb-table-cell">${o(l(t, "formattedTotal", "total"))}</div></div>`).join("")}
+        </div>
+      </div>
+      ${this.mostSoldProducts.totalPages > 1 ? this.renderMostSoldProductsPagination() : ""}
+    ` : "<p>No products found.</p>";
+  }
+  renderMostSoldProductsPagination() {
+    return `
+      <div class="pagination">
+        <ul>
+          ${b(this.pageMostSoldProducts, this.mostSoldProducts.totalPages).map((t) => {
+      const a = Number(String(t).replace("...", ""));
+      return `<li class="${a === this.pageMostSoldProducts ? "active" : ""}"><button type="button" data-action="set-most-sold-page" data-page="${a}" ${a === this.pageMostSoldProducts ? "disabled" : ""}>${o(t)}</button></li>`;
+    }).join("")}
+        </ul>
+      </div>
+    `;
+  }
+  renderCharts() {
+    if (!this.chartData)
+      return;
+    const t = this.querySelector("#chartRevenue"), a = this.querySelector("#chartOrders"), i = this.querySelector("#chartAvarage");
+    t && n(t, this.chartData.revenueChart, "rgba(30, 64, 175, 1)"), a && n(a, this.chartData.ordersChart, "rgba(8, 145, 178, 1)"), i && n(i, this.chartData.avarageChart, "rgba(217, 119, 6, 1)");
+  }
+  bindEvents() {
+    this.querySelectorAll("[data-action]").forEach((t) => {
+      t.addEventListener("click", (a) => void this.handleAction(a));
+    }), this.querySelectorAll("[data-field]").forEach((t) => {
+      t.addEventListener("change", (a) => void this.handleFieldChange(a));
+    });
+  }
+  async handleAction(t) {
+    const a = t.currentTarget;
+    a.dataset.action === "set-most-sold-page" && (this.pageMostSoldProducts = Number(a.dataset.page || 1), await this.loadMostSoldProducts());
+  }
+  async handleFieldChange(t) {
+    const a = t.currentTarget, i = a.dataset.field;
+    !i || !(i in e.filters) || (e.filters[i] = a.value, this.pageMostSoldProducts = 1, await this.loadAnalytics());
+  }
+}
+function l(s, ...r) {
+  for (const t of r)
+    if (s[t] != null)
+      return s[t];
+  return "";
+}
+function c(s, r) {
+  return s instanceof Error ? s.message : r;
+}
+customElements.define("ekom-analytics-section-view", f);
+export {
+  f as EkomAnalyticsSectionViewElement,
+  f as default
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manager-shared.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manager-shared.js
@@ -1,0 +1,339 @@
+const f = /* @__PURE__ */ new Date(), y = new Date(f.getFullYear(), 0, 1), w = {
+  filters: {
+    dateFrom: h(y),
+    dateTo: h(f),
+    orderStatus: "CompletedOrders",
+    store: "",
+    paymentProvider: "",
+    productSku: "",
+    trackingSource: "",
+    trackingMedium: "",
+    trackingCampaign: "",
+    trackingTerm: "",
+    trackingContent: "",
+    trackingClickId: "",
+    query: ""
+  },
+  statusList: [],
+  stores: [],
+  paymentProviders: []
+};
+class m {
+  async searchOrders(e, r, t = 20) {
+    return this.getJson("/ekom/manager/SearchOrders", {
+      ...e,
+      start: e.dateFrom,
+      end: e.dateTo,
+      page: r,
+      pageSize: t
+    });
+  }
+  async exportOrders(e, r, t) {
+    return this.getBlob("/ekom/manager/ExportOrders", {
+      ...e,
+      start: e.dateFrom,
+      end: e.dateTo,
+      page: 1,
+      pageSize: r,
+      includeOrderLines: t
+    });
+  }
+  async statusList() {
+    return this.getJson("/ekom/manager/StatusList");
+  }
+  async stores() {
+    return this.getJson("/ekom/manager/stores");
+  }
+  async paymentProviders(e) {
+    return this.getJson(`/ekom/provider/paymentsproviders/${encodeURIComponent(e)}`);
+  }
+  async orderInfo(e) {
+    return this.getJson(`/ekom/manager/OrderInfo/${encodeURIComponent(e)}`);
+  }
+  async orderLogs(e) {
+    return this.getJson(`/ekom/manager/OrderLogs/${encodeURIComponent(e)}`);
+  }
+  async orderActions(e) {
+    return this.getJson(`/ekom/manager/OrderActions/${encodeURIComponent(e)}`);
+  }
+  async executeOrderAction(e, r) {
+    const t = await fetch(`/ekom/manager/OrderActions/${encodeURIComponent(e)}/${encodeURIComponent(r)}`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { Accept: "application/json, application/octet-stream" }
+    });
+    if (!t.ok)
+      throw await m.createError(t, "Order action failed.");
+    return t;
+  }
+  async changeOrderStatus(e, r, t) {
+    return this.postJson("/ekom/manager/changeOrderStatus", { orderId: e, orderStatus: r, notify: t });
+  }
+  async updateCustomerInformation(e, r, t) {
+    return this.postBody("/ekom/manager/UpdateCustomerInformation", { orderId: e, customer: r, shipping: t });
+  }
+  async charts(e) {
+    return this.getJson("/ekom/manager/charts", {
+      start: e.dateFrom,
+      end: e.dateTo,
+      orderStatus: e.orderStatus,
+      store: e.store
+    });
+  }
+  async mostSoldProducts(e, r, t = 20) {
+    return this.getJson("/ekom/manager/MostSoldProducts", {
+      start: e.dateFrom,
+      end: e.dateTo,
+      orderStatus: e.orderStatus,
+      store: e.store,
+      page: r,
+      pageSize: t
+    });
+  }
+  async getJson(e, r) {
+    const t = await fetch(e + u(r), {
+      credentials: "same-origin",
+      headers: { Accept: "application/json" }
+    });
+    if (!t.ok)
+      throw await m.createError(t, "Request failed.");
+    return t.json();
+  }
+  async getBlob(e, r) {
+    const t = await fetch(e + u(r), {
+      credentials: "same-origin",
+      headers: { Accept: "text/csv, application/octet-stream" }
+    });
+    if (!t.ok)
+      throw await m.createError(t, "Request failed.");
+    return t.blob();
+  }
+  async postJson(e, r) {
+    const t = await fetch(e + u(r), {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" }
+    });
+    if (!t.ok)
+      throw await m.createError(t, "Request failed.");
+    return t.json();
+  }
+  async postBody(e, r) {
+    const t = await fetch(e, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(r)
+    });
+    if (!t.ok)
+      throw await m.createError(t, "Request failed.");
+    return t.json();
+  }
+  static async createError(e, r) {
+    const t = await e.text();
+    let n = t || r;
+    try {
+      n = JSON.parse(t).message || n;
+    } catch {
+    }
+    return new Error(n || `${r} Status ${e.status}.`);
+  }
+}
+function u(a) {
+  if (!a)
+    return "";
+  const e = new URLSearchParams();
+  for (const [t, n] of Object.entries(a))
+    e.set(t, n == null ? "" : String(n));
+  const r = e.toString();
+  return r ? `?${r}` : "";
+}
+function h(a) {
+  const e = String(a.getMonth() + 1).padStart(2, "0"), r = String(a.getDate()).padStart(2, "0");
+  return `${a.getFullYear()}-${e}-${r}`;
+}
+function _(a) {
+  if (!a)
+    return "";
+  const e = new Date(a);
+  return Number.isNaN(e.getTime()) ? a : new Intl.DateTimeFormat(void 0, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(e);
+}
+function v(a) {
+  return String(a ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+}
+function S(a) {
+  const e = document.createElement("textarea");
+  return e.innerHTML = String(a ?? ""), e.value;
+}
+function O(a) {
+  return a.enumValue || a.value || "";
+}
+function C(a, e) {
+  const t = [], n = Math.max(e || 1, 1);
+  let d;
+  a <= Math.floor(5 / 2) ? d = 1 : a + Math.floor(5 / 2) >= n ? d = Math.max(n - 5 + 1, 1) : d = a - Math.floor(5 / 2);
+  for (let i = 0; i < 5; i += 1) {
+    const o = d + i;
+    o <= n && t.push(o);
+  }
+  return t.length && Number(t[t.length - 1]) < n && t.push(`...${n}`), t.length && Number(t[0]) > 1 && t.unshift("...1"), t;
+}
+function M(a, e) {
+  const r = URL.createObjectURL(a), t = document.createElement("a");
+  t.href = r, t.download = e, document.body.append(t), t.click(), t.remove(), URL.revokeObjectURL(r);
+}
+const T = `
+  :host { display: block; height: 100%; color: var(--uui-color-text, #1b264f); }
+  .ekmManager { min-height: 100%; background: var(--uui-color-surface, #f6f4f4); }
+  .ekmManager__body { padding: 24px; }
+  .cards { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin-bottom: 20px; }
+  .card { background-color: #fff; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,.08); padding: 15px; text-align: center; }
+  .card strong { display: block; font-size: 24px; margin-bottom: 15px; }
+  .ekmSummaryCard { align-items: flex-start; background: linear-gradient(135deg, #fff 0%, #f8fafc 100%); border: 1px solid #e6e8ef; display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 18px 20px; text-align: left; }
+  .ekmSummaryCard__label { color: var(--uui-color-text-alt, #515054); font-size: 13px; font-weight: 700; letter-spacing: .02em; text-transform: uppercase; }
+  .ekmSummaryCard__value { color: #1b264f; font-size: clamp(24px, 4vw, 34px); line-height: 1.1; margin: 0; overflow-wrap: anywhere; }
+  .umb-sub-header, .ekmToolbar { background: #fff; border-radius: 6px; margin-bottom: 20px; padding: 15px; }
+  .ekmManager__filters { align-items: end; display: grid; gap: 15px; grid-template-columns: repeat(4, minmax(150px, max-content)) minmax(260px, 1fr); width: 100%; }
+  .ekmManager__filter { display: grid; gap: 5px; min-width: 0; }
+  .ekmManager__filter input, .ekmManager__filter select { width: 100%; }
+  .ekmManager__search { align-items: end; display: flex; gap: 10px; justify-content: flex-end; min-width: 0; }
+  label { font-weight: 700; }
+  input:not([type='checkbox']), select { border: 1px solid #d8d7d9; border-radius: 3px; box-sizing: border-box; font: inherit; min-height: 36px; padding: 6px 10px; }
+  .ekmCheckboxLabel { align-items: center; display: inline-flex; gap: 6px; }
+  .ekmCheckboxLabel input { margin: 0; }
+  .form-search { min-width: 0; }
+  .form-search input { min-width: 220px; width: 100%; }
+  button, .btn { border: 1px solid #d8d7d9; border-radius: 3px; cursor: pointer; font: inherit; min-height: 36px; padding: 7px 14px; }
+  button:disabled { cursor: not-allowed; opacity: .6; }
+  .btn-primary, .btn-success { background: var(--uui-color-positive, #1b7f43); border-color: var(--uui-color-positive, #1b7f43); color: #fff; }
+  .btn-outline { background: #fff; color: #1b264f; }
+  .btn-reset { background: transparent; border: 0; min-height: 0; padding: 0; }
+  .umb-table { background: #fff; border: 1px solid #e9e9eb; border-radius: 6px; display: table; overflow: hidden; width: 100%; }
+  .umb-table-head { display: table-header-group; font-weight: 700; }
+  .umb-table-body { display: table-row-group; }
+  .umb-table-footer { display: table-footer-group; font-weight: 700; }
+  .umb-table-row { display: table-row; }
+  .umb-table-cell { border-bottom: 1px solid #eee; color: #111; display: table-cell; padding: 12px; vertical-align: middle; }
+  .not-fixed { min-width: 110px; }
+  .pagination ul { display: flex; gap: 4px; justify-content: center; list-style: none; padding: 0; }
+  .pagination li.active button { background: var(--uui-color-interactive, #3544b1); color: #fff; }
+  .ekmGrid { display: grid; gap: 40px; grid-template-columns: 1fr 1fr; margin-bottom: 40px; }
+  .ekmChartCard { text-align: left; }
+  .ekmChartCard__canvas { height: 320px; position: relative; }
+  .ekmChartCard canvas { height: 100%; width: 100%; }
+  .ekmSplit { display: flex; gap: 30px; margin-bottom: 30px; }
+  .ekmSplit__column { flex: 1; min-width: 0; }
+  .ekmOverlay { align-items: flex-start; background: rgba(0,0,0,.35); display: flex; inset: 0; justify-content: center; overflow: auto; padding: 40px 20px; position: fixed; z-index: 10000; }
+  .ekmOverlay__panel { background: #fff; border-radius: 3px; box-shadow: 0 10px 30px rgba(0,0,0,.25); max-width: 1100px; width: 100%; }
+  .ekmOverlay__panel--small { max-width: 620px; }
+  .ekmOverlay__header { align-items: center; border-bottom: 1px solid #d8d7d9; display: flex; gap: 12px; justify-content: space-between; padding: 20px; }
+  .ekmOverlay__header h2 { margin: 0; }
+  .ekmOverlay__content { padding: 20px; }
+  .ekmOrderStatusBar { align-items: center; border-bottom: 1px solid #d8d7d9; display: flex; flex-wrap: wrap; gap: 15px; margin-bottom: 15px; padding-bottom: 15px; }
+  .ekmOrderStatusBar__status { align-items: center; display: flex; gap: 8px; }
+  .ekmOrderStatusBar__print { margin-left: auto; }
+  .ekmOrderTracking, .ekmOrderActivityLog { border: 1px solid #d8d7d9; margin: 30px 0; padding: 14px 16px; }
+  .ekmOrderTracking__header { align-items: center; display: flex; justify-content: space-between; }
+  .ekmOrderTracking__wrap { overflow-wrap: anywhere; word-break: break-word; }
+  .ekmOrderActivityLog__item { border-top: 1px solid #eee; padding: 12px 0; }
+  .ekmOrderActivityLog__date { color: #666; font-size: 12px; margin-bottom: 6px; }
+  .ekmCustomerInformationModal { align-items: center; background: rgba(0,0,0,.35); display: flex; inset: 0; justify-content: center; padding: 20px; position: fixed; z-index: 10001; }
+  .ekmCustomerInformationModal__panel { background: #fff; border-radius: 3px; box-shadow: 0 10px 30px rgba(0,0,0,.25); max-height: 90vh; max-width: 760px; overflow: auto; width: 100%; }
+  .control-group { display: grid; gap: 5px; margin-bottom: 14px; }
+  .status { margin: 10px 0; }
+  .status--error { color: var(--uui-color-danger, #d42054); }
+  @media only screen and (max-width: 1180px) { .ekmManager__filters { grid-template-columns: repeat(2, minmax(0, 1fr)); } .ekmManager__search { grid-column: 1 / -1; justify-content: flex-start; } }
+  @media only screen and (max-width: 900px) { .cards { grid-template-columns: 1fr; } }
+  @media only screen and (max-width: 800px) { .ekmGrid { grid-template-columns: 1fr; } .ekmSplit { flex-direction: column; } }
+  @media only screen and (max-width: 720px) {
+    .ekmManager__filters { grid-template-columns: 1fr; }
+    .ekmManager__search { align-items: stretch; flex-direction: column; }
+    .ekmManager__search button, .form-search input { width: 100%; }
+    .umb-table, .umb-table-head, .umb-table-body, .umb-table-row, .umb-table-cell { display: block; }
+    .umb-table { background: transparent; border: 0; overflow: visible; }
+    .umb-table-head { display: none; }
+    .umb-table-row { background: #fff; border: 1px solid #e9e9eb; border-radius: 6px; box-shadow: 0 1px 2px rgba(0,0,0,.06); margin-bottom: 12px; overflow: hidden; }
+    .umb-table-cell { align-items: center; border-bottom: 1px solid #f0f0f0; display: grid; gap: 12px; grid-template-columns: minmax(110px, 38%) minmax(0, 1fr); min-height: 44px; overflow-wrap: anywhere; padding: 10px 12px; }
+    .umb-table-cell::before { color: var(--uui-color-text-alt, #515054); content: attr(data-label); font-size: 12px; font-weight: 700; letter-spacing: .02em; text-transform: uppercase; }
+    .umb-table-cell:last-child { border-bottom: 0; }
+    .umb-table-cell.not-fixed { min-width: 0; }
+    .umb-table-cell select, .umb-table-cell button { width: 100%; }
+  }
+  @media only screen and (max-width: 640px) {
+    .ekmOverlay { padding: 0; }
+    .ekmOverlay__panel { border-radius: 0; box-shadow: none; min-height: 100vh; max-width: none; }
+    .ekmOverlay__header { padding: 14px 16px; position: sticky; top: 0; z-index: 2; background: #fff; }
+    .ekmOverlay__header h2 { font-size: 20px; }
+    .ekmOverlay__content { padding: 16px; }
+    .ekmOrder h1 { font-size: 22px; line-height: 1.2; overflow-wrap: anywhere; }
+    .ekmOrderStatusBar { align-items: stretch; display: grid; grid-template-columns: 1fr; }
+    .ekmOrderStatusBar__status { align-items: stretch; display: grid; gap: 5px; }
+    .ekmOrderStatusBar__print { margin-left: 0; }
+    .ekmOrderStatusBar button, .ekmOrderStatusBar select { width: 100%; }
+    .ekmOrder p { overflow-wrap: anywhere; }
+    .ekmOrder .umb-table-cell { grid-template-columns: minmax(105px, 36%) minmax(0, 1fr); }
+    .ekmCustomerInformationModal { align-items: stretch; padding: 0; }
+    .ekmCustomerInformationModal__panel { border-radius: 0; max-height: none; max-width: none; width: 100%; }
+  }
+  @media only screen and (max-width: 520px) { .ekmManager__body { padding: 16px; } .ekmSummaryCard { padding: 15px; } .ekmSummaryCard__value { font-size: 24px; } .umb-sub-header { padding: 12px; } }
+  @media print {
+    :host { color: #000; height: auto; }
+    .ekmManager { display: none; }
+    .ekmOverlay { background: #fff; display: block; inset: auto; overflow: visible; padding: 0; position: static; }
+    .ekmOverlay__panel { border-radius: 0; box-shadow: none; max-width: none; min-height: auto; width: 100%; }
+    .ekmOverlay__header,
+    .ekmOrderStatusBar,
+    .ekmOrder button,
+    .ekmCustomerInformationModal { display: none !important; }
+    .ekmOverlay__content { padding: 0; }
+    .ekmOrder h1 { font-size: 22px; margin-top: 0; }
+    .ekmSplit { break-inside: avoid; display: flex; gap: 24px; margin-bottom: 18px; }
+    .ekmOrderTracking,
+    .ekmOrderActivityLog,
+    .card,
+    .umb-table-row { break-inside: avoid; box-shadow: none; }
+    .umb-table { border-color: #bbb; overflow: visible; }
+    .umb-table-cell { border-color: #ddd; color: #000; padding: 7px 8px; }
+  }
+`;
+function j(a, e, r) {
+  const t = a.getBoundingClientRect(), n = window.devicePixelRatio || 1, d = Math.max(t.width, 300), i = Math.max(t.height, 220);
+  a.width = d * n, a.height = i * n;
+  const o = a.getContext("2d");
+  if (!o)
+    return;
+  o.scale(n, n), o.clearRect(0, 0, d, i), o.strokeStyle = "#e5e5e5", o.lineWidth = 1;
+  for (let s = 0; s < 5; s += 1) {
+    const l = 20 + (i - 50) / 4 * s;
+    o.beginPath(), o.moveTo(40, l), o.lineTo(d - 10, l), o.stroke();
+  }
+  const p = e.points || [], k = p.map((s) => Number(s.y || 0)), b = Math.max(...k, 1), x = p.length > 1 ? (d - 60) / (p.length - 1) : 0;
+  o.strokeStyle = r, o.lineWidth = 2, o.beginPath(), p.forEach((s, l) => {
+    const c = 40 + x * l, g = i - 30 - Number(s.y || 0) / b * (i - 60);
+    l === 0 ? o.moveTo(c, g) : o.lineTo(c, g);
+  }), o.stroke(), o.fillStyle = r, p.forEach((s, l) => {
+    const c = 40 + x * l, g = i - 30 - Number(s.y || 0) / b * (i - 60);
+    o.beginPath(), o.arc(c, g, 3, 0, Math.PI * 2), o.fill();
+  });
+}
+export {
+  m as E,
+  T as a,
+  M as b,
+  S as d,
+  v as e,
+  _ as f,
+  O as g,
+  w as m,
+  C as p,
+  j as r
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
@@ -1,5 +1,59 @@
 const e = [
   {
+    type: "section",
+    kind: "default",
+    alias: "ekommanager",
+    name: "Ekom Manager Section",
+    weight: 300,
+    meta: {
+      label: "Ekom",
+      pathname: "ekommanager",
+      preventUrlRetention: !0
+    },
+    conditions: [
+      {
+        alias: "Umb.Condition.SectionUserPermission",
+        match: "ekommanager"
+      }
+    ]
+  },
+  {
+    type: "sectionView",
+    alias: "Ekom.SectionView.Manager.Orders",
+    name: "Ekom Manager Orders Section View",
+    element: "/App_Plugins/Ekom/dist/orders-section-view.element.js",
+    weight: 200,
+    meta: {
+      label: "Orders",
+      pathname: "orders",
+      icon: "icon-shopping-basket"
+    },
+    conditions: [
+      {
+        alias: "Umb.Condition.SectionAlias",
+        match: "ekommanager"
+      }
+    ]
+  },
+  {
+    type: "sectionView",
+    alias: "Ekom.SectionView.Manager.Analytics",
+    name: "Ekom Manager Analytics Section View",
+    element: "/App_Plugins/Ekom/dist/analytics-section-view.element.js",
+    weight: 100,
+    meta: {
+      label: "Analytics",
+      pathname: "analytics",
+      icon: "icon-chart-curve"
+    },
+    conditions: [
+      {
+        alias: "Umb.Condition.SectionAlias",
+        match: "ekommanager"
+      }
+    ]
+  },
+  {
     type: "propertyEditorSchema",
     alias: "Ekom.Cache",
     name: "Ekom Cache Editor",

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/orders-section-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/orders-section-view.element.js
@@ -1,0 +1,702 @@
+var N = Object.defineProperty;
+var j = (r, a, e) => a in r ? N(r, a, { enumerable: !0, configurable: !0, writable: !0, value: e }) : r[a] = e;
+var n = (r, a, e) => j(r, typeof a != "symbol" ? a + "" : a, e);
+import { UmbElementMixin as V } from "@umbraco-cms/backoffice/element-api";
+import { UMB_NOTIFICATION_CONTEXT as U } from "@umbraco-cms/backoffice/notification";
+import { E as B, m as l, a as K, e as i, g, f as b, p as z, d as f, b as R } from "./manager-shared.js";
+const H = [
+  { key: "customerName", label: "Name", property: "name" },
+  { key: "customerEmail", label: "Email", property: "email" },
+  { key: "customerAddress", label: "Address", property: "address" },
+  { key: "customerApartment", label: "Apartment", property: "apartment" },
+  { key: "customerCity", label: "City", property: "city" },
+  { key: "customerCountry", label: "Country", property: "country" },
+  { key: "customerZipCode", label: "Zipcode", property: "zipCode" },
+  { key: "customerPhone", label: "Phone", property: "phone" }
+], Z = [
+  { key: "shippingName", label: "Name", property: "name" },
+  { key: "shippingEmail", label: "Email", property: "email" },
+  { key: "shippingAddress", label: "Address", property: "address" },
+  { key: "shippingApartment", label: "Apartment", property: "apartment" },
+  { key: "shippingCity", label: "City", property: "city" },
+  { key: "shippingCountry", label: "Country", property: "country" },
+  { key: "shippingZipCode", label: "Zipcode", property: "zipCode" },
+  { key: "shippingPhone", label: "Phone", property: "phone" }
+];
+class W extends V(HTMLElement) {
+  constructor() {
+    super(...arguments);
+    n(this, "api", new B());
+    n(this, "notificationContext");
+    n(this, "result", { orders: [], count: 0, totalPages: 0 });
+    n(this, "page", 1);
+    n(this, "loading", !0);
+    n(this, "error", "");
+    n(this, "searchTimer", 0);
+    n(this, "overlay", "");
+    n(this, "selectedOrder");
+    n(this, "orderLogs", []);
+    n(this, "orderLogsLoading", !1);
+    n(this, "orderActions", []);
+    n(this, "orderActionsLoading", !1);
+    n(this, "executingActionKey", "");
+    n(this, "trackingExpanded", !1);
+    n(this, "consentExpanded", !1);
+    n(this, "customerEditorOpen", !1);
+    n(this, "customerSaving", !1);
+    n(this, "customerEditModel");
+    n(this, "exportIncludeOrderLines", !1);
+    n(this, "exporting", !1);
+    n(this, "handleKeyDown", (e) => {
+      if (!(e.key !== "Escape" || !this.overlay)) {
+        if (this.customerEditorOpen) {
+          if (this.customerSaving)
+            return;
+          this.customerEditorOpen = !1, this.customerEditModel = void 0, this.render();
+          return;
+        }
+        this.exporting || this.closeOverlay();
+      }
+    });
+  }
+  connectedCallback() {
+    super.connectedCallback(), this.consumeContext(U, (e) => {
+      this.notificationContext = e;
+    }), document.addEventListener("keydown", this.handleKeyDown), this.render(), this.initialize();
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback(), document.removeEventListener("keydown", this.handleKeyDown), window.clearTimeout(this.searchTimer);
+  }
+  async initialize() {
+    try {
+      const [e, t] = await Promise.all([
+        this.api.statusList(),
+        this.api.stores()
+      ]);
+      l.statusList = e || [], l.stores = t || [], !l.filters.store && l.stores.length && (l.filters.store = l.stores[0].alias), await this.loadPaymentProviders(), await this.loadOrders();
+    } catch (e) {
+      this.error = h(e, "Error loading Ekom Manager."), this.loading = !1, this.render();
+    }
+  }
+  async loadPaymentProviders(e = !1) {
+    if (!l.filters.store) {
+      l.paymentProviders = [];
+      return;
+    }
+    l.paymentProviders = await this.api.paymentProviders(l.filters.store), e && (l.filters.paymentProvider = ""), l.filters.paymentProvider && (l.paymentProviders.some((s) => s.key === l.filters.paymentProvider) || (l.filters.paymentProvider = ""));
+  }
+  async loadOrders() {
+    if (!l.filters.store) {
+      this.loading = !1, this.result = { orders: [], count: 0, totalPages: 0 }, this.render();
+      return;
+    }
+    this.loading = !0, this.error = "", this.render();
+    try {
+      const e = await this.api.searchOrders(l.filters, this.page);
+      this.result = {
+        ...e,
+        orders: e.orders || []
+      };
+    } catch (e) {
+      this.error = h(e, "Error searching orders.");
+    } finally {
+      this.loading = !1, this.render();
+    }
+  }
+  render() {
+    this.innerHTML = `
+      <style>${K}</style>
+      <section class="ekmManager">
+        <div class="ekmManager__body">
+          ${this.renderOrders()}
+        </div>
+      </section>
+      ${this.renderOverlay()}
+    `, this.bindEvents();
+  }
+  renderOrders() {
+    return `
+      <div class="cards">
+        <div class="card ekmSummaryCard">
+          <span class="ekmSummaryCard__label">Orders</span>
+          <strong class="ekmSummaryCard__value">${i(this.result.count || 0)}</strong>
+        </div>
+        <div class="card ekmSummaryCard">
+          <span class="ekmSummaryCard__label">Payments total</span>
+          <strong class="ekmSummaryCard__value">${i(this.result.grandTotal || 0)}</strong>
+        </div>
+        <div class="card ekmSummaryCard">
+          <span class="ekmSummaryCard__label">Average order amount</span>
+          <strong class="ekmSummaryCard__value">${i(this.result.averageAmount || 0)}</strong>
+        </div>
+      </div>
+      ${this.renderToolbar()}
+      ${this.error ? `<p class="status status--error">${i(this.error)}</p>` : ""}
+      ${this.loading ? "<p>Hang tight! Fetching your order details... This might take a moment.</p>" : this.renderOrderTable()}
+      ${!this.loading && this.result.totalPages > 1 ? this.renderPagination() : ""}
+    `;
+  }
+  renderToolbar() {
+    const e = l.filters;
+    return `
+      <div class="umb-sub-header">
+        <div class="ekmManager__filters">
+          <label class="ekmManager__filter">Order Status:
+            <select data-field="orderStatus">
+              <option value="CompletedOrders" ${e.orderStatus === "CompletedOrders" ? "selected" : ""}>Completed Orders</option>
+              <option value="AllOrders" ${e.orderStatus === "AllOrders" ? "selected" : ""}>All Orders</option>
+              ${l.statusList.map((t) => {
+      const s = g(t);
+      return `<option value="${i(s)}" ${e.orderStatus === s ? "selected" : ""}>${i(t.label)}</option>`;
+    }).join("")}
+            </select>
+          </label>
+          <label class="ekmManager__filter">Date From:
+            <input type="date" data-field="dateFrom" value="${i(e.dateFrom)}">
+          </label>
+          <label class="ekmManager__filter">Date To:
+            <input type="date" data-field="dateTo" value="${i(e.dateTo)}">
+          </label>
+          <label class="ekmManager__filter">Store:
+            <select data-field="store">
+              ${l.stores.map((t) => `<option value="${i(t.alias)}" ${e.store === t.alias ? "selected" : ""}>${i(t.title)}</option>`).join("")}
+            </select>
+          </label>
+          <div class="ekmManager__search">
+            <button type="button" class="btn-outline" data-action="open-export">Export</button>
+            <button type="button" class="btn-primary" data-action="open-filter">Filter</button>
+            <div class="form-search"><input type="text" data-field="query" value="${i(e.query)}" placeholder="Type to search..."></div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+  renderOrderTable() {
+    return this.result.orders.length ? `
+      <div class="umb-table">
+        <div class="umb-table-head">
+          <div class="umb-table-row">
+            <div class="umb-table-cell not-fixed"></div>
+            <div class="umb-table-cell">Order Number</div>
+            <div class="umb-table-cell">Status</div>
+            <div class="umb-table-cell">Name</div>
+            <div class="umb-table-cell">Store</div>
+            <div class="umb-table-cell">Created</div>
+            <div class="umb-table-cell">Payment</div>
+          </div>
+        </div>
+        <div class="umb-table-body">
+          ${this.result.orders.map((e) => this.renderOrderRow(e)).join("")}
+        </div>
+      </div>
+    ` : '<div class="umb-table"><div class="umb-table-row"><div class="umb-table-cell">No orders found</div></div></div>';
+  }
+  renderOrderRow(e) {
+    return `
+      <div class="umb-table-row">
+        <div class="umb-table-cell not-fixed" data-label="Action"><button class="btn-success" type="button" data-action="view-order" data-order-id="${i(e.uniqueId)}">View</button></div>
+        <div class="umb-table-cell" data-label="Order Number" title="${i(e.uniqueId)}">${i(e.referenceId)}</div>
+        <div class="umb-table-cell" data-label="Status">
+          <select data-action="change-row-status" data-order-id="${i(e.uniqueId)}">
+            ${l.statusList.map((t) => {
+      const s = g(t);
+      return `<option value="${i(s)}" ${e.orderStatusCol === s ? "selected" : ""}>${i(t.label)}</option>`;
+    }).join("")}
+          </select>
+        </div>
+        <div class="umb-table-cell" data-label="Name">${i(e.customerName)}</div>
+        <div class="umb-table-cell" data-label="Store">${i(e.storeAlias)}</div>
+        <div class="umb-table-cell" data-label="Created">${i(b(e.createDate))}</div>
+        <div class="umb-table-cell" data-label="Payment">${i(e.formattedTotal)}</div>
+      </div>
+    `;
+  }
+  renderPagination() {
+    return `
+      <div class="pagination">
+        <ul>
+          ${z(this.page, this.result.totalPages).map((e) => {
+      const t = Number(String(e).replace("...", ""));
+      return `<li class="${t === this.page ? "active" : ""}"><button type="button" data-action="set-page" data-page="${t}" ${t === this.page ? "disabled" : ""}>${i(e)}</button></li>`;
+    }).join("")}
+        </ul>
+      </div>
+    `;
+  }
+  renderOverlay() {
+    return this.overlay === "filter" ? this.renderFilterOverlay() : this.overlay === "export" ? this.renderExportOverlay() : this.overlay === "order" && this.selectedOrder ? this.renderOrderOverlay(this.selectedOrder) : "";
+  }
+  renderFilterOverlay() {
+    const e = l.filters;
+    return `
+      <div class="ekmOverlay">
+        <div class="ekmOverlay__panel ekmOverlay__panel--small">
+          <div class="ekmOverlay__header"><h2>Filter</h2><button class="btn-reset" type="button" data-action="close-overlay">&times;</button></div>
+          <div class="ekmOverlay__content">
+            <label class="control-group">Payment provider:
+              <select data-filter-field="paymentProvider">
+                <option value="">Select payment provider</option>
+                ${l.paymentProviders.map((t) => `<option value="${i(t.key)}" ${e.paymentProvider === t.key ? "selected" : ""}>${i(t.title)}</option>`).join("")}
+              </select>
+            </label>
+            ${this.renderFilterInput("productSku", "Product SKU:", "Exact SKU")}
+            ${this.renderFilterInput("trackingSource", "Tracking source:", "facebook")}
+            ${this.renderFilterInput("trackingMedium", "Tracking medium:", "paid-social")}
+            ${this.renderFilterInput("trackingCampaign", "Tracking campaign:", "summer_2026")}
+            ${this.renderFilterInput("trackingTerm", "Tracking term:", "running shoes")}
+            ${this.renderFilterInput("trackingContent", "Tracking content:", "hero_banner")}
+            ${this.renderFilterInput("trackingClickId", "Tracking click id:", "gclid or fbclid")}
+            <div style="margin-top:25px; display:flex; gap:10px;"><button type="button" class="btn-success" data-action="apply-filter">Apply</button><button type="button" class="btn-outline" data-action="close-overlay">Cancel</button></div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+  renderFilterInput(e, t, s) {
+    return `
+      <label class="control-group">${i(t)}
+        <input type="text" data-filter-field="${i(e)}" value="${i(l.filters[e])}" placeholder="${i(s)}">
+      </label>
+    `;
+  }
+  renderExportOverlay() {
+    return `
+      <div class="ekmOverlay">
+        <div class="ekmOverlay__panel ekmOverlay__panel--small">
+          <div class="ekmOverlay__header"><h2>Export orders</h2><button class="btn-reset" type="button" data-action="close-overlay" ${this.exporting ? "disabled" : ""}>&times;</button></div>
+          <div class="ekmOverlay__content">
+            <p>Choose how to export the orders matching the current filters.</p>
+            <label style="display:block; margin-top:15px;"><input type="checkbox" data-field="includeOrderLines" ${this.exportIncludeOrderLines ? "checked" : ""} ${this.exporting ? "disabled" : ""}> Include order lines</label>
+            ${this.exportIncludeOrderLines ? '<p style="margin-top:10px;">Including order lines can take longer because each matching order needs to be loaded before the CSV is created.</p>' : ""}
+            ${this.exporting ? '<p style="margin-top:15px;">Exporting orders. This may take a while...</p>' : ""}
+            <div style="margin-top:25px; display:flex; gap:10px;"><button type="button" class="btn-success" data-action="export-orders" ${this.exporting ? "disabled" : ""}>Export</button><button type="button" class="btn-outline" data-action="close-overlay" ${this.exporting ? "disabled" : ""}>Cancel</button></div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+  renderOrderOverlay(e) {
+    return `
+      <div class="ekmOverlay">
+        <div class="ekmOverlay__panel ekmOrderOverlay__panel">
+          <div class="ekmOverlay__header"><h2>View Order</h2><button class="btn-reset" type="button" data-action="close-overlay">&times;</button></div>
+          <div class="ekmOverlay__content ekmOrder">
+            ${this.renderOrderDetails(e)}
+          </div>
+        </div>
+      </div>
+      ${this.customerEditorOpen ? this.renderCustomerEditor() : ""}
+    `;
+  }
+  renderOrderDetails(e) {
+    var d, c, m, v;
+    const t = ((d = e.customerInformation) == null ? void 0 : d.customer) || {}, s = ((c = e.customerInformation) == null ? void 0 : c.shipping) || {}, o = this.getOrderStatusValue(e.orderStatus);
+    return `
+      <div class="ekmOrder__header">
+        <h1>Order number: ${i(e.referenceId)}</h1>
+        <div class="ekmOrderStatusBar">
+          <label class="ekmOrderStatusBar__status">Order Status:
+            <select data-field="orderStatusOverlay">
+              ${l.statusList.map((y) => {
+      const u = g(y);
+      return `<option value="${i(u)}" ${o === u ? "selected" : ""}>${i(y.label)}</option>`;
+    }).join("")}
+            </select>
+          </label>
+          <label class="ekmCheckboxLabel"><input type="checkbox" data-field="notifyOrderStatus"> Fire events?</label>
+          <button type="button" class="btn-success" data-action="save-overlay-status">Save</button>
+          <button type="button" class="btn-outline ekmOrderStatusBar__print" data-action="print-order">Print</button>
+        </div>
+        <p>UniqueId: ${i(e.uniqueId)}</p>
+        <p>Created date: ${i(b(e.createDate))}</p>
+        <p>Paid date: ${i(b(e.paidDate))}</p>
+        <p>Store: ${i(((m = e.storeInfo) == null ? void 0 : m.alias) || e.storeAlias)}</p>
+        <p>Payment: <strong>${i((v = e.chargedAmount) == null ? void 0 : v.currencyString)}</strong></p>
+        ${this.renderOrderActions()}
+      </div>
+      <div class="ekmSplit">
+        <div class="ekmSplit__column"><h4>Billing</h4><button type="button" class="btn-outline" data-action="open-customer-editor" style="margin-bottom:10px;">Edit customer information</button>${this.renderAddress(t)}${this.renderExtraProperties(t.properties, "customer")}</div>
+        <div class="ekmSplit__column"><h4>Shipping</h4>${J(s) ? `${this.renderAddress(s)}${this.renderExtraProperties(s.properties, "shipping")}` : '<p style="font-weight:bold">Same as billing address</p>'}</div>
+      </div>
+      <div class="ekmSplit">
+        <div class="ekmSplit__column">${this.renderProvider("Payment Method", e.paymentProvider, "custompayment")}</div>
+        <div class="ekmSplit__column">${this.renderProvider("Shipping Method", e.shippingProvider, "customshipping")}</div>
+      </div>
+      ${this.renderOrderLines(e)}
+      ${this.renderTracking(e)}
+      ${this.renderConsent(e)}
+      ${this.renderActivityLogs()}
+    `;
+  }
+  renderAddress(e) {
+    return ["name", "email", "address", "apartment", "city", "country", "zipCode", "phone"].filter((t) => e[t]).map((t) => `<p>${G(t)}: ${i(f(e[t]))}</p>`).join("");
+  }
+  renderExtraProperties(e, t) {
+    const s = D(e, t);
+    return s.length ? `<h5 style="margin-top:20px; font-weight:bold;">Extra ${t === "shipping" ? "Shipping" : "Customer"} Data</h5><ul>${s.map(([o, d]) => `<li><strong>${i(q(o))}</strong>: ${i(d)}</li>`).join("")}</ul>` : "";
+  }
+  renderProvider(e, t, s) {
+    var o;
+    return t ? `<h4>${i(e)}</h4><h4><strong>${i(t.title)}</strong></h4>${t.price ? `<p>Price: ${i((o = t.price.withVat) == null ? void 0 : o.currencyString)}</p>` : ""}${this.renderExtraProperties(t.customData, s)}` : "";
+  }
+  renderOrderLines(e) {
+    var s, o, d, c, m, v, y;
+    return `
+      <h4>Order Details</h4>
+      <div class="umb-table">
+        <div class="umb-table-head"><div class="umb-table-row"><div class="umb-table-cell not-fixed">Product</div><div class="umb-table-cell">Quantity</div><div class="umb-table-cell">Unit Price (inc VAT)</div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">Discount</div><div class="umb-table-cell">Total (inc VAT)</div></div></div>
+        <div class="umb-table-body">
+          ${(Array.isArray(e.orderLines) ? e.orderLines : []).map((u) => {
+      var $, O, k, S, w, x, E, _, C, A, L;
+      return `<div class="umb-table-row"><div class="umb-table-cell not-fixed">${i(($ = u.product) == null ? void 0 : $.title)} (${i((O = u.product) == null ? void 0 : O.sku)})${u.variant ? `<small style="display:block; margin-top:3px;">${i(u.variant.title)} ${u.variant.sku ? `(${i(u.variant.sku)})` : ""}</small>` : ""}${Q(u)}</div><div class="umb-table-cell">${i(u.quantity)}</div><div class="umb-table-cell">${i((w = (S = (k = u.product) == null ? void 0 : k.price) == null ? void 0 : S.withVat) == null ? void 0 : w.currencyString)}</div><div class="umb-table-cell">${i((E = (x = u.amount) == null ? void 0 : x.vat) == null ? void 0 : E.currencyString)}</div><div class="umb-table-cell">-${i((C = (_ = u.amount) == null ? void 0 : _.discountAmount) == null ? void 0 : C.currencyString)}</div><div class="umb-table-cell"><strong>${i((L = (A = u.amount) == null ? void 0 : A.withVat) == null ? void 0 : L.currencyString)}</strong></div></div>`;
+    }).join("")}
+        </div>
+        <div class="umb-table-footer">
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Sub Total (inc VAT)</div><div class="umb-table-cell">${i((o = (s = e.subTotal) == null ? void 0 : s.withVat) == null ? void 0 : o.currencyString)}</div></div>
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Discount</div><div class="umb-table-cell">-${i((d = e.discountAmount) == null ? void 0 : d.currencyString)}</div></div>
+          ${e.shippingProvider ? `<div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Shipping Total</div><div class="umb-table-cell">${i((m = (c = e.shippingProvider.price) == null ? void 0 : c.withVat) == null ? void 0 : m.currencyString)}</div></div>` : ""}
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">${i((v = e.chargedVat) == null ? void 0 : v.currencyString)}</div></div>
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Total</div><div class="umb-table-cell"><strong>${i((y = e.chargedAmount) == null ? void 0 : y.currencyString)}</strong></div></div>
+        </div>
+      </div>
+    `;
+  }
+  renderTracking(e) {
+    const t = e.tracking;
+    return ee(t) ? `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Tracking</h4><button class="btn-reset" type="button" data-action="toggle-tracking">${this.trackingExpanded ? "Hide" : "Show"}</button></div>${this.trackingExpanded ? te(t) : ""}</div>` : '<div class="ekmOrderTracking"><h4>Tracking</h4><p>No tracking data was captured for this order.</p></div>';
+  }
+  renderConsent(e) {
+    const t = e.consent;
+    return re(t) ? `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Consent</h4><button class="btn-reset" type="button" data-action="toggle-consent">${this.consentExpanded ? "Hide" : "Show"}</button></div>${this.consentExpanded ? `<p>Resolved: ${i(b(t.resolvedAtUtc))}</p><p>Source: ${i(t.source)}</p><p>Analytics: ${T(t.analytics)}</p><p>Marketing: ${T(t.marketing)}</p>` : ""}</div>` : '<div class="ekmOrderTracking"><h4>Consent</h4><p>No consent data was captured for this order.</p></div>';
+  }
+  renderActivityLogs() {
+    return this.orderLogsLoading ? '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>Loading activity...</p></div>' : this.orderLogs.length ? `<div class="ekmOrderActivityLog"><h4>Activity log</h4>${this.orderLogs.map((e) => `<div class="ekmOrderActivityLog__item"><div class="ekmOrderActivityLog__date">${i(b(e.date))}</div><div>${i(e.message)}</div></div>`).join("")}</div>` : '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>No activity yet.</p></div>';
+  }
+  renderOrderActions() {
+    return !this.orderActions.length && !this.orderActionsLoading ? "" : `<div style="margin-top:15px;"><h4>Order Actions</h4><div style="display:flex; flex-wrap:wrap; gap:10px;">${this.orderActions.map((e) => `<button type="button" class="${e.look === "primary" ? "btn-success" : "btn-outline"}" data-action="execute-order-action" data-action-key="${i(e.key)}" ${e.enabled === !1 || this.executingActionKey === e.key ? "disabled" : ""}>${i(e.label)}</button>`).join("")}</div>${this.orderActionsLoading ? "<p>Loading actions...</p>" : ""}</div>`;
+  }
+  renderCustomerEditor() {
+    const e = this.customerEditModel;
+    return e ? `<div class="ekmCustomerInformationModal"><div class="ekmCustomerInformationModal__panel"><div class="ekmOverlay__header"><h3>Edit customer information</h3><button class="btn-reset" type="button" data-action="close-customer-editor" ${this.customerSaving ? "disabled" : ""}>&times;</button></div><div class="ekmOverlay__content"><div class="ekmSplit"><div class="ekmSplit__column"><h4>Billing</h4>${this.renderCustomerFields(e.customer, "customer")}</div><div class="ekmSplit__column"><h4>Shipping</h4>${this.renderCustomerFields(e.shipping, "shipping")}</div></div><div style="display:flex; justify-content:flex-end; gap:10px; padding-top:20px; border-top:1px solid #d8d7d9;"><button class="btn-outline" type="button" data-action="close-customer-editor" ${this.customerSaving ? "disabled" : ""}>Cancel</button><button class="btn-success" type="button" data-action="save-customer-information" ${this.customerSaving ? "disabled" : ""}>${this.customerSaving ? "Saving..." : "Save customer information"}</button></div></div></div></div>` : "";
+  }
+  renderCustomerFields(e, t) {
+    return e.map((s) => `<label class="control-group">${i(s.label)} ${s.isExtra ? `<small>(${i(s.key)})</small>` : ""}<input type="text" data-customer-group="${t}" data-customer-key="${i(s.key)}" value="${i(s.value)}" ${this.customerSaving ? "disabled" : ""}></label>`).join("");
+  }
+  bindEvents() {
+    this.querySelectorAll("[data-action]").forEach((e) => {
+      e instanceof HTMLSelectElement ? e.addEventListener("change", (t) => void this.handleAction(t)) : e.addEventListener("click", (t) => void this.handleAction(t));
+    }), this.querySelectorAll("[data-field]").forEach((e) => {
+      e.addEventListener("change", (t) => void this.handleFieldChange(t)), e.dataset.field === "query" && e.addEventListener("input", (t) => this.handleSearchInput(t));
+    });
+  }
+  async handleAction(e) {
+    const t = e.currentTarget, s = t.dataset.action;
+    if (s === "set-page") {
+      this.page = Number(t.dataset.page || 1), await this.loadOrders();
+      return;
+    }
+    if (s === "open-filter" || s === "open-export") {
+      this.overlay = s === "open-filter" ? "filter" : "export", this.render();
+      return;
+    }
+    if (s === "close-overlay") {
+      this.closeOverlay();
+      return;
+    }
+    if (s === "apply-filter") {
+      this.applyFilterOverlay(), this.overlay = "", this.page = 1, await this.loadOrders();
+      return;
+    }
+    if (s === "export-orders") {
+      await this.exportOrders();
+      return;
+    }
+    if (s === "view-order") {
+      await this.openOrder(t.dataset.orderId || "");
+      return;
+    }
+    if (s === "save-overlay-status") {
+      await this.saveOverlayStatus();
+      return;
+    }
+    if (s === "change-row-status") {
+      await this.changeRowStatus(t);
+      return;
+    }
+    if (s === "print-order") {
+      window.print();
+      return;
+    }
+    if (s === "toggle-tracking") {
+      this.trackingExpanded = !this.trackingExpanded, this.renderPreservingOverlayScroll();
+      return;
+    }
+    if (s === "toggle-consent") {
+      this.consentExpanded = !this.consentExpanded, this.renderPreservingOverlayScroll();
+      return;
+    }
+    if (s === "execute-order-action") {
+      await this.executeOrderAction(t.dataset.actionKey || "");
+      return;
+    }
+    if (s === "open-customer-editor") {
+      this.openCustomerEditor();
+      return;
+    }
+    if (s === "close-customer-editor") {
+      this.customerEditorOpen = !1, this.customerEditModel = void 0, this.render();
+      return;
+    }
+    s === "save-customer-information" && await this.saveCustomerInformation();
+  }
+  async handleFieldChange(e) {
+    const t = e.currentTarget, s = t.dataset.field;
+    if (s === "includeOrderLines") {
+      this.exportIncludeOrderLines = t.checked, this.render();
+      return;
+    }
+    s === "orderStatusOverlay" || s === "notifyOrderStatus" || s === "query" || !s || !(s in l.filters) || (l.filters[s] = t.value, this.page = 1, s === "store" && await this.loadPaymentProviders(!0), await this.loadOrders());
+  }
+  handleSearchInput(e) {
+    const t = e.currentTarget;
+    l.filters.query = t.value, this.page = 1, window.clearTimeout(this.searchTimer), this.searchTimer = window.setTimeout(() => void this.loadOrders(), 700);
+  }
+  applyFilterOverlay() {
+    this.querySelectorAll("[data-filter-field]").forEach((e) => {
+      const t = e.dataset.filterField;
+      t && t in l.filters && (l.filters[t] = e.value);
+    });
+  }
+  async exportOrders() {
+    if (this.result.count) {
+      this.exporting = !0, this.render();
+      try {
+        const e = await this.api.exportOrders(l.filters, this.result.count, this.exportIncludeOrderLines);
+        R(e, this.exportIncludeOrderLines ? "orders-with-orderlines.csv" : "orders.csv"), this.overlay = "";
+      } catch (e) {
+        this.showError(h(e, "Error exporting orders."));
+      } finally {
+        this.exporting = !1, this.render();
+      }
+    }
+  }
+  async openOrder(e) {
+    if (e)
+      try {
+        this.selectedOrder = await this.api.orderInfo(e), this.overlay = "order", this.trackingExpanded = !1, this.consentExpanded = !1, this.render(), await Promise.all([this.loadOrderLogs(e), this.loadOrderActions(e)]);
+      } catch (t) {
+        this.showError(h(t, "Error on getting orderInfo."));
+      }
+  }
+  async loadOrderLogs(e) {
+    this.orderLogsLoading = !0, this.render();
+    try {
+      this.orderLogs = await this.api.orderLogs(e);
+    } catch {
+      this.orderLogs = [];
+    } finally {
+      this.orderLogsLoading = !1, this.render();
+    }
+  }
+  async loadOrderActions(e) {
+    this.orderActionsLoading = !0, this.render();
+    try {
+      this.orderActions = await this.api.orderActions(e);
+    } catch {
+      this.orderActions = [];
+    } finally {
+      this.orderActionsLoading = !1, this.render();
+    }
+  }
+  async saveOverlayStatus() {
+    var s, o, d;
+    if (!((s = this.selectedOrder) != null && s.uniqueId))
+      return;
+    const e = ((o = this.querySelector('[data-field="orderStatusOverlay"]')) == null ? void 0 : o.value) || "", t = ((d = this.querySelector('[data-field="notifyOrderStatus"]')) == null ? void 0 : d.checked) || !1;
+    try {
+      await this.api.changeOrderStatus(this.selectedOrder.uniqueId, e, t), this.selectedOrder.orderStatus = e, this.showSuccess("Order status updated."), await this.loadOrders(), await this.loadOrderLogs(this.selectedOrder.uniqueId);
+    } catch (c) {
+      this.showError(h(c, "Error updating order status."));
+    }
+  }
+  showSuccess(e) {
+    this.showNotification("positive", "Success", e);
+  }
+  showError(e) {
+    this.showNotification("danger", "Error", e);
+  }
+  showNotification(e, t, s) {
+    if (this.notificationContext) {
+      this.notificationContext.peek(e, {
+        data: {
+          headline: t,
+          message: s
+        }
+      });
+      return;
+    }
+    e === "danger" && console.error(`${t}: ${s}`);
+  }
+  renderPreservingOverlayScroll() {
+    const e = this.querySelector(".ekmOverlay"), t = (e == null ? void 0 : e.scrollTop) ?? 0;
+    this.render(), requestAnimationFrame(() => {
+      const s = this.querySelector(".ekmOverlay");
+      s && (s.scrollTop = t);
+    });
+  }
+  closeOverlay() {
+    this.overlay = "", this.selectedOrder = void 0, this.customerEditorOpen = !1, this.customerEditModel = void 0, this.render();
+  }
+  getOrderStatusValue(e) {
+    const t = String(e ?? ""), s = l.statusList.find((o) => String(o.value ?? "") === t || String(o.enumValue ?? "") === t);
+    return s ? g(s) : t;
+  }
+  async changeRowStatus(e) {
+    const t = e.dataset.orderId || "";
+    if (t)
+      try {
+        await this.api.changeOrderStatus(t, e.value, !0);
+        const s = this.result.orders.find((o) => o.uniqueId === t);
+        s && (s.orderStatusCol = e.value), this.showSuccess("Order status updated.");
+      } catch (s) {
+        this.showError(h(s, "Error updating order status.")), await this.loadOrders();
+      }
+  }
+  async executeOrderAction(e) {
+    var s;
+    if (!((s = this.selectedOrder) != null && s.uniqueId) || !e || this.executingActionKey)
+      return;
+    const t = this.orderActions.find((o) => o.key === e);
+    if (!(t != null && t.confirmMessage && !window.confirm(t.confirmMessage))) {
+      this.executingActionKey = e, this.render();
+      try {
+        const o = await this.api.executeOrderAction(this.selectedOrder.uniqueId, e), d = await o.blob(), c = o.headers.get("content-disposition") || "", m = o.headers.get("content-type") || "";
+        if (c.toLowerCase().includes("filename=") || m.startsWith("application/pdf") || m.startsWith("application/octet-stream") || m.startsWith("image/"))
+          window.open(URL.createObjectURL(d), "_blank");
+        else {
+          const v = await d.text();
+          this.showSuccess(se(v));
+        }
+        this.selectedOrder = await this.api.orderInfo(this.selectedOrder.uniqueId), await this.loadOrderLogs(this.selectedOrder.uniqueId), await this.loadOrderActions(this.selectedOrder.uniqueId);
+      } catch (o) {
+        this.showError(h(o, "Order action failed."));
+      } finally {
+        this.executingActionKey = "", this.render();
+      }
+    }
+  }
+  openCustomerEditor() {
+    var o, d;
+    const e = this.selectedOrder;
+    if (!e)
+      return;
+    const t = ((o = e.customerInformation) == null ? void 0 : o.customer) || {}, s = ((d = e.customerInformation) == null ? void 0 : d.shipping) || {};
+    this.customerEditModel = {
+      customer: P(t, H).concat(M(t.properties, "customer")),
+      shipping: P(s, Z).concat(M(s.properties, "shipping"))
+    }, this.customerEditorOpen = !0, this.render();
+  }
+  async saveCustomerInformation() {
+    var e;
+    if (!(!((e = this.selectedOrder) != null && e.uniqueId) || !this.customerEditModel || this.customerSaving)) {
+      this.querySelectorAll("[data-customer-group]").forEach((t) => {
+        var c;
+        const s = t.dataset.customerGroup, o = t.dataset.customerKey, d = (c = this.customerEditModel) == null ? void 0 : c[s].find((m) => m.key === o);
+        d && (d.value = t.value);
+      }), this.customerSaving = !0, this.render();
+      try {
+        this.selectedOrder = await this.api.updateCustomerInformation(
+          this.selectedOrder.uniqueId,
+          F(this.customerEditModel.customer),
+          F(this.customerEditModel.shipping)
+        ), this.customerEditorOpen = !1, this.customerEditModel = void 0, this.showSuccess("Customer information updated."), await this.loadOrders();
+      } catch (t) {
+        this.showError(h(t, "Error updating customer information."));
+      } finally {
+        this.customerSaving = !1, this.render();
+      }
+    }
+  }
+}
+function h(r, a) {
+  return r instanceof Error ? r.message : a;
+}
+function G(r) {
+  return r === "zipCode" ? "Zipcode" : r.charAt(0).toUpperCase() + r.slice(1);
+}
+function Y(r) {
+  return (/* @__PURE__ */ new Set(["shippingname", "shippingaddress", "shippingcity", "shippingcountry", "shippingemail", "shippingapartment", "shippingzipcode", "shippingphone", "customeremail", "customername", "customeraddress", "customerapartment", "customercity", "customercountry", "customerzipcode", "customerphone"])).has(r.toLowerCase());
+}
+function q(r) {
+  return r.replace(/^customshipping/i, "").replace(/^custompayment/i, "").replace(/^shipping/i, "").replace(/^customer/i, "");
+}
+function D(r, a) {
+  return Object.entries(r || {}).filter(([e, t]) => !!t && e.toLowerCase().startsWith(a) && !Y(e)).map(([e, t]) => [e, f(t)]);
+}
+function J(r) {
+  return !!(r != null && r.name || r != null && r.email || r != null && r.address || r != null && r.apartment || r != null && r.city || r != null && r.country || r != null && r.zipCode || r != null && r.phone);
+}
+function Q(r) {
+  var e;
+  const a = ((e = r.orderLineInfo) == null ? void 0 : e.properties) || {};
+  return Object.entries(a).filter(([, t]) => !!t).map(([t, s]) => `<small style="display:block; margin-top:3px;"><strong>${i(X(t))}</strong>: ${i(f(s))}</small>`).join("");
+}
+function X(r) {
+  const a = r.replace(/^orderline/i, "").replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+  return a ? a.charAt(0).toUpperCase() + a.slice(1) : r;
+}
+function ee(r) {
+  var a, e, t, s;
+  return !!(r && (r.source || r.medium || r.campaign || r.term || r.content || r.clickId || r.clickIdType || r.landingUrl || r.referrer || r.captureMethod || r.capturedAtUtc || r.hasCookieSupport !== null && r.hasCookieSupport !== void 0 || (a = r.ga4) != null && a.clientId || (e = r.ga4) != null && e.sessionId || (t = r.meta) != null && t.fbp || (s = r.meta) != null && s.fbc));
+}
+function te(r) {
+  var t, s, o, d, c, m;
+  const a = Object.entries(((t = r.ga4) == null ? void 0 : t.data) || {}), e = Object.entries(((s = r.meta) == null ? void 0 : s.data) || {});
+  return `<div class="ekmSplit"><div class="ekmSplit__column">${p("Captured", b(r.capturedAtUtc))}${p("Capture method", r.captureMethod)}${r.hasCookieSupport !== null && r.hasCookieSupport !== void 0 ? `<p>Cookie support: ${r.hasCookieSupport ? "Yes" : "No"}</p>` : ""}${p("Source", r.source)}${p("Medium", r.medium)}${p("Campaign", r.campaign)}${p("Term", r.term)}${p("Content", r.content)}${p("Click ID", r.clickId)}${p("Click ID Type", r.clickIdType)}${p("Landing URL", r.landingUrl)}${p("Referrer", r.referrer)}</div><div class="ekmSplit__column"><h5>GA4</h5>${p("Client ID", (o = r.ga4) == null ? void 0 : o.clientId)}${p("Session ID", (d = r.ga4) == null ? void 0 : d.sessionId)}${I(a)}<h5>Meta</h5>${p("FBP", (c = r.meta) == null ? void 0 : c.fbp)}${p("FBC", (m = r.meta) == null ? void 0 : m.fbc)}${I(e)}</div></div>`;
+}
+function p(r, a) {
+  return a ? `<p class="ekmOrderTracking__wrap">${i(r)}: ${i(a)}</p>` : "";
+}
+function I(r) {
+  return r.length ? `<ul>${r.map(([a, e]) => `<li><strong>${i(a)}</strong>: ${i(e)}</li>`).join("")}</ul>` : "";
+}
+function re(r) {
+  return !!(r && (r.resolvedAtUtc || r.source || r.analytics !== null && r.analytics !== void 0 || r.marketing !== null && r.marketing !== void 0));
+}
+function T(r) {
+  return r === !0 ? "Yes" : r === !1 ? "No" : "Unknown";
+}
+function P(r, a) {
+  return a.map((e) => {
+    var t;
+    return {
+      key: e.key,
+      label: e.label,
+      value: f(r[e.property] || ((t = r.properties) == null ? void 0 : t[e.key]) || ""),
+      isExtra: !1
+    };
+  });
+}
+function M(r, a) {
+  return D(r, a).map(([e, t]) => ({
+    key: e,
+    label: q(e).replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim() || e,
+    value: t,
+    isExtra: !0
+  }));
+}
+function F(r) {
+  return Object.fromEntries(r.map((a) => [a.key, a.value || ""]));
+}
+function se(r) {
+  try {
+    return JSON.parse(r).message || r;
+  } catch {
+    return r;
+  }
+}
+customElements.define("ekom-orders-section-view", W);
+export {
+  W as EkomOrdersSectionViewElement,
+  W as default
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/analytics-section-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/analytics-section-view.element.ts
@@ -1,0 +1,269 @@
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import {
+  ChartData,
+  EkomManagerApi,
+  MostSoldProductsResult,
+  escapeHtml,
+  getStatusValue,
+  managerState,
+  managerStyles,
+  pageRange,
+  renderLineChart,
+} from './manager-shared';
+
+export class EkomAnalyticsSectionViewElement extends UmbElementMixin(HTMLElement) {
+  private readonly api = new EkomManagerApi();
+  private loading = true;
+  private loadingMostSoldProducts = true;
+  private error = '';
+  private chartData?: ChartData;
+  private mostSoldProducts: MostSoldProductsResult = { products: [], count: 0, totalPages: 0, page: 1 };
+  private pageMostSoldProducts = 1;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.render();
+    void this.initialize();
+  }
+
+  private async initialize(): Promise<void> {
+    try {
+      const [statuses, stores] = await Promise.all([
+        this.api.statusList(),
+        this.api.stores(),
+      ]);
+
+      managerState.statusList = statuses || [];
+      managerState.stores = stores || [];
+
+      if (!managerState.filters.store && managerState.stores.length) {
+        managerState.filters.store = managerState.stores[0].alias;
+      }
+
+      await this.loadAnalytics();
+    } catch (error) {
+      this.error = getErrorMessage(error, 'Error loading Ekom analytics.');
+      this.loading = false;
+      this.loadingMostSoldProducts = false;
+      this.render();
+    }
+  }
+
+  private async loadAnalytics(): Promise<void> {
+    await Promise.all([
+      this.loadCharts(),
+      this.loadMostSoldProducts(),
+    ]);
+  }
+
+  private async loadCharts(): Promise<void> {
+    if (!managerState.filters.store) {
+      this.loading = false;
+      return;
+    }
+
+    this.loading = true;
+    this.error = '';
+    this.render();
+
+    try {
+      this.chartData = await this.api.charts(managerState.filters);
+    } catch (error) {
+      this.error = getErrorMessage(error, 'Error on chart data.');
+    } finally {
+      this.loading = false;
+      this.render();
+      this.renderCharts();
+    }
+  }
+
+  private async loadMostSoldProducts(): Promise<void> {
+    if (!managerState.filters.store) {
+      this.loadingMostSoldProducts = false;
+      return;
+    }
+
+    this.loadingMostSoldProducts = true;
+    this.render();
+
+    try {
+      this.mostSoldProducts = await this.api.mostSoldProducts(managerState.filters, this.pageMostSoldProducts);
+      this.mostSoldProducts.products = this.mostSoldProducts.products || [];
+      this.pageMostSoldProducts = this.mostSoldProducts.page || this.pageMostSoldProducts;
+    } catch (error) {
+      this.error = getErrorMessage(error, 'Error on most sold products data.');
+    } finally {
+      this.loadingMostSoldProducts = false;
+      this.render();
+      this.renderCharts();
+    }
+  }
+
+  private render(): void {
+    this.innerHTML = `
+      <style>${managerStyles}</style>
+      <section class="ekmManager">
+        <div class="ekmManager__body">
+          ${this.renderToolbar()}
+          ${this.error ? `<p class="status status--error">${escapeHtml(this.error)}</p>` : ''}
+          ${this.renderAnalytics()}
+        </div>
+      </section>
+    `;
+
+    this.bindEvents();
+    this.renderCharts();
+  }
+
+  private renderToolbar(): string {
+    const filters = managerState.filters;
+    return `
+      <div class="umb-sub-header">
+        <div class="ekmManager__filters">
+          <label class="ekmManager__filter">Order Status:
+            <select data-field="orderStatus">
+              <option value="CompletedOrders" ${filters.orderStatus === 'CompletedOrders' ? 'selected' : ''}>Completed Orders</option>
+              <option value="AllOrders" ${filters.orderStatus === 'AllOrders' ? 'selected' : ''}>All Orders</option>
+              ${managerState.statusList.map(status => {
+                const value = getStatusValue(status);
+                return `<option value="${escapeHtml(value)}" ${filters.orderStatus === value ? 'selected' : ''}>${escapeHtml(status.label)}</option>`;
+              }).join('')}
+            </select>
+          </label>
+          <label class="ekmManager__filter">Date From:
+            <input type="date" data-field="dateFrom" value="${escapeHtml(filters.dateFrom)}">
+          </label>
+          <label class="ekmManager__filter">Date To:
+            <input type="date" data-field="dateTo" value="${escapeHtml(filters.dateTo)}">
+          </label>
+          <label class="ekmManager__filter">Store:
+            <select data-field="store">
+              ${managerState.stores.map(store => `<option value="${escapeHtml(store.alias)}" ${filters.store === store.alias ? 'selected' : ''}>${escapeHtml(store.title)}</option>`).join('')}
+            </select>
+          </label>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAnalytics(): string {
+    return `
+      <div class="ekmGrid">
+        <div class="card ekmChartCard"><h3>Sales Revenue</h3><div class="ekmChartCard__canvas">${this.loading ? '<p>Loading chart...</p>' : '<canvas id="chartRevenue"></canvas>'}</div></div>
+        <div class="card ekmChartCard"><h3>Total Orders</h3><div class="ekmChartCard__canvas">${this.loading ? '<p>Loading chart...</p>' : '<canvas id="chartOrders"></canvas>'}</div></div>
+        <div class="card ekmChartCard"><h3>Average Order Value</h3><div class="ekmChartCard__canvas">${this.loading ? '<p>Loading chart...</p>' : '<canvas id="chartAvarage"></canvas>'}</div></div>
+      </div>
+      <div class="card ekmChartCard">
+        <h3>Most Sold Products</h3>
+        ${this.loadingMostSoldProducts ? '<p>Loading most sold products...</p>' : this.renderMostSoldProducts()}
+      </div>
+    `;
+  }
+
+  private renderMostSoldProducts(): string {
+    if (!this.mostSoldProducts.products.length) {
+      return '<p>No products found.</p>';
+    }
+
+    return `
+      <div class="umb-table">
+        <div class="umb-table-head"><div class="umb-table-row"><div class="umb-table-cell">Product</div><div class="umb-table-cell">Sku</div><div class="umb-table-cell">Quantity</div><div class="umb-table-cell">Total</div></div></div>
+        <div class="umb-table-body">
+          ${this.mostSoldProducts.products.map(product => `<div class="umb-table-row"><div class="umb-table-cell">${escapeHtml(readProductValue(product, 'title', 'productTitle', 'name'))}</div><div class="umb-table-cell">${escapeHtml(readProductValue(product, 'sku', 'productSku'))}</div><div class="umb-table-cell">${escapeHtml(readProductValue(product, 'quantity', 'count'))}</div><div class="umb-table-cell">${escapeHtml(readProductValue(product, 'formattedTotal', 'total'))}</div></div>`).join('')}
+        </div>
+      </div>
+      ${this.mostSoldProducts.totalPages > 1 ? this.renderMostSoldProductsPagination() : ''}
+    `;
+  }
+
+  private renderMostSoldProductsPagination(): string {
+    return `
+      <div class="pagination">
+        <ul>
+          ${pageRange(this.pageMostSoldProducts, this.mostSoldProducts.totalPages).map(page => {
+            const pageNumber = Number(String(page).replace('...', ''));
+            return `<li class="${pageNumber === this.pageMostSoldProducts ? 'active' : ''}"><button type="button" data-action="set-most-sold-page" data-page="${pageNumber}" ${pageNumber === this.pageMostSoldProducts ? 'disabled' : ''}>${escapeHtml(page)}</button></li>`;
+          }).join('')}
+        </ul>
+      </div>
+    `;
+  }
+
+  private renderCharts(): void {
+    if (!this.chartData) {
+      return;
+    }
+
+    const revenue = this.querySelector<HTMLCanvasElement>('#chartRevenue');
+    const orders = this.querySelector<HTMLCanvasElement>('#chartOrders');
+    const average = this.querySelector<HTMLCanvasElement>('#chartAvarage');
+
+    if (revenue) {
+      renderLineChart(revenue, this.chartData.revenueChart, 'rgba(30, 64, 175, 1)');
+    }
+
+    if (orders) {
+      renderLineChart(orders, this.chartData.ordersChart, 'rgba(8, 145, 178, 1)');
+    }
+
+    if (average) {
+      renderLineChart(average, this.chartData.avarageChart, 'rgba(217, 119, 6, 1)');
+    }
+  }
+
+  private bindEvents(): void {
+    this.querySelectorAll('[data-action]').forEach(element => {
+      element.addEventListener('click', event => void this.handleAction(event));
+    });
+
+    this.querySelectorAll('[data-field]').forEach(element => {
+      element.addEventListener('change', event => void this.handleFieldChange(event));
+    });
+  }
+
+  private async handleAction(event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+
+    if (target.dataset.action === 'set-most-sold-page') {
+      this.pageMostSoldProducts = Number(target.dataset.page || 1);
+      await this.loadMostSoldProducts();
+    }
+  }
+
+  private async handleFieldChange(event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLInputElement | HTMLSelectElement;
+    const field = target.dataset.field;
+
+    if (!field || !(field in managerState.filters)) {
+      return;
+    }
+
+    (managerState.filters as Record<string, string>)[field] = target.value;
+    this.pageMostSoldProducts = 1;
+    await this.loadAnalytics();
+  }
+}
+
+function readProductValue(product: Record<string, unknown>, ...keys: string[]): unknown {
+  for (const key of keys) {
+    if (product[key] != null) {
+      return product[key];
+    }
+  }
+
+  return '';
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+customElements.define('ekom-analytics-section-view', EkomAnalyticsSectionViewElement);
+
+export default EkomAnalyticsSectionViewElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ekom-analytics-section-view': EkomAnalyticsSectionViewElement;
+  }
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/manager-shared.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/manager-shared.ts
@@ -1,0 +1,570 @@
+export type ManagerFilters = {
+  dateFrom: string;
+  dateTo: string;
+  orderStatus: string;
+  store: string;
+  paymentProvider: string;
+  productSku: string;
+  trackingSource: string;
+  trackingMedium: string;
+  trackingCampaign: string;
+  trackingTerm: string;
+  trackingContent: string;
+  trackingClickId: string;
+  query: string;
+};
+
+export type StatusItem = {
+  label: string;
+  value?: string;
+  enumValue?: string;
+};
+
+export type StoreItem = {
+  alias: string;
+  title: string;
+};
+
+export type PaymentProviderItem = {
+  key: string;
+  title: string;
+};
+
+export type OrderListItem = {
+  uniqueId: string;
+  referenceId: string | number;
+  orderStatusCol?: string;
+  customerName?: string;
+  storeAlias?: string;
+  createDate?: string;
+  formattedTotal?: string;
+};
+
+export type OrderSearchResult = {
+  orders: OrderListItem[];
+  count: number;
+  totalPages: number;
+  page?: number;
+  grandTotal?: string;
+  averageAmount?: string;
+};
+
+export type ChartPoint = {
+  x?: string;
+  y?: number;
+};
+
+export type ChartSeries = {
+  labels: string[];
+  points: ChartPoint[];
+};
+
+export type ChartData = {
+  revenueChart: ChartSeries;
+  ordersChart: ChartSeries;
+  avarageChart: ChartSeries;
+};
+
+export type MostSoldProductsResult = {
+  products: Array<Record<string, unknown>>;
+  count: number;
+  totalPages: number;
+  page: number;
+};
+
+export type OrderAction = {
+  key: string;
+  label: string;
+  enabled?: boolean;
+  look?: string;
+  confirmMessage?: string;
+};
+
+export type OrderActivityLog = {
+  date?: string;
+  message?: string;
+  logType?: number;
+};
+
+export type CustomerInformationField = {
+  key: string;
+  label: string;
+  value: string;
+  isExtra: boolean;
+};
+
+export type OrderInfo = Record<string, any>;
+
+export type ManagerState = {
+  filters: ManagerFilters;
+  statusList: StatusItem[];
+  stores: StoreItem[];
+  paymentProviders: PaymentProviderItem[];
+};
+
+const currentDate = new Date();
+const januaryFirstCurrentYear = new Date(currentDate.getFullYear(), 0, 1);
+
+export const managerState: ManagerState = {
+  filters: {
+    dateFrom: toDateInputValue(januaryFirstCurrentYear),
+    dateTo: toDateInputValue(currentDate),
+    orderStatus: 'CompletedOrders',
+    store: '',
+    paymentProvider: '',
+    productSku: '',
+    trackingSource: '',
+    trackingMedium: '',
+    trackingCampaign: '',
+    trackingTerm: '',
+    trackingContent: '',
+    trackingClickId: '',
+    query: '',
+  },
+  statusList: [],
+  stores: [],
+  paymentProviders: [],
+};
+
+export class EkomManagerApi {
+  async searchOrders(filters: ManagerFilters, page: number, pageSize = 20): Promise<OrderSearchResult> {
+    return this.getJson('/ekom/manager/SearchOrders', {
+      ...filters,
+      start: filters.dateFrom,
+      end: filters.dateTo,
+      page,
+      pageSize,
+    });
+  }
+
+  async exportOrders(filters: ManagerFilters, pageSize: number, includeOrderLines: boolean): Promise<Blob> {
+    return this.getBlob('/ekom/manager/ExportOrders', {
+      ...filters,
+      start: filters.dateFrom,
+      end: filters.dateTo,
+      page: 1,
+      pageSize,
+      includeOrderLines,
+    });
+  }
+
+  async statusList(): Promise<StatusItem[]> {
+    return this.getJson('/ekom/manager/StatusList');
+  }
+
+  async stores(): Promise<StoreItem[]> {
+    return this.getJson('/ekom/manager/stores');
+  }
+
+  async paymentProviders(storeAlias: string): Promise<PaymentProviderItem[]> {
+    return this.getJson(`/ekom/provider/paymentsproviders/${encodeURIComponent(storeAlias)}`);
+  }
+
+  async orderInfo(orderId: string): Promise<OrderInfo> {
+    return this.getJson(`/ekom/manager/OrderInfo/${encodeURIComponent(orderId)}`);
+  }
+
+  async orderLogs(orderId: string): Promise<OrderActivityLog[]> {
+    return this.getJson(`/ekom/manager/OrderLogs/${encodeURIComponent(orderId)}`);
+  }
+
+  async orderActions(orderId: string): Promise<OrderAction[]> {
+    return this.getJson(`/ekom/manager/OrderActions/${encodeURIComponent(orderId)}`);
+  }
+
+  async executeOrderAction(orderId: string, actionKey: string): Promise<Response> {
+    const response = await fetch(`/ekom/manager/OrderActions/${encodeURIComponent(orderId)}/${encodeURIComponent(actionKey)}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json, application/octet-stream' },
+    });
+
+    if (!response.ok) {
+      throw await EkomManagerApi.createError(response, 'Order action failed.');
+    }
+
+    return response;
+  }
+
+  async changeOrderStatus(orderId: string, orderStatus: string, notify: boolean): Promise<boolean> {
+    return this.postJson('/ekom/manager/changeOrderStatus', { orderId, orderStatus, notify });
+  }
+
+  async updateCustomerInformation(orderId: string, customer: Record<string, string>, shipping: Record<string, string>): Promise<OrderInfo> {
+    return this.postBody('/ekom/manager/UpdateCustomerInformation', { orderId, customer, shipping });
+  }
+
+  async charts(filters: ManagerFilters): Promise<ChartData> {
+    return this.getJson('/ekom/manager/charts', {
+      start: filters.dateFrom,
+      end: filters.dateTo,
+      orderStatus: filters.orderStatus,
+      store: filters.store,
+    });
+  }
+
+  async mostSoldProducts(filters: ManagerFilters, page: number, pageSize = 20): Promise<MostSoldProductsResult> {
+    return this.getJson('/ekom/manager/MostSoldProducts', {
+      start: filters.dateFrom,
+      end: filters.dateTo,
+      orderStatus: filters.orderStatus,
+      store: filters.store,
+      page,
+      pageSize,
+    });
+  }
+
+  private async getJson<T>(url: string, query?: Record<string, unknown>): Promise<T> {
+    const response = await fetch(url + buildQueryString(query), {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw await EkomManagerApi.createError(response, 'Request failed.');
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private async getBlob(url: string, query?: Record<string, unknown>): Promise<Blob> {
+    const response = await fetch(url + buildQueryString(query), {
+      credentials: 'same-origin',
+      headers: { Accept: 'text/csv, application/octet-stream' },
+    });
+
+    if (!response.ok) {
+      throw await EkomManagerApi.createError(response, 'Request failed.');
+    }
+
+    return response.blob();
+  }
+
+  private async postJson<T>(url: string, query?: Record<string, unknown>): Promise<T> {
+    const response = await fetch(url + buildQueryString(query), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw await EkomManagerApi.createError(response, 'Request failed.');
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private async postBody<T>(url: string, body: unknown): Promise<T> {
+    const response = await fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw await EkomManagerApi.createError(response, 'Request failed.');
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private static async createError(response: Response, fallbackMessage: string): Promise<Error> {
+    const text = await response.text();
+    let message = text || fallbackMessage;
+
+    try {
+      const data = JSON.parse(text) as { message?: string };
+      message = data.message || message;
+    } catch {
+      // Use plain text response.
+    }
+
+    return new Error(message || `${fallbackMessage} Status ${response.status}.`);
+  }
+}
+
+export function buildQueryString(query?: Record<string, unknown>): string {
+  if (!query) {
+    return '';
+  }
+
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query)) {
+    params.set(key, value == null ? '' : String(value));
+  }
+
+  const value = params.toString();
+  return value ? `?${value}` : '';
+}
+
+export function toDateInputValue(value: Date): string {
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${value.getFullYear()}-${month}-${day}`;
+}
+
+export function formatDate(value?: string): string {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+export function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function decodeHtml(value: unknown): string {
+  const textArea = document.createElement('textarea');
+  textArea.innerHTML = String(value ?? '');
+  return textArea.value;
+}
+
+export function getStatusValue(status: StatusItem): string {
+  return status.enumValue || status.value || '';
+}
+
+export function getStatusLabel(statuses: StatusItem[], value?: string): string {
+  const item = statuses.find(status => status.enumValue === value || status.value === value);
+  return item?.label || value || '';
+}
+
+export function pageRange(page: number, totalPages: number): Array<number | string> {
+  const rangeSize = 5;
+  const result: Array<number | string> = [];
+  const safeTotalPages = Math.max(totalPages || 1, 1);
+  let start: number;
+
+  if (page <= Math.floor(rangeSize / 2)) {
+    start = 1;
+  } else if (page + Math.floor(rangeSize / 2) >= safeTotalPages) {
+    start = Math.max(safeTotalPages - rangeSize + 1, 1);
+  } else {
+    start = page - Math.floor(rangeSize / 2);
+  }
+
+  for (let i = 0; i < rangeSize; i += 1) {
+    const pageNumber = start + i;
+
+    if (pageNumber <= safeTotalPages) {
+      result.push(pageNumber);
+    }
+  }
+
+  if (result.length && Number(result[result.length - 1]) < safeTotalPages) {
+    result.push(`...${safeTotalPages}`);
+  }
+
+  if (result.length && Number(result[0]) > 1) {
+    result.unshift('...1');
+  }
+
+  return result;
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+export const managerStyles = `
+  :host { display: block; height: 100%; color: var(--uui-color-text, #1b264f); }
+  .ekmManager { min-height: 100%; background: var(--uui-color-surface, #f6f4f4); }
+  .ekmManager__body { padding: 24px; }
+  .cards { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); margin-bottom: 20px; }
+  .card { background-color: #fff; border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,.08); padding: 15px; text-align: center; }
+  .card strong { display: block; font-size: 24px; margin-bottom: 15px; }
+  .ekmSummaryCard { align-items: flex-start; background: linear-gradient(135deg, #fff 0%, #f8fafc 100%); border: 1px solid #e6e8ef; display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 18px 20px; text-align: left; }
+  .ekmSummaryCard__label { color: var(--uui-color-text-alt, #515054); font-size: 13px; font-weight: 700; letter-spacing: .02em; text-transform: uppercase; }
+  .ekmSummaryCard__value { color: #1b264f; font-size: clamp(24px, 4vw, 34px); line-height: 1.1; margin: 0; overflow-wrap: anywhere; }
+  .umb-sub-header, .ekmToolbar { background: #fff; border-radius: 6px; margin-bottom: 20px; padding: 15px; }
+  .ekmManager__filters { align-items: end; display: grid; gap: 15px; grid-template-columns: repeat(4, minmax(150px, max-content)) minmax(260px, 1fr); width: 100%; }
+  .ekmManager__filter { display: grid; gap: 5px; min-width: 0; }
+  .ekmManager__filter input, .ekmManager__filter select { width: 100%; }
+  .ekmManager__search { align-items: end; display: flex; gap: 10px; justify-content: flex-end; min-width: 0; }
+  label { font-weight: 700; }
+  input:not([type='checkbox']), select { border: 1px solid #d8d7d9; border-radius: 3px; box-sizing: border-box; font: inherit; min-height: 36px; padding: 6px 10px; }
+  .ekmCheckboxLabel { align-items: center; display: inline-flex; gap: 6px; }
+  .ekmCheckboxLabel input { margin: 0; }
+  .form-search { min-width: 0; }
+  .form-search input { min-width: 220px; width: 100%; }
+  button, .btn { border: 1px solid #d8d7d9; border-radius: 3px; cursor: pointer; font: inherit; min-height: 36px; padding: 7px 14px; }
+  button:disabled { cursor: not-allowed; opacity: .6; }
+  .btn-primary, .btn-success { background: var(--uui-color-positive, #1b7f43); border-color: var(--uui-color-positive, #1b7f43); color: #fff; }
+  .btn-outline { background: #fff; color: #1b264f; }
+  .btn-reset { background: transparent; border: 0; min-height: 0; padding: 0; }
+  .umb-table { background: #fff; border: 1px solid #e9e9eb; border-radius: 6px; display: table; overflow: hidden; width: 100%; }
+  .umb-table-head { display: table-header-group; font-weight: 700; }
+  .umb-table-body { display: table-row-group; }
+  .umb-table-footer { display: table-footer-group; font-weight: 700; }
+  .umb-table-row { display: table-row; }
+  .umb-table-cell { border-bottom: 1px solid #eee; color: #111; display: table-cell; padding: 12px; vertical-align: middle; }
+  .not-fixed { min-width: 110px; }
+  .pagination ul { display: flex; gap: 4px; justify-content: center; list-style: none; padding: 0; }
+  .pagination li.active button { background: var(--uui-color-interactive, #3544b1); color: #fff; }
+  .ekmGrid { display: grid; gap: 40px; grid-template-columns: 1fr 1fr; margin-bottom: 40px; }
+  .ekmChartCard { text-align: left; }
+  .ekmChartCard__canvas { height: 320px; position: relative; }
+  .ekmChartCard canvas { height: 100%; width: 100%; }
+  .ekmSplit { display: flex; gap: 30px; margin-bottom: 30px; }
+  .ekmSplit__column { flex: 1; min-width: 0; }
+  .ekmOverlay { align-items: flex-start; background: rgba(0,0,0,.35); display: flex; inset: 0; justify-content: center; overflow: auto; padding: 40px 20px; position: fixed; z-index: 10000; }
+  .ekmOverlay__panel { background: #fff; border-radius: 3px; box-shadow: 0 10px 30px rgba(0,0,0,.25); max-width: 1100px; width: 100%; }
+  .ekmOverlay__panel--small { max-width: 620px; }
+  .ekmOverlay__header { align-items: center; border-bottom: 1px solid #d8d7d9; display: flex; gap: 12px; justify-content: space-between; padding: 20px; }
+  .ekmOverlay__header h2 { margin: 0; }
+  .ekmOverlay__content { padding: 20px; }
+  .ekmOrderStatusBar { align-items: center; border-bottom: 1px solid #d8d7d9; display: flex; flex-wrap: wrap; gap: 15px; margin-bottom: 15px; padding-bottom: 15px; }
+  .ekmOrderStatusBar__status { align-items: center; display: flex; gap: 8px; }
+  .ekmOrderStatusBar__print { margin-left: auto; }
+  .ekmOrderTracking, .ekmOrderActivityLog { border: 1px solid #d8d7d9; margin: 30px 0; padding: 14px 16px; }
+  .ekmOrderTracking__header { align-items: center; display: flex; justify-content: space-between; }
+  .ekmOrderTracking__wrap { overflow-wrap: anywhere; word-break: break-word; }
+  .ekmOrderActivityLog__item { border-top: 1px solid #eee; padding: 12px 0; }
+  .ekmOrderActivityLog__date { color: #666; font-size: 12px; margin-bottom: 6px; }
+  .ekmCustomerInformationModal { align-items: center; background: rgba(0,0,0,.35); display: flex; inset: 0; justify-content: center; padding: 20px; position: fixed; z-index: 10001; }
+  .ekmCustomerInformationModal__panel { background: #fff; border-radius: 3px; box-shadow: 0 10px 30px rgba(0,0,0,.25); max-height: 90vh; max-width: 760px; overflow: auto; width: 100%; }
+  .control-group { display: grid; gap: 5px; margin-bottom: 14px; }
+  .status { margin: 10px 0; }
+  .status--error { color: var(--uui-color-danger, #d42054); }
+  @media only screen and (max-width: 1180px) { .ekmManager__filters { grid-template-columns: repeat(2, minmax(0, 1fr)); } .ekmManager__search { grid-column: 1 / -1; justify-content: flex-start; } }
+  @media only screen and (max-width: 900px) { .cards { grid-template-columns: 1fr; } }
+  @media only screen and (max-width: 800px) { .ekmGrid { grid-template-columns: 1fr; } .ekmSplit { flex-direction: column; } }
+  @media only screen and (max-width: 720px) {
+    .ekmManager__filters { grid-template-columns: 1fr; }
+    .ekmManager__search { align-items: stretch; flex-direction: column; }
+    .ekmManager__search button, .form-search input { width: 100%; }
+    .umb-table, .umb-table-head, .umb-table-body, .umb-table-row, .umb-table-cell { display: block; }
+    .umb-table { background: transparent; border: 0; overflow: visible; }
+    .umb-table-head { display: none; }
+    .umb-table-row { background: #fff; border: 1px solid #e9e9eb; border-radius: 6px; box-shadow: 0 1px 2px rgba(0,0,0,.06); margin-bottom: 12px; overflow: hidden; }
+    .umb-table-cell { align-items: center; border-bottom: 1px solid #f0f0f0; display: grid; gap: 12px; grid-template-columns: minmax(110px, 38%) minmax(0, 1fr); min-height: 44px; overflow-wrap: anywhere; padding: 10px 12px; }
+    .umb-table-cell::before { color: var(--uui-color-text-alt, #515054); content: attr(data-label); font-size: 12px; font-weight: 700; letter-spacing: .02em; text-transform: uppercase; }
+    .umb-table-cell:last-child { border-bottom: 0; }
+    .umb-table-cell.not-fixed { min-width: 0; }
+    .umb-table-cell select, .umb-table-cell button { width: 100%; }
+  }
+  @media only screen and (max-width: 640px) {
+    .ekmOverlay { padding: 0; }
+    .ekmOverlay__panel { border-radius: 0; box-shadow: none; min-height: 100vh; max-width: none; }
+    .ekmOverlay__header { padding: 14px 16px; position: sticky; top: 0; z-index: 2; background: #fff; }
+    .ekmOverlay__header h2 { font-size: 20px; }
+    .ekmOverlay__content { padding: 16px; }
+    .ekmOrder h1 { font-size: 22px; line-height: 1.2; overflow-wrap: anywhere; }
+    .ekmOrderStatusBar { align-items: stretch; display: grid; grid-template-columns: 1fr; }
+    .ekmOrderStatusBar__status { align-items: stretch; display: grid; gap: 5px; }
+    .ekmOrderStatusBar__print { margin-left: 0; }
+    .ekmOrderStatusBar button, .ekmOrderStatusBar select { width: 100%; }
+    .ekmOrder p { overflow-wrap: anywhere; }
+    .ekmOrder .umb-table-cell { grid-template-columns: minmax(105px, 36%) minmax(0, 1fr); }
+    .ekmCustomerInformationModal { align-items: stretch; padding: 0; }
+    .ekmCustomerInformationModal__panel { border-radius: 0; max-height: none; max-width: none; width: 100%; }
+  }
+  @media only screen and (max-width: 520px) { .ekmManager__body { padding: 16px; } .ekmSummaryCard { padding: 15px; } .ekmSummaryCard__value { font-size: 24px; } .umb-sub-header { padding: 12px; } }
+  @media print {
+    :host { color: #000; height: auto; }
+    .ekmManager { display: none; }
+    .ekmOverlay { background: #fff; display: block; inset: auto; overflow: visible; padding: 0; position: static; }
+    .ekmOverlay__panel { border-radius: 0; box-shadow: none; max-width: none; min-height: auto; width: 100%; }
+    .ekmOverlay__header,
+    .ekmOrderStatusBar,
+    .ekmOrder button,
+    .ekmCustomerInformationModal { display: none !important; }
+    .ekmOverlay__content { padding: 0; }
+    .ekmOrder h1 { font-size: 22px; margin-top: 0; }
+    .ekmSplit { break-inside: avoid; display: flex; gap: 24px; margin-bottom: 18px; }
+    .ekmOrderTracking,
+    .ekmOrderActivityLog,
+    .card,
+    .umb-table-row { break-inside: avoid; box-shadow: none; }
+    .umb-table { border-color: #bbb; overflow: visible; }
+    .umb-table-cell { border-color: #ddd; color: #000; padding: 7px 8px; }
+  }
+`;
+
+export function renderLineChart(canvas: HTMLCanvasElement, series: ChartSeries, color: string): void {
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  const width = Math.max(rect.width, 300);
+  const height = Math.max(rect.height, 220);
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return;
+  }
+
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, width, height);
+  ctx.strokeStyle = '#e5e5e5';
+  ctx.lineWidth = 1;
+
+  for (let i = 0; i < 5; i += 1) {
+    const y = 20 + ((height - 50) / 4) * i;
+    ctx.beginPath();
+    ctx.moveTo(40, y);
+    ctx.lineTo(width - 10, y);
+    ctx.stroke();
+  }
+
+  const points = series.points || [];
+  const values = points.map(point => Number(point.y || 0));
+  const max = Math.max(...values, 1);
+  const step = points.length > 1 ? (width - 60) / (points.length - 1) : 0;
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+
+  points.forEach((point, index) => {
+    const x = 40 + step * index;
+    const y = height - 30 - ((Number(point.y || 0) / max) * (height - 60));
+
+    if (index === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+
+  ctx.stroke();
+
+  ctx.fillStyle = color;
+  points.forEach((point, index) => {
+    const x = 40 + step * index;
+    const y = height - 30 - ((Number(point.y || 0) / max) * (height - 60));
+    ctx.beginPath();
+    ctx.arc(x, y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/orders-section-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/orders-section-view.element.ts
@@ -1,0 +1,1053 @@
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UMB_NOTIFICATION_CONTEXT, type UmbNotificationColor } from '@umbraco-cms/backoffice/notification';
+import {
+  CustomerInformationField,
+  EkomManagerApi,
+  ManagerFilters,
+  OrderAction,
+  OrderActivityLog,
+  OrderInfo,
+  OrderListItem,
+  OrderSearchResult,
+  decodeHtml,
+  downloadBlob,
+  escapeHtml,
+  formatDate,
+  getStatusValue,
+  managerState,
+  managerStyles,
+  pageRange,
+} from './manager-shared';
+
+type EditorFieldDefinition = {
+  key: string;
+  label: string;
+  property: string;
+};
+
+const customerFields: EditorFieldDefinition[] = [
+  { key: 'customerName', label: 'Name', property: 'name' },
+  { key: 'customerEmail', label: 'Email', property: 'email' },
+  { key: 'customerAddress', label: 'Address', property: 'address' },
+  { key: 'customerApartment', label: 'Apartment', property: 'apartment' },
+  { key: 'customerCity', label: 'City', property: 'city' },
+  { key: 'customerCountry', label: 'Country', property: 'country' },
+  { key: 'customerZipCode', label: 'Zipcode', property: 'zipCode' },
+  { key: 'customerPhone', label: 'Phone', property: 'phone' },
+];
+
+const shippingFields: EditorFieldDefinition[] = [
+  { key: 'shippingName', label: 'Name', property: 'name' },
+  { key: 'shippingEmail', label: 'Email', property: 'email' },
+  { key: 'shippingAddress', label: 'Address', property: 'address' },
+  { key: 'shippingApartment', label: 'Apartment', property: 'apartment' },
+  { key: 'shippingCity', label: 'City', property: 'city' },
+  { key: 'shippingCountry', label: 'Country', property: 'country' },
+  { key: 'shippingZipCode', label: 'Zipcode', property: 'zipCode' },
+  { key: 'shippingPhone', label: 'Phone', property: 'phone' },
+];
+
+export class EkomOrdersSectionViewElement extends UmbElementMixin(HTMLElement) {
+  private readonly api = new EkomManagerApi();
+  private notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
+  private result: OrderSearchResult = { orders: [], count: 0, totalPages: 0 };
+  private page = 1;
+  private loading = true;
+  private error = '';
+  private searchTimer = 0;
+  private overlay = '';
+  private selectedOrder?: OrderInfo;
+  private orderLogs: OrderActivityLog[] = [];
+  private orderLogsLoading = false;
+  private orderActions: OrderAction[] = [];
+  private orderActionsLoading = false;
+  private executingActionKey = '';
+  private trackingExpanded = false;
+  private consentExpanded = false;
+  private customerEditorOpen = false;
+  private customerSaving = false;
+  private customerEditModel?: { customer: CustomerInformationField[]; shipping: CustomerInformationField[] };
+  private exportIncludeOrderLines = false;
+  private exporting = false;
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape' || !this.overlay) {
+      return;
+    }
+
+    if (this.customerEditorOpen) {
+      if (this.customerSaving) {
+        return;
+      }
+
+      this.customerEditorOpen = false;
+      this.customerEditModel = undefined;
+      this.render();
+      return;
+    }
+
+    if (this.exporting) {
+      return;
+    }
+
+    this.closeOverlay();
+  };
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.consumeContext(UMB_NOTIFICATION_CONTEXT, context => {
+      this.notificationContext = context;
+    });
+    document.addEventListener('keydown', this.handleKeyDown);
+    this.render();
+    void this.initialize();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
+    window.clearTimeout(this.searchTimer);
+  }
+
+  private async initialize(): Promise<void> {
+    try {
+      const [statuses, stores] = await Promise.all([
+        this.api.statusList(),
+        this.api.stores(),
+      ]);
+
+      managerState.statusList = statuses || [];
+      managerState.stores = stores || [];
+
+      if (!managerState.filters.store && managerState.stores.length) {
+        managerState.filters.store = managerState.stores[0].alias;
+      }
+
+      await this.loadPaymentProviders();
+      await this.loadOrders();
+    } catch (error) {
+      this.error = getErrorMessage(error, 'Error loading Ekom Manager.');
+      this.loading = false;
+      this.render();
+    }
+  }
+
+  private async loadPaymentProviders(resetSelection = false): Promise<void> {
+    if (!managerState.filters.store) {
+      managerState.paymentProviders = [];
+      return;
+    }
+
+    managerState.paymentProviders = await this.api.paymentProviders(managerState.filters.store);
+
+    if (resetSelection) {
+      managerState.filters.paymentProvider = '';
+    }
+
+    if (managerState.filters.paymentProvider) {
+      const selectedProviderStillExists = managerState.paymentProviders.some(provider => provider.key === managerState.filters.paymentProvider);
+
+      if (!selectedProviderStillExists) {
+        managerState.filters.paymentProvider = '';
+      }
+    }
+  }
+
+  private async loadOrders(): Promise<void> {
+    if (!managerState.filters.store) {
+      this.loading = false;
+      this.result = { orders: [], count: 0, totalPages: 0 };
+      this.render();
+      return;
+    }
+
+    this.loading = true;
+    this.error = '';
+    this.render();
+
+    try {
+      const result = await this.api.searchOrders(managerState.filters, this.page);
+      this.result = {
+        ...result,
+        orders: result.orders || [],
+      };
+    } catch (error) {
+      this.error = getErrorMessage(error, 'Error searching orders.');
+    } finally {
+      this.loading = false;
+      this.render();
+    }
+  }
+
+  private render(): void {
+    this.innerHTML = `
+      <style>${managerStyles}</style>
+      <section class="ekmManager">
+        <div class="ekmManager__body">
+          ${this.renderOrders()}
+        </div>
+      </section>
+      ${this.renderOverlay()}
+    `;
+
+    this.bindEvents();
+  }
+
+  private renderOrders(): string {
+    return `
+      <div class="cards">
+        <div class="card ekmSummaryCard">
+          <span class="ekmSummaryCard__label">Orders</span>
+          <strong class="ekmSummaryCard__value">${escapeHtml(this.result.count || 0)}</strong>
+        </div>
+        <div class="card ekmSummaryCard">
+          <span class="ekmSummaryCard__label">Payments total</span>
+          <strong class="ekmSummaryCard__value">${escapeHtml(this.result.grandTotal || 0)}</strong>
+        </div>
+        <div class="card ekmSummaryCard">
+          <span class="ekmSummaryCard__label">Average order amount</span>
+          <strong class="ekmSummaryCard__value">${escapeHtml(this.result.averageAmount || 0)}</strong>
+        </div>
+      </div>
+      ${this.renderToolbar()}
+      ${this.error ? `<p class="status status--error">${escapeHtml(this.error)}</p>` : ''}
+      ${this.loading ? '<p>Hang tight! Fetching your order details... This might take a moment.</p>' : this.renderOrderTable()}
+      ${!this.loading && this.result.totalPages > 1 ? this.renderPagination() : ''}
+    `;
+  }
+
+  private renderToolbar(): string {
+    const filters = managerState.filters;
+    return `
+      <div class="umb-sub-header">
+        <div class="ekmManager__filters">
+          <label class="ekmManager__filter">Order Status:
+            <select data-field="orderStatus">
+              <option value="CompletedOrders" ${filters.orderStatus === 'CompletedOrders' ? 'selected' : ''}>Completed Orders</option>
+              <option value="AllOrders" ${filters.orderStatus === 'AllOrders' ? 'selected' : ''}>All Orders</option>
+              ${managerState.statusList.map(status => {
+                const value = getStatusValue(status);
+                return `<option value="${escapeHtml(value)}" ${filters.orderStatus === value ? 'selected' : ''}>${escapeHtml(status.label)}</option>`;
+              }).join('')}
+            </select>
+          </label>
+          <label class="ekmManager__filter">Date From:
+            <input type="date" data-field="dateFrom" value="${escapeHtml(filters.dateFrom)}">
+          </label>
+          <label class="ekmManager__filter">Date To:
+            <input type="date" data-field="dateTo" value="${escapeHtml(filters.dateTo)}">
+          </label>
+          <label class="ekmManager__filter">Store:
+            <select data-field="store">
+              ${managerState.stores.map(store => `<option value="${escapeHtml(store.alias)}" ${filters.store === store.alias ? 'selected' : ''}>${escapeHtml(store.title)}</option>`).join('')}
+            </select>
+          </label>
+          <div class="ekmManager__search">
+            <button type="button" class="btn-outline" data-action="open-export">Export</button>
+            <button type="button" class="btn-primary" data-action="open-filter">Filter</button>
+            <div class="form-search"><input type="text" data-field="query" value="${escapeHtml(filters.query)}" placeholder="Type to search..."></div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderOrderTable(): string {
+    if (!this.result.orders.length) {
+      return '<div class="umb-table"><div class="umb-table-row"><div class="umb-table-cell">No orders found</div></div></div>';
+    }
+
+    return `
+      <div class="umb-table">
+        <div class="umb-table-head">
+          <div class="umb-table-row">
+            <div class="umb-table-cell not-fixed"></div>
+            <div class="umb-table-cell">Order Number</div>
+            <div class="umb-table-cell">Status</div>
+            <div class="umb-table-cell">Name</div>
+            <div class="umb-table-cell">Store</div>
+            <div class="umb-table-cell">Created</div>
+            <div class="umb-table-cell">Payment</div>
+          </div>
+        </div>
+        <div class="umb-table-body">
+          ${this.result.orders.map(order => this.renderOrderRow(order)).join('')}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderOrderRow(order: OrderListItem): string {
+    return `
+      <div class="umb-table-row">
+        <div class="umb-table-cell not-fixed" data-label="Action"><button class="btn-success" type="button" data-action="view-order" data-order-id="${escapeHtml(order.uniqueId)}">View</button></div>
+        <div class="umb-table-cell" data-label="Order Number" title="${escapeHtml(order.uniqueId)}">${escapeHtml(order.referenceId)}</div>
+        <div class="umb-table-cell" data-label="Status">
+          <select data-action="change-row-status" data-order-id="${escapeHtml(order.uniqueId)}">
+            ${managerState.statusList.map(status => {
+              const value = getStatusValue(status);
+              return `<option value="${escapeHtml(value)}" ${order.orderStatusCol === value ? 'selected' : ''}>${escapeHtml(status.label)}</option>`;
+            }).join('')}
+          </select>
+        </div>
+        <div class="umb-table-cell" data-label="Name">${escapeHtml(order.customerName)}</div>
+        <div class="umb-table-cell" data-label="Store">${escapeHtml(order.storeAlias)}</div>
+        <div class="umb-table-cell" data-label="Created">${escapeHtml(formatDate(order.createDate))}</div>
+        <div class="umb-table-cell" data-label="Payment">${escapeHtml(order.formattedTotal)}</div>
+      </div>
+    `;
+  }
+
+  private renderPagination(): string {
+    return `
+      <div class="pagination">
+        <ul>
+          ${pageRange(this.page, this.result.totalPages).map(page => {
+            const pageNumber = Number(String(page).replace('...', ''));
+            return `<li class="${pageNumber === this.page ? 'active' : ''}"><button type="button" data-action="set-page" data-page="${pageNumber}" ${pageNumber === this.page ? 'disabled' : ''}>${escapeHtml(page)}</button></li>`;
+          }).join('')}
+        </ul>
+      </div>
+    `;
+  }
+
+  private renderOverlay(): string {
+    if (this.overlay === 'filter') {
+      return this.renderFilterOverlay();
+    }
+
+    if (this.overlay === 'export') {
+      return this.renderExportOverlay();
+    }
+
+    if (this.overlay === 'order' && this.selectedOrder) {
+      return this.renderOrderOverlay(this.selectedOrder);
+    }
+
+    return '';
+  }
+
+  private renderFilterOverlay(): string {
+    const filters = managerState.filters;
+    return `
+      <div class="ekmOverlay">
+        <div class="ekmOverlay__panel ekmOverlay__panel--small">
+          <div class="ekmOverlay__header"><h2>Filter</h2><button class="btn-reset" type="button" data-action="close-overlay">&times;</button></div>
+          <div class="ekmOverlay__content">
+            <label class="control-group">Payment provider:
+              <select data-filter-field="paymentProvider">
+                <option value="">Select payment provider</option>
+                ${managerState.paymentProviders.map(provider => `<option value="${escapeHtml(provider.key)}" ${filters.paymentProvider === provider.key ? 'selected' : ''}>${escapeHtml(provider.title)}</option>`).join('')}
+              </select>
+            </label>
+            ${this.renderFilterInput('productSku', 'Product SKU:', 'Exact SKU')}
+            ${this.renderFilterInput('trackingSource', 'Tracking source:', 'facebook')}
+            ${this.renderFilterInput('trackingMedium', 'Tracking medium:', 'paid-social')}
+            ${this.renderFilterInput('trackingCampaign', 'Tracking campaign:', 'summer_2026')}
+            ${this.renderFilterInput('trackingTerm', 'Tracking term:', 'running shoes')}
+            ${this.renderFilterInput('trackingContent', 'Tracking content:', 'hero_banner')}
+            ${this.renderFilterInput('trackingClickId', 'Tracking click id:', 'gclid or fbclid')}
+            <div style="margin-top:25px; display:flex; gap:10px;"><button type="button" class="btn-success" data-action="apply-filter">Apply</button><button type="button" class="btn-outline" data-action="close-overlay">Cancel</button></div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderFilterInput(field: keyof ManagerFilters, label: string, placeholder: string): string {
+    return `
+      <label class="control-group">${escapeHtml(label)}
+        <input type="text" data-filter-field="${escapeHtml(field)}" value="${escapeHtml(managerState.filters[field])}" placeholder="${escapeHtml(placeholder)}">
+      </label>
+    `;
+  }
+
+  private renderExportOverlay(): string {
+    return `
+      <div class="ekmOverlay">
+        <div class="ekmOverlay__panel ekmOverlay__panel--small">
+          <div class="ekmOverlay__header"><h2>Export orders</h2><button class="btn-reset" type="button" data-action="close-overlay" ${this.exporting ? 'disabled' : ''}>&times;</button></div>
+          <div class="ekmOverlay__content">
+            <p>Choose how to export the orders matching the current filters.</p>
+            <label style="display:block; margin-top:15px;"><input type="checkbox" data-field="includeOrderLines" ${this.exportIncludeOrderLines ? 'checked' : ''} ${this.exporting ? 'disabled' : ''}> Include order lines</label>
+            ${this.exportIncludeOrderLines ? '<p style="margin-top:10px;">Including order lines can take longer because each matching order needs to be loaded before the CSV is created.</p>' : ''}
+            ${this.exporting ? '<p style="margin-top:15px;">Exporting orders. This may take a while...</p>' : ''}
+            <div style="margin-top:25px; display:flex; gap:10px;"><button type="button" class="btn-success" data-action="export-orders" ${this.exporting ? 'disabled' : ''}>Export</button><button type="button" class="btn-outline" data-action="close-overlay" ${this.exporting ? 'disabled' : ''}>Cancel</button></div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderOrderOverlay(order: OrderInfo): string {
+    return `
+      <div class="ekmOverlay">
+        <div class="ekmOverlay__panel ekmOrderOverlay__panel">
+          <div class="ekmOverlay__header"><h2>View Order</h2><button class="btn-reset" type="button" data-action="close-overlay">&times;</button></div>
+          <div class="ekmOverlay__content ekmOrder">
+            ${this.renderOrderDetails(order)}
+          </div>
+        </div>
+      </div>
+      ${this.customerEditorOpen ? this.renderCustomerEditor() : ''}
+    `;
+  }
+
+  private renderOrderDetails(order: OrderInfo): string {
+    const customer = order.customerInformation?.customer || {};
+    const shipping = order.customerInformation?.shipping || {};
+    const orderStatus = this.getOrderStatusValue(order.orderStatus);
+    return `
+      <div class="ekmOrder__header">
+        <h1>Order number: ${escapeHtml(order.referenceId)}</h1>
+        <div class="ekmOrderStatusBar">
+          <label class="ekmOrderStatusBar__status">Order Status:
+            <select data-field="orderStatusOverlay">
+              ${managerState.statusList.map(status => {
+                const value = getStatusValue(status);
+                return `<option value="${escapeHtml(value)}" ${orderStatus === value ? 'selected' : ''}>${escapeHtml(status.label)}</option>`;
+              }).join('')}
+            </select>
+          </label>
+          <label class="ekmCheckboxLabel"><input type="checkbox" data-field="notifyOrderStatus"> Fire events?</label>
+          <button type="button" class="btn-success" data-action="save-overlay-status">Save</button>
+          <button type="button" class="btn-outline ekmOrderStatusBar__print" data-action="print-order">Print</button>
+        </div>
+        <p>UniqueId: ${escapeHtml(order.uniqueId)}</p>
+        <p>Created date: ${escapeHtml(formatDate(order.createDate))}</p>
+        <p>Paid date: ${escapeHtml(formatDate(order.paidDate))}</p>
+        <p>Store: ${escapeHtml(order.storeInfo?.alias || order.storeAlias)}</p>
+        <p>Payment: <strong>${escapeHtml(order.chargedAmount?.currencyString)}</strong></p>
+        ${this.renderOrderActions()}
+      </div>
+      <div class="ekmSplit">
+        <div class="ekmSplit__column"><h4>Billing</h4><button type="button" class="btn-outline" data-action="open-customer-editor" style="margin-bottom:10px;">Edit customer information</button>${this.renderAddress(customer)}${this.renderExtraProperties(customer.properties, 'customer')}</div>
+        <div class="ekmSplit__column"><h4>Shipping</h4>${hasShippingInfo(shipping) ? `${this.renderAddress(shipping)}${this.renderExtraProperties(shipping.properties, 'shipping')}` : '<p style="font-weight:bold">Same as billing address</p>'}</div>
+      </div>
+      <div class="ekmSplit">
+        <div class="ekmSplit__column">${this.renderProvider('Payment Method', order.paymentProvider, 'custompayment')}</div>
+        <div class="ekmSplit__column">${this.renderProvider('Shipping Method', order.shippingProvider, 'customshipping')}</div>
+      </div>
+      ${this.renderOrderLines(order)}
+      ${this.renderTracking(order)}
+      ${this.renderConsent(order)}
+      ${this.renderActivityLogs()}
+    `;
+  }
+
+  private renderAddress(info: Record<string, any>): string {
+    return ['name', 'email', 'address', 'apartment', 'city', 'country', 'zipCode', 'phone']
+      .filter(key => info[key])
+      .map(key => `<p>${labelFromKey(key)}: ${escapeHtml(decodeHtml(info[key]))}</p>`)
+      .join('');
+  }
+
+  private renderExtraProperties(properties: Record<string, unknown> | undefined, prefix: string): string {
+    const entries = parseProperties(properties, prefix);
+
+    if (!entries.length) {
+      return '';
+    }
+
+    return `<h5 style="margin-top:20px; font-weight:bold;">Extra ${prefix === 'shipping' ? 'Shipping' : 'Customer'} Data</h5><ul>${entries.map(([key, value]) => `<li><strong>${escapeHtml(cleanKey(key))}</strong>: ${escapeHtml(value)}</li>`).join('')}</ul>`;
+  }
+
+  private renderProvider(title: string, provider: Record<string, any> | undefined, prefix: string): string {
+    if (!provider) {
+      return '';
+    }
+
+    return `<h4>${escapeHtml(title)}</h4><h4><strong>${escapeHtml(provider.title)}</strong></h4>${provider.price ? `<p>Price: ${escapeHtml(provider.price.withVat?.currencyString)}</p>` : ''}${this.renderExtraProperties(provider.customData, prefix)}`;
+  }
+
+  private renderOrderLines(order: OrderInfo): string {
+    const lines = Array.isArray(order.orderLines) ? order.orderLines : [];
+    return `
+      <h4>Order Details</h4>
+      <div class="umb-table">
+        <div class="umb-table-head"><div class="umb-table-row"><div class="umb-table-cell not-fixed">Product</div><div class="umb-table-cell">Quantity</div><div class="umb-table-cell">Unit Price (inc VAT)</div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">Discount</div><div class="umb-table-cell">Total (inc VAT)</div></div></div>
+        <div class="umb-table-body">
+          ${lines.map((line: Record<string, any>) => `<div class="umb-table-row"><div class="umb-table-cell not-fixed">${escapeHtml(line.product?.title)} (${escapeHtml(line.product?.sku)})${line.variant ? `<small style="display:block; margin-top:3px;">${escapeHtml(line.variant.title)} ${line.variant.sku ? `(${escapeHtml(line.variant.sku)})` : ''}</small>` : ''}${renderOrderLineProperties(line)}</div><div class="umb-table-cell">${escapeHtml(line.quantity)}</div><div class="umb-table-cell">${escapeHtml(line.product?.price?.withVat?.currencyString)}</div><div class="umb-table-cell">${escapeHtml(line.amount?.vat?.currencyString)}</div><div class="umb-table-cell">-${escapeHtml(line.amount?.discountAmount?.currencyString)}</div><div class="umb-table-cell"><strong>${escapeHtml(line.amount?.withVat?.currencyString)}</strong></div></div>`).join('')}
+        </div>
+        <div class="umb-table-footer">
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Sub Total (inc VAT)</div><div class="umb-table-cell">${escapeHtml(order.subTotal?.withVat?.currencyString)}</div></div>
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Discount</div><div class="umb-table-cell">-${escapeHtml(order.discountAmount?.currencyString)}</div></div>
+          ${order.shippingProvider ? `<div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Shipping Total</div><div class="umb-table-cell">${escapeHtml(order.shippingProvider.price?.withVat?.currencyString)}</div></div>` : ''}
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">${escapeHtml(order.chargedVat?.currencyString)}</div></div>
+          <div class="umb-table-row"><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Total</div><div class="umb-table-cell"><strong>${escapeHtml(order.chargedAmount?.currencyString)}</strong></div></div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderTracking(order: OrderInfo): string {
+    const tracking = order.tracking;
+
+    if (!hasTrackingData(tracking)) {
+      return '<div class="ekmOrderTracking"><h4>Tracking</h4><p>No tracking data was captured for this order.</p></div>';
+    }
+
+    return `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Tracking</h4><button class="btn-reset" type="button" data-action="toggle-tracking">${this.trackingExpanded ? 'Hide' : 'Show'}</button></div>${this.trackingExpanded ? renderTrackingDetails(tracking) : ''}</div>`;
+  }
+
+  private renderConsent(order: OrderInfo): string {
+    const consent = order.consent;
+
+    if (!hasConsentData(consent)) {
+      return '<div class="ekmOrderTracking"><h4>Consent</h4><p>No consent data was captured for this order.</p></div>';
+    }
+
+    return `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Consent</h4><button class="btn-reset" type="button" data-action="toggle-consent">${this.consentExpanded ? 'Hide' : 'Show'}</button></div>${this.consentExpanded ? `<p>Resolved: ${escapeHtml(formatDate(consent.resolvedAtUtc))}</p><p>Source: ${escapeHtml(consent.source)}</p><p>Analytics: ${consentLabel(consent.analytics)}</p><p>Marketing: ${consentLabel(consent.marketing)}</p>` : ''}</div>`;
+  }
+
+  private renderActivityLogs(): string {
+    if (this.orderLogsLoading) {
+      return '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>Loading activity...</p></div>';
+    }
+
+    if (!this.orderLogs.length) {
+      return '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>No activity yet.</p></div>';
+    }
+
+    return `<div class="ekmOrderActivityLog"><h4>Activity log</h4>${this.orderLogs.map(log => `<div class="ekmOrderActivityLog__item"><div class="ekmOrderActivityLog__date">${escapeHtml(formatDate(log.date))}</div><div>${escapeHtml(log.message)}</div></div>`).join('')}</div>`;
+  }
+
+  private renderOrderActions(): string {
+    if (!this.orderActions.length && !this.orderActionsLoading) {
+      return '';
+    }
+
+    return `<div style="margin-top:15px;"><h4>Order Actions</h4><div style="display:flex; flex-wrap:wrap; gap:10px;">${this.orderActions.map(action => `<button type="button" class="${action.look === 'primary' ? 'btn-success' : 'btn-outline'}" data-action="execute-order-action" data-action-key="${escapeHtml(action.key)}" ${action.enabled === false || this.executingActionKey === action.key ? 'disabled' : ''}>${escapeHtml(action.label)}</button>`).join('')}</div>${this.orderActionsLoading ? '<p>Loading actions...</p>' : ''}</div>`;
+  }
+
+  private renderCustomerEditor(): string {
+    const model = this.customerEditModel;
+
+    if (!model) {
+      return '';
+    }
+
+    return `<div class="ekmCustomerInformationModal"><div class="ekmCustomerInformationModal__panel"><div class="ekmOverlay__header"><h3>Edit customer information</h3><button class="btn-reset" type="button" data-action="close-customer-editor" ${this.customerSaving ? 'disabled' : ''}>&times;</button></div><div class="ekmOverlay__content"><div class="ekmSplit"><div class="ekmSplit__column"><h4>Billing</h4>${this.renderCustomerFields(model.customer, 'customer')}</div><div class="ekmSplit__column"><h4>Shipping</h4>${this.renderCustomerFields(model.shipping, 'shipping')}</div></div><div style="display:flex; justify-content:flex-end; gap:10px; padding-top:20px; border-top:1px solid #d8d7d9;"><button class="btn-outline" type="button" data-action="close-customer-editor" ${this.customerSaving ? 'disabled' : ''}>Cancel</button><button class="btn-success" type="button" data-action="save-customer-information" ${this.customerSaving ? 'disabled' : ''}>${this.customerSaving ? 'Saving...' : 'Save customer information'}</button></div></div></div></div>`;
+  }
+
+  private renderCustomerFields(fields: CustomerInformationField[], group: string): string {
+    return fields.map(field => `<label class="control-group">${escapeHtml(field.label)} ${field.isExtra ? `<small>(${escapeHtml(field.key)})</small>` : ''}<input type="text" data-customer-group="${group}" data-customer-key="${escapeHtml(field.key)}" value="${escapeHtml(field.value)}" ${this.customerSaving ? 'disabled' : ''}></label>`).join('');
+  }
+
+  private bindEvents(): void {
+    this.querySelectorAll('[data-action]').forEach(element => {
+      if (element instanceof HTMLSelectElement) {
+        element.addEventListener('change', event => void this.handleAction(event));
+      } else {
+        element.addEventListener('click', event => void this.handleAction(event));
+      }
+    });
+
+    this.querySelectorAll('[data-field]').forEach(element => {
+      element.addEventListener('change', event => void this.handleFieldChange(event));
+      if ((element as HTMLElement).dataset.field === 'query') {
+        element.addEventListener('input', event => this.handleSearchInput(event));
+      }
+    });
+  }
+
+  private async handleAction(event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLElement;
+    const action = target.dataset.action;
+
+    if (action === 'set-page') {
+      this.page = Number(target.dataset.page || 1);
+      await this.loadOrders();
+      return;
+    }
+
+    if (action === 'open-filter' || action === 'open-export') {
+      this.overlay = action === 'open-filter' ? 'filter' : 'export';
+      this.render();
+      return;
+    }
+
+    if (action === 'close-overlay') {
+      this.closeOverlay();
+      return;
+    }
+
+    if (action === 'apply-filter') {
+      this.applyFilterOverlay();
+      this.overlay = '';
+      this.page = 1;
+      await this.loadOrders();
+      return;
+    }
+
+    if (action === 'export-orders') {
+      await this.exportOrders();
+      return;
+    }
+
+    if (action === 'view-order') {
+      await this.openOrder(target.dataset.orderId || '');
+      return;
+    }
+
+    if (action === 'save-overlay-status') {
+      await this.saveOverlayStatus();
+      return;
+    }
+
+    if (action === 'change-row-status') {
+      await this.changeRowStatus(target as HTMLSelectElement);
+      return;
+    }
+
+    if (action === 'print-order') {
+      window.print();
+      return;
+    }
+
+    if (action === 'toggle-tracking') {
+      this.trackingExpanded = !this.trackingExpanded;
+      this.renderPreservingOverlayScroll();
+      return;
+    }
+
+    if (action === 'toggle-consent') {
+      this.consentExpanded = !this.consentExpanded;
+      this.renderPreservingOverlayScroll();
+      return;
+    }
+
+    if (action === 'execute-order-action') {
+      await this.executeOrderAction(target.dataset.actionKey || '');
+      return;
+    }
+
+    if (action === 'open-customer-editor') {
+      this.openCustomerEditor();
+      return;
+    }
+
+    if (action === 'close-customer-editor') {
+      this.customerEditorOpen = false;
+      this.customerEditModel = undefined;
+      this.render();
+      return;
+    }
+
+    if (action === 'save-customer-information') {
+      await this.saveCustomerInformation();
+    }
+  }
+
+  private async handleFieldChange(event: Event): Promise<void> {
+    const target = event.currentTarget as HTMLInputElement | HTMLSelectElement;
+    const field = target.dataset.field;
+
+    if (field === 'includeOrderLines') {
+      this.exportIncludeOrderLines = (target as HTMLInputElement).checked;
+      this.render();
+      return;
+    }
+
+    if (field === 'orderStatusOverlay' || field === 'notifyOrderStatus' || field === 'query') {
+      return;
+    }
+
+    if (!field || !(field in managerState.filters)) {
+      return;
+    }
+
+    (managerState.filters as Record<string, string>)[field] = target.value;
+    this.page = 1;
+
+    if (field === 'store') {
+      await this.loadPaymentProviders(true);
+    }
+
+    await this.loadOrders();
+  }
+
+  private handleSearchInput(event: Event): void {
+    const target = event.currentTarget as HTMLInputElement;
+    managerState.filters.query = target.value;
+    this.page = 1;
+    window.clearTimeout(this.searchTimer);
+    this.searchTimer = window.setTimeout(() => void this.loadOrders(), 700);
+  }
+
+  private applyFilterOverlay(): void {
+    this.querySelectorAll<HTMLInputElement | HTMLSelectElement>('[data-filter-field]').forEach(input => {
+      const field = input.dataset.filterField;
+
+      if (field && field in managerState.filters) {
+        (managerState.filters as Record<string, string>)[field] = input.value;
+      }
+    });
+  }
+
+  private async exportOrders(): Promise<void> {
+    if (!this.result.count) {
+      return;
+    }
+
+    this.exporting = true;
+    this.render();
+
+    try {
+      const blob = await this.api.exportOrders(managerState.filters, this.result.count, this.exportIncludeOrderLines);
+      downloadBlob(blob, this.exportIncludeOrderLines ? 'orders-with-orderlines.csv' : 'orders.csv');
+      this.overlay = '';
+    } catch (error) {
+      this.showError(getErrorMessage(error, 'Error exporting orders.'));
+    } finally {
+      this.exporting = false;
+      this.render();
+    }
+  }
+
+  private async openOrder(orderId: string): Promise<void> {
+    if (!orderId) {
+      return;
+    }
+
+    try {
+      this.selectedOrder = await this.api.orderInfo(orderId);
+      this.overlay = 'order';
+      this.trackingExpanded = false;
+      this.consentExpanded = false;
+      this.render();
+      await Promise.all([this.loadOrderLogs(orderId), this.loadOrderActions(orderId)]);
+    } catch (error) {
+      this.showError(getErrorMessage(error, 'Error on getting orderInfo.'));
+    }
+  }
+
+  private async loadOrderLogs(orderId: string): Promise<void> {
+    this.orderLogsLoading = true;
+    this.render();
+
+    try {
+      this.orderLogs = await this.api.orderLogs(orderId);
+    } catch {
+      this.orderLogs = [];
+    } finally {
+      this.orderLogsLoading = false;
+      this.render();
+    }
+  }
+
+  private async loadOrderActions(orderId: string): Promise<void> {
+    this.orderActionsLoading = true;
+    this.render();
+
+    try {
+      this.orderActions = await this.api.orderActions(orderId);
+    } catch {
+      this.orderActions = [];
+    } finally {
+      this.orderActionsLoading = false;
+      this.render();
+    }
+  }
+
+  private async saveOverlayStatus(): Promise<void> {
+    if (!this.selectedOrder?.uniqueId) {
+      return;
+    }
+
+    const status = this.querySelector<HTMLSelectElement>('[data-field="orderStatusOverlay"]')?.value || '';
+    const notify = this.querySelector<HTMLInputElement>('[data-field="notifyOrderStatus"]')?.checked || false;
+
+    try {
+      await this.api.changeOrderStatus(this.selectedOrder.uniqueId, status, notify);
+      this.selectedOrder.orderStatus = status;
+      this.showSuccess('Order status updated.');
+      await this.loadOrders();
+      await this.loadOrderLogs(this.selectedOrder.uniqueId);
+    } catch (error) {
+      this.showError(getErrorMessage(error, 'Error updating order status.'));
+    }
+  }
+
+  private showSuccess(message: string): void {
+    this.showNotification('positive', 'Success', message);
+  }
+
+  private showError(message: string): void {
+    this.showNotification('danger', 'Error', message);
+  }
+
+  private showNotification(color: UmbNotificationColor, headline: string, message: string): void {
+    if (this.notificationContext) {
+      this.notificationContext.peek(color, {
+        data: {
+          headline,
+          message,
+        },
+      });
+      return;
+    }
+
+    if (color === 'danger') {
+      console.error(`${headline}: ${message}`);
+    }
+  }
+
+  private renderPreservingOverlayScroll(): void {
+    const overlay = this.querySelector<HTMLElement>('.ekmOverlay');
+    const scrollTop = overlay?.scrollTop ?? 0;
+
+    this.render();
+
+    requestAnimationFrame(() => {
+      const newOverlay = this.querySelector<HTMLElement>('.ekmOverlay');
+
+      if (newOverlay) {
+        newOverlay.scrollTop = scrollTop;
+      }
+    });
+  }
+
+  private closeOverlay(): void {
+    this.overlay = '';
+    this.selectedOrder = undefined;
+    this.customerEditorOpen = false;
+    this.customerEditModel = undefined;
+    this.render();
+  }
+
+  private getOrderStatusValue(orderStatus: unknown): string {
+    const stringValue = String(orderStatus ?? '');
+    const status = managerState.statusList.find(item => {
+      return String(item.value ?? '') === stringValue
+        || String(item.enumValue ?? '') === stringValue;
+    });
+
+    return status ? getStatusValue(status) : stringValue;
+  }
+
+  private async changeRowStatus(select: HTMLSelectElement): Promise<void> {
+    const orderId = select.dataset.orderId || '';
+
+    if (!orderId) {
+      return;
+    }
+
+    try {
+      await this.api.changeOrderStatus(orderId, select.value, true);
+      const order = this.result.orders.find(item => item.uniqueId === orderId);
+
+      if (order) {
+        order.orderStatusCol = select.value;
+      }
+
+      this.showSuccess('Order status updated.');
+    } catch (error) {
+      this.showError(getErrorMessage(error, 'Error updating order status.'));
+      await this.loadOrders();
+    }
+  }
+
+  private async executeOrderAction(actionKey: string): Promise<void> {
+    if (!this.selectedOrder?.uniqueId || !actionKey || this.executingActionKey) {
+      return;
+    }
+
+    const action = this.orderActions.find(item => item.key === actionKey);
+
+    if (action?.confirmMessage && !window.confirm(action.confirmMessage)) {
+      return;
+    }
+
+    this.executingActionKey = actionKey;
+    this.render();
+
+    try {
+      const response = await this.api.executeOrderAction(this.selectedOrder.uniqueId, actionKey);
+      const blob = await response.blob();
+      const contentDisposition = response.headers.get('content-disposition') || '';
+      const contentType = response.headers.get('content-type') || '';
+
+      if (contentDisposition.toLowerCase().includes('filename=') || contentType.startsWith('application/pdf') || contentType.startsWith('application/octet-stream') || contentType.startsWith('image/')) {
+        window.open(URL.createObjectURL(blob), '_blank');
+      } else {
+        const message = await blob.text();
+        this.showSuccess(tryParseMessage(message));
+      }
+
+      this.selectedOrder = await this.api.orderInfo(this.selectedOrder.uniqueId);
+      await this.loadOrderLogs(this.selectedOrder.uniqueId);
+      await this.loadOrderActions(this.selectedOrder.uniqueId);
+    } catch (error) {
+      this.showError(getErrorMessage(error, 'Order action failed.'));
+    } finally {
+      this.executingActionKey = '';
+      this.render();
+    }
+  }
+
+  private openCustomerEditor(): void {
+    const order = this.selectedOrder;
+
+    if (!order) {
+      return;
+    }
+
+    const customer = order.customerInformation?.customer || {};
+    const shipping = order.customerInformation?.shipping || {};
+    this.customerEditModel = {
+      customer: mapStandardFields(customer, customerFields).concat(mapExtraFields(customer.properties, 'customer')),
+      shipping: mapStandardFields(shipping, shippingFields).concat(mapExtraFields(shipping.properties, 'shipping')),
+    };
+    this.customerEditorOpen = true;
+    this.render();
+  }
+
+  private async saveCustomerInformation(): Promise<void> {
+    if (!this.selectedOrder?.uniqueId || !this.customerEditModel || this.customerSaving) {
+      return;
+    }
+
+    this.querySelectorAll<HTMLInputElement>('[data-customer-group]').forEach(input => {
+      const group = input.dataset.customerGroup as 'customer' | 'shipping';
+      const key = input.dataset.customerKey;
+      const field = this.customerEditModel?.[group].find(item => item.key === key);
+
+      if (field) {
+        field.value = input.value;
+      }
+    });
+
+    this.customerSaving = true;
+    this.render();
+
+    try {
+      this.selectedOrder = await this.api.updateCustomerInformation(
+        this.selectedOrder.uniqueId,
+        buildPayload(this.customerEditModel.customer),
+        buildPayload(this.customerEditModel.shipping));
+      this.customerEditorOpen = false;
+      this.customerEditModel = undefined;
+      this.showSuccess('Customer information updated.');
+      await this.loadOrders();
+    } catch (error) {
+      this.showError(getErrorMessage(error, 'Error updating customer information.'));
+    } finally {
+      this.customerSaving = false;
+      this.render();
+    }
+  }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function labelFromKey(key: string): string {
+  return key === 'zipCode' ? 'Zipcode' : key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function isDefaultKey(key: string): boolean {
+  return new Set(['shippingname', 'shippingaddress', 'shippingcity', 'shippingcountry', 'shippingemail', 'shippingapartment', 'shippingzipcode', 'shippingphone', 'customeremail', 'customername', 'customeraddress', 'customerapartment', 'customercity', 'customercountry', 'customerzipcode', 'customerphone']).has(key.toLowerCase());
+}
+
+function cleanKey(key: string): string {
+  return key.replace(/^customshipping/i, '').replace(/^custompayment/i, '').replace(/^shipping/i, '').replace(/^customer/i, '');
+}
+
+function parseProperties(properties: Record<string, unknown> | undefined, prefix: string): Array<[string, string]> {
+  return Object.entries(properties || {})
+    .filter(([key, value]) => Boolean(value) && key.toLowerCase().startsWith(prefix) && !isDefaultKey(key))
+    .map(([key, value]) => [key, decodeHtml(value)]);
+}
+
+function hasShippingInfo(shipping: Record<string, any>): boolean {
+  return Boolean(shipping?.name || shipping?.email || shipping?.address || shipping?.apartment || shipping?.city || shipping?.country || shipping?.zipCode || shipping?.phone);
+}
+
+function renderOrderLineProperties(orderLine: Record<string, any>): string {
+  const properties = orderLine.orderLineInfo?.properties || {};
+  return Object.entries(properties)
+    .filter(([, value]) => Boolean(value))
+    .map(([key, value]) => `<small style="display:block; margin-top:3px;"><strong>${escapeHtml(formatOrderLinePropertyKey(key))}</strong>: ${escapeHtml(decodeHtml(value))}</small>`)
+    .join('');
+}
+
+function formatOrderLinePropertyKey(key: string): string {
+  const value = key.replace(/^orderline/i, '').replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').trim();
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : key;
+}
+
+function hasTrackingData(tracking: Record<string, any> | undefined): boolean {
+  return Boolean(tracking && (tracking.source || tracking.medium || tracking.campaign || tracking.term || tracking.content || tracking.clickId || tracking.clickIdType || tracking.landingUrl || tracking.referrer || tracking.captureMethod || tracking.capturedAtUtc || tracking.hasCookieSupport !== null && tracking.hasCookieSupport !== undefined || tracking.ga4?.clientId || tracking.ga4?.sessionId || tracking.meta?.fbp || tracking.meta?.fbc));
+}
+
+function renderTrackingDetails(tracking: Record<string, any>): string {
+  const ga4Data = Object.entries(tracking.ga4?.data || {});
+  const metaData = Object.entries(tracking.meta?.data || {});
+  return `<div class="ekmSplit"><div class="ekmSplit__column">${renderOptional('Captured', formatDate(tracking.capturedAtUtc))}${renderOptional('Capture method', tracking.captureMethod)}${tracking.hasCookieSupport !== null && tracking.hasCookieSupport !== undefined ? `<p>Cookie support: ${tracking.hasCookieSupport ? 'Yes' : 'No'}</p>` : ''}${renderOptional('Source', tracking.source)}${renderOptional('Medium', tracking.medium)}${renderOptional('Campaign', tracking.campaign)}${renderOptional('Term', tracking.term)}${renderOptional('Content', tracking.content)}${renderOptional('Click ID', tracking.clickId)}${renderOptional('Click ID Type', tracking.clickIdType)}${renderOptional('Landing URL', tracking.landingUrl)}${renderOptional('Referrer', tracking.referrer)}</div><div class="ekmSplit__column"><h5>GA4</h5>${renderOptional('Client ID', tracking.ga4?.clientId)}${renderOptional('Session ID', tracking.ga4?.sessionId)}${renderPairs(ga4Data)}<h5>Meta</h5>${renderOptional('FBP', tracking.meta?.fbp)}${renderOptional('FBC', tracking.meta?.fbc)}${renderPairs(metaData)}</div></div>`;
+}
+
+function renderOptional(label: string, value: unknown): string {
+  return value ? `<p class="ekmOrderTracking__wrap">${escapeHtml(label)}: ${escapeHtml(value)}</p>` : '';
+}
+
+function renderPairs(entries: Array<[string, unknown]>): string {
+  return entries.length ? `<ul>${entries.map(([key, value]) => `<li><strong>${escapeHtml(key)}</strong>: ${escapeHtml(value)}</li>`).join('')}</ul>` : '';
+}
+
+function hasConsentData(consent: Record<string, any> | undefined): boolean {
+  return Boolean(consent && (consent.resolvedAtUtc || consent.source || consent.analytics !== null && consent.analytics !== undefined || consent.marketing !== null && consent.marketing !== undefined));
+}
+
+function consentLabel(value: unknown): string {
+  if (value === true) {
+    return 'Yes';
+  }
+
+  if (value === false) {
+    return 'No';
+  }
+
+  return 'Unknown';
+}
+
+function mapStandardFields(info: Record<string, any>, fields: EditorFieldDefinition[]): CustomerInformationField[] {
+  return fields.map(field => ({
+    key: field.key,
+    label: field.label,
+    value: decodeHtml(info[field.property] || info.properties?.[field.key] || ''),
+    isExtra: false,
+  }));
+}
+
+function mapExtraFields(properties: Record<string, unknown> | undefined, prefix: string): CustomerInformationField[] {
+  return parseProperties(properties, prefix).map(([key, value]) => ({
+    key,
+    label: cleanKey(key).replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').trim() || key,
+    value,
+    isExtra: true,
+  }));
+}
+
+function buildPayload(fields: CustomerInformationField[]): Record<string, string> {
+  return Object.fromEntries(fields.map(field => [field.key, field.value || '']));
+}
+
+function tryParseMessage(text: string): string {
+  try {
+    const data = JSON.parse(text) as { message?: string };
+    return data.message || text;
+  } catch {
+    return text;
+  }
+}
+
+customElements.define('ekom-orders-section-view', EkomOrdersSectionViewElement);
+
+export default EkomOrdersSectionViewElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ekom-orders-section-view': EkomOrdersSectionViewElement;
+  }
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
@@ -1,5 +1,59 @@
 export const manifests: Array<UmbExtensionManifest> = [
   {
+    type: 'section',
+    kind: 'default',
+    alias: 'ekommanager',
+    name: 'Ekom Manager Section',
+    weight: 300,
+    meta: {
+      label: 'Ekom',
+      pathname: 'ekommanager',
+      preventUrlRetention: true,
+    },
+    conditions: [
+      {
+        alias: 'Umb.Condition.SectionUserPermission',
+        match: 'ekommanager',
+      },
+    ],
+  },
+  {
+    type: 'sectionView',
+    alias: 'Ekom.SectionView.Manager.Orders',
+    name: 'Ekom Manager Orders Section View',
+    element: '/App_Plugins/Ekom/dist/orders-section-view.element.js',
+    weight: 200,
+    meta: {
+      label: 'Orders',
+      pathname: 'orders',
+      icon: 'icon-shopping-basket',
+    },
+    conditions: [
+      {
+        alias: 'Umb.Condition.SectionAlias',
+        match: 'ekommanager',
+      },
+    ],
+  },
+  {
+    type: 'sectionView',
+    alias: 'Ekom.SectionView.Manager.Analytics',
+    name: 'Ekom Manager Analytics Section View',
+    element: '/App_Plugins/Ekom/dist/analytics-section-view.element.js',
+    weight: 100,
+    meta: {
+      label: 'Analytics',
+      pathname: 'analytics',
+      icon: 'icon-chart-curve',
+    },
+    conditions: [
+      {
+        alias: 'Umb.Condition.SectionAlias',
+        match: 'ekommanager',
+      },
+    ],
+  },
+  {
     type: 'propertyEditorSchema',
     alias: 'Ekom.Cache',
     name: 'Ekom Cache Editor',

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
         'data-type-picker.element': 'src/property-editors/data-type-picker.element.ts',
         'metafield-picker.element': 'src/property-editors/metafield-picker.element.ts',
         'metavalue-editor.element': 'src/property-editors/metavalue-editor.element.ts',
+        'analytics-section-view.element': 'src/manager/analytics-section-view.element.ts',
+        'orders-section-view.element': 'src/manager/orders-section-view.element.ts',
         'price-editor.element': 'src/property-editors/price-editor.element.ts',
         'property-editor.element': 'src/property-editors/property-editor.element.ts',
         'range-editor.element': 'src/property-editors/range-editor.element.ts',


### PR DESCRIPTION
## Summary
- Add a native Umbraco 17 Ekom Manager section with Orders and Analytics section views.
- Port manager order search, filters, exports, order detail, status updates, order actions, activity logs, customer editing, tracking, consent, and analytics UI to TypeScript web components.
- Register new U17 manager Vite entries and generated App_Plugins assets.
- Add responsive styling for summary cards, filters, order tables, modals, notifications, and print output.

## Test Plan
- npm run typecheck
- npm run build
- dotnet build "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj"
- Manually verified the manager section loads and iterated on Orders/Analytics UI behavior in the U17 backoffice.

## Notes
- The sample U17 SQLite database has a local modification and is intentionally not included in this PR.
