### PR TITLE
feat(algolia): add variant indexing

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -210,6 +210,40 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Fact]
+    public void MapRecords_Returns_Only_Product_When_Variant_Indexing_Is_Disabled()
+    {
+        var mapper = CreateMapper(indexVariants: false);
+        var product = CreateProduct(variants: [CreateVariant().Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        Assert.Single(records);
+        Assert.False(records[0].IsVariant);
+        Assert.Equal(product.Object.Key.ToString(), records[0].ProductId);
+    }
+
+    [Fact]
+    public void MapRecords_Maps_Variants_When_Variant_Indexing_Is_Enabled()
+    {
+        var mapper = CreateMapper(indexVariants: true);
+        var variant = CreateVariant(sku: "variant-sku", title: "Variant title");
+        var product = CreateProduct(sku: "placeholder", variants: [variant.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        Assert.Equal(2, records.Count);
+        var variantRecord = records.Single(x => x.IsVariant);
+
+        Assert.Equal($"{product.Object.Key}_{variant.Object.Key}", variantRecord.ObjectId);
+        Assert.Equal(product.Object.Key.ToString(), variantRecord.ProductId);
+        Assert.Equal(variant.Object.Key.ToString(), variantRecord.VariantId);
+        Assert.Equal("variant-sku", variantRecord.Sku);
+        Assert.Equal("placeholder", variantRecord.ParentSku);
+        Assert.Equal("variant-sku", Assert.IsType<string>(variantRecord.Data["variantSku"]));
+        Assert.Equal("Variant title", Assert.IsType<string>(variantRecord.Data["variantTitle"]));
+    }
+
+    [Fact]
     public void Keeps_Relative_Urls_And_Image_Urls_As_Is()
     {
         var mapper = CreateMapper();
@@ -391,7 +425,7 @@ public class AlgoliaProductIndexMapperTests
         Assert.Equal(0, record.CategoryRanking);
     }
 
-    private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null)
+    private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null, bool indexVariants = false)
     {
         var options = Options.Create(new AlgoliaOptions
         {
@@ -400,6 +434,7 @@ public class AlgoliaProductIndexMapperTests
             SearchApiKey = "search",
             Indexing = new AlgoliaIndexingOptions
             {
+                Variants = indexVariants,
                 ProductProperties = productProperties ?? []
             }
         });
@@ -437,7 +472,8 @@ public class AlgoliaProductIndexMapperTests
         string summary = "Summary",
         string description = "Description",
         string url = "/product",
-        bool available = true)
+        bool available = true,
+        IReadOnlyList<Ekom.Models.IVariant>? variants = null)
     {
         var price = new Mock<Ekom.Models.IPrice>();
         price.SetupGet(x => x.Value).Returns(100m);
@@ -460,6 +496,7 @@ public class AlgoliaProductIndexMapperTests
         product.SetupGet(x => x.Price).Returns(price.Object);
         product.SetupGet(x => x.Prices).Returns([price.Object]);
         product.SetupGet(x => x.Categories).Returns((categories ?? []).Select(x => x.Object));
+        product.SetupGet(x => x.AllVariants).Returns(variants ?? []);
         product.SetupGet(x => x.Metafields).Returns(metafields?.ToList() ?? []);
         product.SetupGet(x => x.CreateDate).Returns(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         product.SetupGet(x => x.UpdateDate).Returns(new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc));
@@ -473,6 +510,35 @@ public class AlgoliaProductIndexMapperTests
         product.Setup(x => x.GetValue("nodeName", It.IsAny<string?>(), It.IsAny<bool>())).Returns(nodeName);
 
         return product;
+    }
+
+    private static Mock<Ekom.Models.IVariant> CreateVariant(
+        string sku = "variant-sku",
+        string title = "Variant",
+        string description = "Variant description",
+        bool available = true)
+    {
+        var price = new Mock<Ekom.Models.IPrice>();
+        price.SetupGet(x => x.Value).Returns(10m);
+        price.SetupGet(x => x.WithVat).Returns(Mock.Of<Ekom.Models.ICalculatedPrice>(p => p.Value == 10m));
+        price.SetupGet(x => x.WithoutVat).Returns(Mock.Of<Ekom.Models.ICalculatedPrice>(p => p.Value == 8m));
+        price.SetupGet(x => x.Currency).Returns(new Ekom.Models.CurrencyModel { CurrencyValue = "ISK", CurrencyFormat = "0" });
+
+        var variant = new Mock<Ekom.Models.IVariant>();
+        variant.SetupGet(x => x.Key).Returns(Guid.NewGuid());
+        variant.SetupGet(x => x.SKU).Returns(sku);
+        variant.SetupGet(x => x.Title).Returns(title);
+        variant.SetupGet(x => x.Description).Returns(description);
+        variant.SetupGet(x => x.Images).Returns([]);
+        variant.SetupGet(x => x.Available).Returns(available);
+        variant.SetupGet(x => x.Stock).Returns(5m);
+        variant.SetupGet(x => x.Price).Returns(price.Object);
+        variant.SetupGet(x => x.Prices).Returns([price.Object]);
+        variant.SetupGet(x => x.VariantGroupId).Returns(123);
+        variant.SetupGet(x => x.CreateDate).Returns(new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc));
+        variant.SetupGet(x => x.UpdateDate).Returns(new DateTime(2024, 1, 4, 0, 0, 0, DateTimeKind.Utc));
+
+        return variant;
     }
 
     private static Ekom.Models.MetavalueSlim CreateMetafield(string alias, IReadOnlyList<Dictionary<string, string>> values)

--- a/Plugins/Ekom.Algolia/CHANGELOG.md
+++ b/Plugins/Ekom.Algolia/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **algolia:** add optional variant-level product indexing for SKU search.
 
 ## [0.2.34](https://github.com/Vettvangur/Ekom/compare/Ekom.Algolia-v0.2.33...Ekom.Algolia-v0.2.34) (2026-07-08)
 

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -27,6 +27,7 @@ public sealed class AlgoliaIndexingOptions
     public bool Enabled { get; set; } = true;
     public bool Products { get; set; } = true;
     public bool Categories { get; set; } = true;
+    public bool Variants { get; set; }
 
     public int BatchSize { get; set; } = 1000;
 
@@ -78,6 +79,7 @@ public sealed class AlgoliaSearchOptions
     public bool Enabled { get; set; } = true;
     public bool Products { get; set; } = true;
     public bool Categories { get; set; } = true;
+    public bool GroupVariantsByProduct { get; set; } = true;
     public bool QuerySuggestions { get; set; }
     public bool IncludeUserToken { get; set; } = true;
     public bool VaryCacheByUserToken { get; set; }

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
@@ -129,7 +129,7 @@ internal sealed class AlgoliaProductIndexExecutor
         {
             ct.ThrowIfCancellationRequested();
             var indexName = _indexNameBuilder.BuildPrimary("products", target);
-            await EnsureReplicasAsync(target, indexName, ct).ConfigureAwait(false);
+            await EnsureIndexSettingsAsync(target, indexName, ct).ConfigureAwait(false);
             var records = new List<AlgoliaProductRecord>(products.Count);
 
             var skippedProducts = 0;
@@ -137,9 +137,9 @@ internal sealed class AlgoliaProductIndexExecutor
             foreach (var product in products)
             {
                 ct.ThrowIfCancellationRequested();
-                var record = _mapper.Map(product, target, indexName);
-                if (record != null)
-                    records.Add(record);
+                var mappedRecords = _mapper.MapRecords(product, target, indexName);
+                if (mappedRecords.Count > 0)
+                    records.AddRange(mappedRecords);
                 else
                     skippedProducts++;
             }
@@ -211,7 +211,7 @@ internal sealed class AlgoliaProductIndexExecutor
         {
             ct.ThrowIfCancellationRequested();
             var indexName = _indexNameBuilder.BuildPrimary("products", target);
-            await EnsureReplicasAsync(target, indexName, ct).ConfigureAwait(false);
+            await EnsureIndexSettingsAsync(target, indexName, ct).ConfigureAwait(false);
             var records = new List<AlgoliaProductRecord>(products.Count);
 
             var skippedProducts = 0;
@@ -219,9 +219,9 @@ internal sealed class AlgoliaProductIndexExecutor
 
             foreach (var product in products)
             {
-                var record = _mapper.Map(product, target, indexName);
-                if (record != null)
-                    records.Add(record);
+                var mappedRecords = _mapper.MapRecords(product, target, indexName);
+                if (mappedRecords.Count > 0)
+                    records.AddRange(mappedRecords);
                 else
                     skippedProducts++;
             }
@@ -251,6 +251,9 @@ internal sealed class AlgoliaProductIndexExecutor
                 indexName,
                 target.Locale,
                 target.Currency);
+
+            if (_options.Indexing.Variants)
+                await DeleteByProductIdsAsync(indexName, products.Select(x => x.Key), waitForTasks: true, ct).ConfigureAwait(false);
 
             await _client.SaveObjectsAsync(
                 indexName: indexName,
@@ -283,7 +286,7 @@ internal sealed class AlgoliaProductIndexExecutor
         {
             ct.ThrowIfCancellationRequested();
             var indexName = _indexNameBuilder.BuildPrimary("products", target);
-            await EnsureReplicasAsync(target, indexName, ct).ConfigureAwait(false);
+            await EnsureIndexSettingsAsync(target, indexName, ct).ConfigureAwait(false);
 
             _logger.LogDebug(
                 "Algolia delete {Count} products from {IndexName} for locale {Locale} currency {Currency}",
@@ -292,13 +295,20 @@ internal sealed class AlgoliaProductIndexExecutor
                 target.Locale,
                 target.Currency);
 
-            await _client.DeleteObjectsAsync(
-                indexName: indexName,
-                objectIDs: ids,
-                batchSize: batchSize,
-                waitForTasks: false,
-                options: null,
-                cancellationToken: ct).ConfigureAwait(false);
+            if (_options.Indexing.Variants)
+            {
+                await DeleteByProductIdsAsync(indexName, keys, waitForTasks: false, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await _client.DeleteObjectsAsync(
+                    indexName: indexName,
+                    objectIDs: ids,
+                    batchSize: batchSize,
+                    waitForTasks: false,
+                    options: null,
+                    cancellationToken: ct).ConfigureAwait(false);
+            }
 
             await EnsureQuerySuggestionsAsync(target, indexName, ct).ConfigureAwait(false);
         }
@@ -306,9 +316,9 @@ internal sealed class AlgoliaProductIndexExecutor
         _searchCacheVersions.InvalidateStore(store.Alias);
     }
 
-    private async Task EnsureReplicasAsync(AlgoliaResolvedStore store, string primaryIndexName, CancellationToken ct)
+    private async Task EnsureIndexSettingsAsync(AlgoliaResolvedStore store, string primaryIndexName, CancellationToken ct)
     {
-        if (_options.Indexing.SortedReplicas.Count == 0)
+        if (_options.Indexing.SortedReplicas.Count == 0 && !_options.Indexing.Variants)
             return;
 
         var replicas = _options.Indexing.SortedReplicas
@@ -321,7 +331,7 @@ internal sealed class AlgoliaProductIndexExecutor
             .DistinctBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        if (replicas.Count == 0)
+        if (replicas.Count == 0 && !_options.Indexing.Variants)
             return;
 
         _logger.LogDebug(
@@ -334,7 +344,9 @@ internal sealed class AlgoliaProductIndexExecutor
             primaryIndexName,
             new IndexSettings
             {
-                Replicas = replicas.Select(x => x.Name).ToList()
+                Replicas = replicas.Select(x => x.Name).ToList(),
+                AttributeForDistinct = _options.Indexing.Variants ? "ProductId" : null,
+                AttributesForFaceting = _options.Indexing.Variants ? ["filterOnly(ProductId)"] : null
             },
             forwardToReplicas: false,
             options: null,
@@ -351,6 +363,26 @@ internal sealed class AlgoliaProductIndexExecutor
                 forwardToReplicas: false,
                 options: null,
                 cancellationToken: ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DeleteByProductIdsAsync(string indexName, IEnumerable<Guid> productKeys, bool waitForTasks, CancellationToken ct)
+    {
+        foreach (var productKey in productKeys.Distinct())
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var response = await _client.DeleteByAsync(
+                indexName,
+                new DeleteByParams
+                {
+                    Filters = $"ProductId:{productKey}"
+                },
+                options: null,
+                cancellationToken: ct).ConfigureAwait(false);
+
+            if (waitForTasks)
+                await _client.WaitForTaskAsync(indexName, response.TaskID, 100, null, null, ct).ConfigureAwait(false);
         }
     }
 

--- a/Plugins/Ekom.Algolia/Mappers/AlgoliaProductMappingContracts.cs
+++ b/Plugins/Ekom.Algolia/Mappers/AlgoliaProductMappingContracts.cs
@@ -6,6 +6,11 @@ namespace Ekom.Algolia.Mappers;
 public interface IAlgoliaProductIndexMapper
 {
     AlgoliaProductRecord? Map(IProduct product, AlgoliaResolvedStore store, string baseIndexName);
+    IReadOnlyList<AlgoliaProductRecord> MapRecords(IProduct product, AlgoliaResolvedStore store, string baseIndexName)
+    {
+        var record = Map(product, store, baseIndexName);
+        return record is null ? [] : [record];
+    }
 }
 
 public interface IAlgoliaProductEnricher

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -70,6 +70,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         {
             ObjectId = product.Key.ToString(),
             Sku = NullIfWhiteSpace(product.SKU),
+            ProductId = product.Key.ToString(),
             NodeName = NullIfWhiteSpace(nodeName),
             Title = title,
             Summary = NullIfWhiteSpace(GetLocalizedValue(product, "summary", product.Summary, locale)),
@@ -138,6 +139,87 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         RemoveEmptyValues(record.Data);
 
         return record;
+    }
+
+    public IReadOnlyList<AlgoliaProductRecord> MapRecords(IProduct product, AlgoliaResolvedStore store, string baseIndexName)
+    {
+        var productRecord = Map(product, store, baseIndexName);
+        if (productRecord is null)
+            return [];
+
+        if (!_options.Indexing.Variants)
+            return [productRecord];
+
+        var records = new List<AlgoliaProductRecord> { productRecord };
+
+        foreach (var variant in product.AllVariants)
+        {
+            var record = MapVariant(product, variant, productRecord, store);
+            if (record is not null)
+                records.Add(record);
+        }
+
+        return records;
+    }
+
+    private static AlgoliaProductRecord? MapVariant(
+        IProduct product,
+        IVariant variant,
+        AlgoliaProductRecord productRecord,
+        AlgoliaResolvedStore store)
+    {
+        if (string.IsNullOrWhiteSpace(variant.SKU))
+            return null;
+
+        var images = variant.Images
+            .Select(i => i?.Url)
+            .Where(u => !string.IsNullOrWhiteSpace(u))
+            .Select(u => u!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var price = ResolvePrice(variant, store);
+        var data = new Dictionary<string, object?>(productRecord.Data, StringComparer.OrdinalIgnoreCase)
+        {
+            ["variantSku"] = variant.SKU,
+            ["variantTitle"] = NullIfWhiteSpace(variant.Title),
+            ["variantDescription"] = NullIfWhiteSpace(variant.Description),
+            ["variantAvailable"] = variant.Available ? 1 : 0,
+            ["variantStock"] = store.IncludeStock ? variant.Stock : null
+        };
+
+        RemoveEmptyValues(data);
+
+        return new AlgoliaProductRecord
+        {
+            ObjectId = $"{product.Key}_{variant.Key}",
+            Sku = NullIfWhiteSpace(variant.SKU),
+            ProductId = product.Key.ToString(),
+            VariantId = variant.Key.ToString(),
+            ParentSku = NullIfWhiteSpace(product.SKU),
+            IsVariant = true,
+            VariantGroupId = variant.VariantGroupId,
+            NodeName = productRecord.NodeName,
+            Title = productRecord.Title,
+            Summary = productRecord.Summary,
+            Description = NullIfWhiteSpace(variant.Description) ?? productRecord.Description,
+            Url = productRecord.Url,
+            ImageUrl = NullIfWhiteSpace(images.FirstOrDefault()) ?? productRecord.ImageUrl,
+            ImageUrls = images.Count > 0 ? images : productRecord.ImageUrls,
+            Price = price?.Value ?? productRecord.Price,
+            PriceWithVat = price?.WithVat.Value ?? productRecord.PriceWithVat,
+            PriceWithoutVat = price?.WithoutVat.Value ?? productRecord.PriceWithoutVat,
+            Currency = NullIfWhiteSpace(price?.Currency.ISOCurrencySymbol ?? store.Currency) ?? productRecord.Currency,
+            Available = variant.Available ? 1 : 0,
+            ProductRanking = productRecord.ProductRanking,
+            CategoryRanking = productRecord.CategoryRanking,
+            Stock = store.IncludeStock ? variant.Stock : productRecord.Stock,
+            StoreAlias = productRecord.StoreAlias,
+            Locale = productRecord.Locale,
+            CreatedAt = ToUnixTimeSeconds(variant.CreateDate),
+            UpdatedAt = ToUnixTimeSeconds(variant.UpdateDate),
+            Data = data
+        };
     }
 
     private Dictionary<string, ConfiguredField> BuildAllowedProperties(IProduct product, AlgoliaResolvedStore store)
@@ -446,6 +528,15 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
         return product.Prices.FirstOrDefault(x => x.Currency.CurrencyValue.Equals(store.Currency, StringComparison.OrdinalIgnoreCase))
             ?? product.Price;
+    }
+
+    private static IPrice? ResolvePrice(IVariant variant, AlgoliaResolvedStore store)
+    {
+        if (string.IsNullOrWhiteSpace(store.Currency))
+            return variant.Price;
+
+        return variant.Prices.FirstOrDefault(x => x.Currency.CurrencyValue.Equals(store.Currency, StringComparison.OrdinalIgnoreCase))
+            ?? variant.Price;
     }
 
     private static object? TryToUnix(object? value, bool unixMilliseconds)

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
@@ -11,6 +11,20 @@ public sealed class AlgoliaProductRecord
     public string? Sku { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ProductId { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? VariantId { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ParentSku { get; init; }
+
+    public bool IsVariant { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? VariantGroupId { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? NodeName { get; init; }
 
     public required string Title { get; init; }

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -81,6 +81,7 @@ public sealed class ProductSearchController
         "Enabled": true,
         "Products": true,
         "Categories": true,
+        "Variants": false,
         "BatchSize": 1000,
         "ProductProperties": [
           "title",
@@ -122,6 +123,7 @@ public sealed class ProductSearchController
         "Enabled": true,
         "Products": true,
         "Categories": true,
+        "GroupVariantsByProduct": true,
         "QuerySuggestions": true,
         "IncludeUserToken": true,
         "VaryCacheByUserToken": false,
@@ -173,6 +175,7 @@ public sealed class ProductSearchController
 | `Indexing:Enabled` | `bool` | `true` | Enables indexing features. |
 | `Indexing:Products` | `bool` | `true` | Enables product indexing. |
 | `Indexing:Categories` | `bool` | `true` | Enables category indexing. |
+| `Indexing:Variants` | `bool` | `false` | Indexes product variants as separate product records so variant SKUs can be searched directly. |
 | `Indexing:BatchSize` | `int` | `1000` | Batch size for Algolia save/replace/delete operations. |
 | `Indexing:ProductProperties` | `string[]` | `[]` | Additional product properties/metafields to include in product records. Supports modifiers documented below. |
 | `Indexing:SortedReplicas` | `object[]` | `[]` | Replica definitions using `Attribute` and `Direction` (`Asc` or `Desc`). |
@@ -188,6 +191,7 @@ public sealed class ProductSearchController
 | `Search:Enabled` | `bool` | `true` | Enables Algolia search services. |
 | `Search:Products` | `bool` | `true` | Enables product search. |
 | `Search:Categories` | `bool` | `true` | Enables category search. |
+| `Search:GroupVariantsByProduct` | `bool` | `true` | When variant indexing is enabled, applies Algolia `distinct` so product searches group variant records by product. |
 | `Search:QuerySuggestions` | `bool` | `false` | Enables query suggestion search and provisioning. |
 | `Search:IncludeUserToken` | `bool` | `true` | Adds `userToken` to Algolia search requests using `IAlgoliaUserTokenProvider`, unless the query already has a token. |
 | `Search:VaryCacheByUserToken` | `bool` | `false` | Includes `userToken` in search cache keys. Keep `false` for shared cache; set `true` when Algolia personalization changes result order/content per user. |
@@ -212,31 +216,263 @@ public sealed class ProductSearchController
 | `Stores[*]:Alias` | `string` | required | Ekom store alias. |
 | `Stores[*]:IncludeStock` | `bool` | `false` | Includes product stock in indexed records for this store. |
 
-## Notes
-- Indexing triggers from Umbraco content notifications for `ekmProduct` and `ekmCategory`.
-- Search uses the required `SearchApiKey`; indexing and settings operations continue to use `AdminApiKey`.
-- When `Search.QuerySuggestions` is enabled, the plugin provisions the separate `query_suggestions...` index configuration automatically with the Admin API key.
-- Set `AnalyticsRegion` to `us` or `eu` if you know your Algolia analytics region; if omitted, the plugin tries `us` and then `eu`.
-- `IAlgoliaSearchService.SearchProductsAsync(...)` returns hits together with paging metadata, query text, processing time, and raw facets.
-- `IAlgoliaSearchService.SearchCategoriesAsync(...)` searches a dedicated category index scoped by store alias and locale.
-- `IAlgoliaSearchService.SearchContentAsync(...)` searches configured standard content indexes. Content index names resolve as `{IndexName}.{Environment}.{Culture}`.
-- `IAlgoliaSearchService.FederatedSearchAsync(...)` executes products, categories, query suggestions, and content searches in one Algolia multi-search request and returns typed product/category/suggestion results plus keyed content results.
-- The plugin always resolves and sets the Algolia index name from Ekom store alias, locale, and currency; callers should not set `IndexName` themselves.
-- Category indexes omit the currency suffix because category records are scoped by store alias and locale only.
-- Search cache keys include the resolved index name and serialized Algolia query payload so all SDK options affect caching.
-- `Search:IncludeUserToken` sends user context to Algolia search. The default provider uses authenticated username, then session ID, then request trace identifier.
-- `Search:VaryCacheByUserToken` controls whether that token also affects cache keys. Leave it `false` when results are not personalized so users can share cached results.
-- Store `Locale` and `Currency` now come from the Ekom store resolved by alias, so `appsettings.json` only needs the store alias.
-- Request and order context decide which culture and currency suffix is used; background indexing falls back to the store's default culture/currency.
-- `Title` is always indexed as a top-level field, and `NodeName` contains the Umbraco node name.
-- `Available` is indexed as `1` for available products and `0` for unavailable products, so it can be used for numeric ranking.
-- Product records always include top-level `ProductRanking` and `CategoryRanking` integer fields. Both support negative values. `ProductRanking` reads the product `ekmAlgoliaRank` property and defaults to `0` when missing or invalid. `CategoryRanking` uses the highest valid `ekmAlgoliaRank` value across the product's categories and defaults to `0` when no category has a valid rank.
-- Variants are not indexed by default.
-- `Indexing.ProductProperties` supports one optional modifier per property: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
-- Metafields can be indexed explicitly with `metafield:<alias>`, for example `metafield:material`, `metafield:color|array`, or `metafield:releaseDate|unix`.
+## Usage notes
+
+### Indexing triggers and API keys
+
+Product and category indexing is triggered from Umbraco content notifications for `ekmProduct` and `ekmCategory`.
+
+Search requests use `SearchApiKey`. Indexing, settings updates, replicas, delete operations, and query suggestion provisioning use `AdminApiKey`.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "ApplicationId": "APP_ID",
+      "AdminApiKey": "ADMIN_API_KEY",
+      "SearchApiKey": "SEARCH_API_KEY"
+    }
+  }
+}
+```
+
+When `Search:QuerySuggestions` is enabled, the plugin provisions the separate `query_suggestions...` index configuration automatically. Set `AnalyticsRegion` to `us` or `eu` if you know it; if omitted, the plugin tries `us` and then `eu`.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "AnalyticsRegion": "eu",
+      "Search": {
+        "QuerySuggestions": true
+      }
+    }
+  }
+}
+```
+
+### Index naming and store context
+
+The plugin resolves Algolia index names from the configured environment, store alias, locale, and currency. Callers should not set `SearchForHits.IndexName`; the search service sets it before executing the request.
+
+Product index names include currency when a currency is resolved:
+
+```text
+primary.prod.Store.products.en-US.USD
+```
+
+Category index names omit currency because category records are scoped by store alias and locale only:
+
+```text
+primary.prod.Store.categories.en-US
+```
+
+Standard content index names resolve as `{IndexName}.{Environment}.{Culture}`:
+
+```text
+SearchIndex.prod.en-US
+```
+
+Only the store alias must be configured in `appsettings.json`. Locale and currency are resolved from the Ekom store and the current request/order context. Background indexing falls back to the store's default culture and currency.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Stores": [
+        {
+          "Alias": "Store"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Searching
+
+`IAlgoliaSearchService.SearchProductsAsync(...)` returns typed product hits with paging metadata, query text, processing time, and raw facets.
+
+```csharp
+var response = await algoliaSearchService.SearchProductsAsync(
+    new AlgoliaSearchRequest
+    {
+        StoreAlias = "Store",
+        Locale = "en-US",
+        Currency = "USD",
+        Query = new SearchForHits
+        {
+            Query = "shoe",
+            HitsPerPage = 20,
+            Filters = "Available:1"
+        }
+    },
+    ct).ConfigureAwait(false);
+```
+
+Other search methods target their own index types:
+
+- `SearchCategoriesAsync(...)` searches category records scoped by store alias and locale.
+- `SearchContentAsync(...)` searches configured standard content indexes.
+- `FederatedSearchAsync(...)` executes products, categories, query suggestions, and content searches in one Algolia multi-search request.
+
+### Search caching and user tokens
+
+Search cache keys include the resolved index name and serialized Algolia query payload, so SDK options such as filters, facets, page, and hits-per-page affect caching.
+
+`Search:IncludeUserToken` sends user context to Algolia. The default provider uses authenticated username first, then session ID, then request trace identifier.
+
+`Search:VaryCacheByUserToken` controls whether that token also affects cache keys. Leave it `false` for shared cache when results are not personalized. Set it to `true` when Algolia personalization changes result order or content per user.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Search": {
+        "IncludeUserToken": true,
+        "VaryCacheByUserToken": false,
+        "Cache": {
+          "Enabled": true,
+          "DurationMinutes": 60
+        }
+      }
+    }
+  }
+}
+```
+
+### Product records and ranking fields
+
+Product records always include `Title` as a top-level field. `NodeName` contains the Umbraco node name.
+
+`Available` is indexed as a numeric value so it can be used for ranking:
+
+```json
+{
+  "Title": "Running shoe",
+  "NodeName": "Running shoe - black",
+  "Available": 1
+}
+```
+
+Product records also include `ProductRanking` and `CategoryRanking` integer fields. Both support negative values.
+
+- `ProductRanking` reads the product `ekmAlgoliaRank` property and defaults to `0` when missing or invalid.
+- `CategoryRanking` uses the highest valid `ekmAlgoliaRank` value across the product's categories and defaults to `0` when no category has a valid rank.
+
+```json
+{
+  "ProductRanking": 10,
+  "CategoryRanking": 5
+}
+```
+
+### Variant indexing
+
+Variants are not indexed by default. Enable variant indexing when products use placeholder parent SKUs and the real sellable SKUs live on variants.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Indexing": {
+        "Variants": true
+      },
+      "Search": {
+        "GroupVariantsByProduct": true
+      }
+    }
+  }
+}
+```
+
+When enabled, the plugin creates one additional product record per variant. Variant records use the variant SKU as top-level `Sku`, preserve the parent product SKU as `ParentSku`, and include `ProductId` and `VariantId` for grouping and selection.
+
+```json
+{
+  "objectID": "product-key_variant-key",
+  "ProductId": "product-key",
+  "VariantId": "variant-key",
+  "Sku": "REAL-VARIANT-SKU",
+  "ParentSku": "PLACEHOLDER-SKU",
+  "IsVariant": true,
+  "variantSku": "REAL-VARIANT-SKU",
+  "variantTitle": "Black / XL"
+}
+```
+
+Product indexes are configured with `AttributeForDistinct = ProductId`. `Search:GroupVariantsByProduct` defaults to `true`, so normal searches return grouped product results while SKU searches can still match variant records. Set it to `false` if you want one hit per matching variant.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Search": {
+        "GroupVariantsByProduct": false
+      }
+    }
+  }
+}
+```
+
+### Additional product properties and metafields
+
+`Indexing:ProductProperties` adds extra product properties and metafields to product records. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Indexing": {
+        "ProductProperties": [
+          "channels|array",
+          "stockCount|int",
+          "weight|decimal",
+          "publishedAt|unix"
+        ]
+      }
+    }
+  }
+}
+```
+
+Metafields can be indexed explicitly with `metafield:<alias>`:
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Indexing": {
+        "ProductProperties": [
+          "metafield:material",
+          "metafield:color|array",
+          "metafield:releaseDate|unix"
+        ]
+      }
+    }
+  }
+}
+```
+
+Modifier behavior:
+
+- `|array` parses JSON arrays such as `["Web","Store"]` into Algolia string arrays.
+- `|decimal` accepts comma or dot decimal separators, such as `0,1` and `0.0`.
 - Multi-value metafields are skipped unless `|array` is configured.
-- `|array` parses JSON arrays such as checkbox-list values like `["Web","Store"]` into Algolia string arrays.
-- `|decimal` accepts either comma or dot decimal separators, so values like `0,1` and `0.0` are indexed as decimals.
 - Invalid `|array`, `|int`, and `|decimal` values are skipped instead of being indexed as strings.
-- Manual reindex all endpoint: `GET` or `POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildIndexes`.
-- Manual reindex store endpoint: `GET` or `POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildStoreIndexes?storeAlias=Store`.
+
+### Manual reindexing
+
+Use the backoffice endpoints to rebuild Algolia indexes manually. Both endpoints support `GET` and `POST`.
+
+Rebuild all configured store indexes:
+
+```http
+POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildIndexes
+```
+
+Rebuild one store:
+
+```http
+POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildStoreIndexes?storeAlias=Store
+```

--- a/Plugins/Ekom.Algolia/Services/AlgoliaSearchService.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaSearchService.cs
@@ -84,6 +84,7 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
         var indexName = _indexNameBuilder.BuildPrimary(ProductsEntity, target);
 
         query.IndexName = indexName;
+        ApplyVariantGrouping(query);
 
         if (_options.Search.MaxHitsPerPage > 0 && query.HitsPerPage > _options.Search.MaxHitsPerPage)
             query.HitsPerPage = _options.Search.MaxHitsPerPage;
@@ -413,9 +414,20 @@ internal sealed class AlgoliaSearchService : IAlgoliaSearchService
             return false;
 
         query.IndexName = indexName;
+        if (target.Kind == AlgoliaFederatedSearchTargetKind.Products)
+            ApplyVariantGrouping(query);
+
         var userToken = PrepareUserTokenForCache(query);
         ApplyUserToken(query, userToken);
         return true;
+    }
+
+    private void ApplyVariantGrouping(SearchForHits query)
+    {
+        if (!_options.Indexing.Variants || !_options.Search.GroupVariantsByProduct)
+            return;
+
+        query.Distinct ??= new Distinct(true);
     }
 
     private string? PrepareUserTokenForCache(SearchForHits query)

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaUmbracoNotifications.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaUmbracoNotifications.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 
 namespace Ekom.Algolia.Events;
@@ -28,11 +29,14 @@ internal sealed class AlgoliaUmbracoNotifications :
     INotificationAsyncHandler<ContentDeletedNotification>
 {
     private const string ProductAlias = "ekmProduct";
+    private const string ProductVariantAlias = "ekmProductVariant";
+    private const string ProductVariantGroupAlias = "ekmProductVariantGroup";
     private const string CategoryAlias = "ekmCategory";
 
     private readonly IAlgoliaProductIndexService _productIndexer;
     private readonly IAlgoliaCategoryIndexService _categoryIndexer;
     private readonly IAlgoliaContentIndexService _contentIndexer;
+    private readonly IContentService _contentService;
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly AlgoliaOptions _options;
     private readonly ILogger<AlgoliaUmbracoNotifications> _logger;
@@ -41,6 +45,7 @@ internal sealed class AlgoliaUmbracoNotifications :
         IAlgoliaProductIndexService productIndexer,
         IAlgoliaCategoryIndexService categoryIndexer,
         IAlgoliaContentIndexService contentIndexer,
+        IContentService contentService,
         IServerRoleAccessor serverRoleAccessor,
         IOptions<AlgoliaOptions> options,
         ILogger<AlgoliaUmbracoNotifications> logger)
@@ -48,6 +53,7 @@ internal sealed class AlgoliaUmbracoNotifications :
         _productIndexer = productIndexer;
         _categoryIndexer = categoryIndexer;
         _contentIndexer = contentIndexer;
+        _contentService = contentService;
         _serverRoleAccessor = serverRoleAccessor;
         _options = options.Value;
         _logger = logger;
@@ -89,6 +95,9 @@ internal sealed class AlgoliaUmbracoNotifications :
     {
         if (string.Equals(entity.ContentType.Alias, ProductAlias, StringComparison.OrdinalIgnoreCase))
             return EnqueueProductAsync(entity, isPublished, ct);
+
+        if (_options.Indexing.Variants && IsProductVariantContent(entity.ContentType.Alias))
+            return EnqueueVariantProductAsync(entity, isPublished, ct);
 
         if (string.Equals(entity.ContentType.Alias, CategoryAlias, StringComparison.OrdinalIgnoreCase))
             return EnqueueCategoryAsync(entity, isPublished, ct);
@@ -153,6 +162,21 @@ internal sealed class AlgoliaUmbracoNotifications :
         }
     }
 
+    private async Task EnqueueVariantProductAsync(IContent entity, bool isPublished, CancellationToken ct)
+    {
+        var product = ResolveProductAncestor(entity);
+        if (product is null)
+        {
+            _logger.LogDebug(
+                "Algolia could not resolve parent product for variant content {Id} alias {Alias}.",
+                entity.Id,
+                entity.ContentType.Alias);
+            return;
+        }
+
+        await EnqueueProductAsync(product, isPublished: true, ct).ConfigureAwait(false);
+    }
+
     private async Task EnqueueCategoryAsync(IContent entity, bool isPublished, CancellationToken ct)
     {
         if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Categories)
@@ -203,4 +227,27 @@ internal sealed class AlgoliaUmbracoNotifications :
         => _options.ContentIndexing.Indexes
             .SelectMany(x => x.ContentTypes)
             .Any(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsProductVariantContent(string alias)
+        => string.Equals(alias, ProductVariantAlias, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(alias, ProductVariantGroupAlias, StringComparison.OrdinalIgnoreCase);
+
+    private IContent? ResolveProductAncestor(IContent entity)
+    {
+        var current = entity;
+
+        while (current.ParentId > 0)
+        {
+            var parent = _contentService.GetById(current.ParentId);
+            if (parent is null)
+                return null;
+
+            if (string.Equals(parent.ContentType.Alias, ProductAlias, StringComparison.OrdinalIgnoreCase))
+                return parent;
+
+            current = parent;
+        }
+
+        return null;
+    }
 }

--- a/Samples/U17/Ekom.Site.U17/appsettings.json
+++ b/Samples/U17/Ekom.Site.U17/appsettings.json
@@ -68,6 +68,7 @@
               "Enabled": true,
               "Products": true,
               "Categories": true,
+              "Variants": true,
               "BatchSize": 1000,
               "ProductProperties": [
                   "brand"


### PR DESCRIPTION
## Summary
- Add optional Algolia variant indexing via `Indexing:Variants` for products whose real SKUs live on variants.
- Emit variant product records with product/variant identifiers, parent SKU, variant SKU metadata, and product-level grouping support.
- Configure product distinct settings and default grouped variant search via `Search:GroupVariantsByProduct`.
- Reindex parent products when variant or variant group content changes, and delete/upsert all records for a product by `ProductId` when variants are enabled.
- Refresh Algolia README usage notes with grouped sections and examples.

## Test Plan
- `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj"`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaProductIndexMapperTests"`
