### PR TITLE
feat: add product variant content app

### DIFF
--- a/Ekom/Ekom.Core/Ekom/EkomOptions.cs
+++ b/Ekom/Ekom.Core/Ekom/EkomOptions.cs
@@ -1,6 +1,13 @@
 public sealed class EkomOptions
 {
     public ManagerOptions Manager { get; set; } = new();
+    public VariantAppOptions VariantApp { get; set; } = new();
+}
+
+public sealed class VariantAppOptions
+{
+    public List<string> VariantGroups { get; set; } = [];
+    public List<string> Variants { get; set; } = [];
 }
 
 public sealed class ManagerOptions

--- a/Ekom/Ekom.Core/Ekom/Models/CurrencyPrice.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/CurrencyPrice.cs
@@ -2,6 +2,11 @@ namespace Ekom.Models;
 
 public class CurrencyPrice
 {
+    public CurrencyPrice()
+    {
+        Currency = string.Empty;
+    }
+
     public CurrencyPrice(decimal price, string currency)
     {
         Currency = currency;

--- a/Ekom/Ekom.Umbraco/Ekom.U10/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/ApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Ekom.AspNetCore;
 using Ekom.Services;
 using Ekom.Tracking;
 using Ekom.Umb.Services;
+using Ekom.Umb.VariantApp.Services;
 using EkomCore.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -31,6 +32,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<IEkomRichTextResolver, EkomRichTextResolver>();
         services.AddTransient<IMetafieldService, MetafieldService>();
         services.AddTransient<IUmbracoService, UmbracoService>();
+        services.AddTransient<IVariantAppService, VariantAppService>();
         services.AddTransient<IUrlService, UrlService>();
         services.AddScoped<BackofficeUserAccessor>();
         services.AddScoped<ISecurityService, SecurityService>();

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/UmbracoService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/UmbracoService.cs
@@ -5,6 +5,7 @@ using Ekom.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Net;
 using System.Threading;
 using Umbraco.Cms.Core.Cache;
@@ -219,4 +220,6 @@ class UmbracoService : IUmbracoService
     {
         return value.ToUrlSegment(_shortStringHelper);
     }
+
+
 }

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/ContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/ContentExtensions.cs
@@ -374,15 +374,25 @@ public static class ContentExtensions
             try
             {
                 currencyPriceRoot = string.IsNullOrEmpty(fieldValue) ? currencyPriceRoot : JsonConvert.DeserializeObject<CurrencyPriceRoot>(fieldValue);
-                if (currencyPriceRoot.ContainsKey(storeAlias))
-                {
-                    var storeItems = currencyPriceRoot[storeAlias];
+                var storeItems = currencyPriceRoot
+                    .Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase))
+                    .SelectMany(x => x.Value)
+                    .GroupBy(x => x.Currency, StringComparer.OrdinalIgnoreCase)
+                    .Select(x => x.Last())
+                    .ToList();
 
+                foreach (var key in currencyPriceRoot.Keys.Where(x => x.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)).ToList())
+                {
+                    currencyPriceRoot.Remove(key);
+                }
+
+                if (storeItems.Count > 0)
+                {
                     // Ensure the storeItems list is not null and has elements
                     if (storeItems.Any())
                     {
                         // Find the first item with the specified currency
-                        priceObject = storeItems.FirstOrDefault(z => z.Currency == currency);
+                        priceObject = storeItems.FirstOrDefault(z => z.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase));
 
                         if (priceObject != null)
                         {
@@ -397,6 +407,8 @@ public static class ContentExtensions
                     {
                         storeItems.Add(new CurrencyPrice(price, currency));
                     }
+
+                    currencyPriceRoot.Add(storeAlias, storeItems);
                 }
                 else
                 {

--- a/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Controllers/VariantAppController.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Controllers/VariantAppController.cs
@@ -1,0 +1,84 @@
+using Ekom.ActionFilters;
+using Ekom.Authorization;
+using Ekom.Umb.VariantApp.Models;
+using Ekom.Umb.VariantApp.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ekom.Umb.VariantApp.Controllers;
+
+[Route("ekom/backoffice/Variants")]
+[CamelCaseJson]
+public sealed class VariantAppController : ControllerBase
+{
+    private readonly IVariantAppService _variantAppService;
+
+    public VariantAppController(IVariantAppService variantAppService)
+    {
+        _variantAppService = variantAppService;
+    }
+
+    [HttpGet]
+    [Route("{productId}")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerProduct GetProductVariants([FromRoute] string productId)
+        => _variantAppService.GetProductVariants(productId);
+
+    [HttpGet]
+    [Route("{productId}/Count")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerCount GetVariantCount([FromRoute] string productId)
+        => _variantAppService.GetVariantCount(productId);
+
+    [HttpPost]
+    [Route("Groups")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerGroup CreateVariantGroup([FromBody] VariantManagerGroupRequest request)
+        => _variantAppService.CreateVariantGroup(request);
+
+    [HttpPost]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public Task<VariantManagerVariant> CreateVariant([FromBody] VariantManagerVariantRequest request)
+        => _variantAppService.CreateVariantAsync(request);
+
+    [HttpPost]
+    [Route("Save")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public Task<VariantManagerProduct> SaveProductVariants([FromBody] VariantManagerSaveRequest request)
+        => _variantAppService.SaveProductVariantsAsync(request);
+
+    [HttpPost]
+    [Route("Groups/Save")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerGroup SaveVariantGroup([FromBody] VariantManagerGroupSaveRequest request)
+        => _variantAppService.SaveVariantGroup(request);
+
+    [HttpPost]
+    [Route("Items/Save")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public Task<VariantManagerVariant> SaveVariant([FromBody] VariantManagerVariantSaveRequest request)
+        => _variantAppService.SaveVariantAsync(request);
+
+    [HttpGet]
+    [Route("Media/Thumbnail")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public IActionResult GetMediaThumbnail([FromQuery] string mediaId, [FromQuery] int width = 38, [FromQuery] int height = 38)
+    {
+        var url = _variantAppService.GetMediaThumbnailPath(mediaId, width, height);
+        return string.IsNullOrWhiteSpace(url) ? NotFound() : Redirect(url);
+    }
+
+    [HttpDelete]
+    [Route("{nodeId}")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public bool DeleteVariantNode([FromRoute] string nodeId)
+        => _variantAppService.DeleteVariantNode(nodeId);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Models/VariantAppModels.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Models/VariantAppModels.cs
@@ -1,0 +1,117 @@
+using Ekom.Models;
+using Ekom.Models.Umbraco;
+
+namespace Ekom.Umb.VariantApp.Models;
+
+public sealed class VariantManagerProduct
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Sku { get; set; } = string.Empty;
+    public int VariantCount { get; set; }
+    public IReadOnlyList<UmbracoLanguage> Languages { get; set; } = Array.Empty<UmbracoLanguage>();
+    public IReadOnlyList<VariantManagerStore> Stores { get; set; } = Array.Empty<VariantManagerStore>();
+    public IReadOnlyList<VariantManagerCustomFieldDefinition> VariantGroupFields { get; set; } = Array.Empty<VariantManagerCustomFieldDefinition>();
+    public IReadOnlyList<VariantManagerCustomFieldDefinition> VariantFields { get; set; } = Array.Empty<VariantManagerCustomFieldDefinition>();
+    public IReadOnlyList<VariantManagerGroup> Groups { get; set; } = Array.Empty<VariantManagerGroup>();
+}
+
+public sealed class VariantManagerCount
+{
+    public int Count { get; set; }
+}
+
+public sealed class VariantManagerStore
+{
+    public string Alias { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public IReadOnlyList<CurrencyModel> Currencies { get; set; } = Array.Empty<CurrencyModel>();
+}
+
+public class VariantManagerCustomFieldDefinition
+{
+    public string Alias { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public bool Required { get; set; }
+}
+
+public sealed class VariantManagerCustomField : VariantManagerCustomFieldDefinition
+{
+    public string Value { get; set; } = string.Empty;
+}
+
+public sealed class VariantManagerGroup
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public IDictionary<string, string> TitleValues { get; set; } = new Dictionary<string, string>();
+    public string Color { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+    public bool Changed { get; set; }
+    public bool Published { get; set; }
+    public IReadOnlyList<VariantManagerCustomField> CustomFields { get; set; } = Array.Empty<VariantManagerCustomField>();
+    public IReadOnlyList<VariantManagerVariant> Variants { get; set; } = Array.Empty<VariantManagerVariant>();
+}
+
+public sealed class VariantManagerVariant
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public IDictionary<string, string> TitleValues { get; set; } = new Dictionary<string, string>();
+    public string Sku { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public CurrencyPriceRoot PriceValues { get; set; } = new();
+    public IReadOnlyList<StockRequest> StockValues { get; set; } = Array.Empty<StockRequest>();
+    public IReadOnlyList<VariantManagerCustomField> CustomFields { get; set; } = Array.Empty<VariantManagerCustomField>();
+    public int SortOrder { get; set; }
+    public bool Changed { get; set; }
+    public bool Published { get; set; }
+}
+
+public sealed class VariantManagerGroupRequest
+{
+    public string ProductId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Color { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+}
+
+public sealed class VariantManagerVariantRequest
+{
+    public string GroupId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Sku { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public string Price { get; set; } = string.Empty;
+    public string Stock { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+}
+
+public sealed class VariantManagerSaveRequest
+{
+    public string ProductId { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+    public IReadOnlyList<VariantManagerGroup> Groups { get; set; } = Array.Empty<VariantManagerGroup>();
+}
+
+public sealed class VariantManagerGroupSaveRequest
+{
+    public string ProductId { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+    public VariantManagerGroup Group { get; set; } = new();
+}
+
+public sealed class VariantManagerVariantSaveRequest
+{
+    public string GroupId { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+    public VariantManagerVariant Variant { get; set; } = new();
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/IVariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/IVariantAppService.cs
@@ -1,0 +1,16 @@
+using Ekom.Umb.VariantApp.Models;
+
+namespace Ekom.Umb.VariantApp.Services;
+
+public interface IVariantAppService
+{
+    VariantManagerProduct GetProductVariants(string productId);
+    VariantManagerCount GetVariantCount(string productId);
+    VariantManagerGroup CreateVariantGroup(VariantManagerGroupRequest request);
+    Task<VariantManagerVariant> CreateVariantAsync(VariantManagerVariantRequest request);
+    Task<VariantManagerProduct> SaveProductVariantsAsync(VariantManagerSaveRequest request);
+    VariantManagerGroup SaveVariantGroup(VariantManagerGroupSaveRequest request);
+    Task<VariantManagerVariant> SaveVariantAsync(VariantManagerVariantSaveRequest request);
+    string GetMediaThumbnailPath(string mediaId, int width, int height);
+    bool DeleteVariantNode(string nodeId);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/VariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/VariantAppService.cs
@@ -1,0 +1,793 @@
+using Ekom.Models;
+using Ekom.Models.Umbraco;
+using Ekom.Services;
+using Ekom.Umb.Models;
+using Ekom.Umb.VariantApp.Models;
+using Ekom.Utilities;
+using Newtonsoft.Json;
+using System.Globalization;
+using System.Net;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Ekom.Umb.VariantApp.Services;
+
+internal sealed class VariantAppService : IVariantAppService
+{
+    private readonly IContentService _contentService;
+    private readonly IContentTypeService _contentTypeService;
+    private readonly INodeService _nodeService;
+    private readonly ILocalizationService _localizationService;
+    private readonly VariantAppOptions _variantAppOptions;
+
+    public VariantAppService(
+        IContentService contentService,
+        IContentTypeService contentTypeService,
+        INodeService nodeService,
+        ILocalizationService localizationService,
+        IOptions<EkomOptions> options)
+    {
+        _contentService = contentService;
+        _contentTypeService = contentTypeService;
+        _nodeService = nodeService;
+        _localizationService = localizationService;
+        _variantAppOptions = options.Value.VariantApp;
+    }
+
+    public VariantManagerProduct GetProductVariants(string productId)
+    {
+        var product = GetContent(productId, "ekmProduct");
+        return MapProduct(product);
+    }
+
+    public VariantManagerCount GetVariantCount(string productId)
+    {
+        var product = GetContent(productId, "ekmProduct");
+        return new VariantManagerCount
+        {
+            Count = CountVariants(product),
+        };
+    }
+
+    public VariantManagerGroup CreateVariantGroup(VariantManagerGroupRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var product = GetContent(request.ProductId, "ekmProduct");
+        var title = GetRequiredTitle(request.Title, "Variant group");
+        var group = _contentService.Create(title, product.Id, "ekmProductVariantGroup");
+
+        group.SetProperty("title", CreateTitleValues(title, LoadLanguages()));
+        group.SetValue("color", request.Color ?? string.Empty);
+        group.SetValue("images", request.Images ?? string.Empty);
+        SaveContent(group, request.Publish);
+
+        return MapGroup(group, LoadVariantStores(product));
+    }
+
+    public async Task<VariantManagerVariant> CreateVariantAsync(VariantManagerVariantRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var group = GetContent(request.GroupId, "ekmProductVariantGroup");
+        var title = GetRequiredTitle(request.Title, "Variant");
+        var variant = _contentService.Create(title, group.Id, "ekmProductVariant");
+
+        var product = GetContent(group.ParentId.ToString(CultureInfo.InvariantCulture), "ekmProduct");
+        var stores = LoadVariantStores(product);
+
+        ApplyVariantValues(variant, request.Title, request.Sku, request.Images, request.Price, request.Stock, stores);
+        SaveContent(variant, request.Publish);
+        await ApplyStockValuesAsync(variant.Key, ParseStockValues(request.Stock)).ConfigureAwait(false);
+
+        return MapVariant(variant, stores);
+    }
+
+    public async Task<VariantManagerProduct> SaveProductVariantsAsync(VariantManagerSaveRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var product = GetContent(request.ProductId, "ekmProduct");
+        var stores = LoadVariantStores(product);
+
+        foreach (var groupModel in request.Groups)
+        {
+            var group = GetOrCreateVariantGroup(product, groupModel);
+
+            if (group.ParentId != product.Id)
+            {
+                continue;
+            }
+
+                var groupFieldDefinitions = GetVariantGroupFieldDefinitions();
+                if (groupModel.Changed || groupModel.Id <= 0)
+                {
+                    ApplyGroupValues(group, groupModel, groupFieldDefinitions);
+                    group.SortOrder = groupModel.SortOrder;
+                    SaveContent(group, request.Publish);
+                }
+
+                var variantFieldDefinitions = GetVariantFieldDefinitions();
+                foreach (var variantModel in groupModel.Variants)
+                {
+                var isNewVariant = variantModel.Id <= 0;
+                var variant = GetOrCreateVariant(group, variantModel);
+
+                if (variant.ParentId != group.Id)
+                {
+                    continue;
+                }
+
+                if (isNewVariant || HasVariantContentChanges(variant, variantModel, stores, variantFieldDefinitions))
+                {
+                    ApplyVariantValues(variant, variantModel, stores, variantFieldDefinitions);
+                    variant.SortOrder = variantModel.SortOrder;
+                    SaveContent(variant, request.Publish);
+                }
+
+                await ApplyStockValuesAsync(variant.Key, variantModel.StockValues).ConfigureAwait(false);
+            }
+        }
+
+        return MapProduct(product);
+    }
+
+    public VariantManagerGroup SaveVariantGroup(VariantManagerGroupSaveRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var product = GetContent(request.ProductId, "ekmProduct");
+        var group = GetOrCreateVariantGroup(product, request.Group);
+
+        if (group.ParentId != product.Id)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        ApplyGroupValues(group, request.Group, GetVariantGroupFieldDefinitions());
+        SaveContent(group, request.Publish);
+
+        return MapGroup(group, LoadVariantStores(product));
+    }
+
+    public async Task<VariantManagerVariant> SaveVariantAsync(VariantManagerVariantSaveRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var group = GetContent(request.GroupId, "ekmProductVariantGroup");
+        var variant = GetOrCreateVariant(group, request.Variant);
+        var product = GetContent(group.ParentId.ToString(CultureInfo.InvariantCulture), "ekmProduct");
+        var stores = LoadVariantStores(product);
+
+        if (variant.ParentId != group.Id)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        var variantFieldDefinitions = GetVariantFieldDefinitions();
+        if (request.Variant.Id <= 0 || HasVariantContentChanges(variant, request.Variant, stores, variantFieldDefinitions))
+        {
+            ApplyVariantValues(variant, request.Variant, stores, variantFieldDefinitions);
+            SaveContent(variant, request.Publish);
+        }
+
+        await ApplyStockValuesAsync(variant.Key, request.Variant.StockValues).ConfigureAwait(false);
+
+        return MapVariant(variant, stores);
+    }
+
+    public bool DeleteVariantNode(string nodeId)
+    {
+        var content = GetContent(nodeId, null);
+
+        if (content.ContentType.Alias is not ("ekmProductVariant" or "ekmProductVariantGroup"))
+        {
+            return false;
+        }
+
+        _contentService.MoveToRecycleBin(content);
+        return true;
+    }
+
+    public string GetMediaThumbnailPath(string mediaId, int width, int height)
+    {
+        var media = _nodeService.MediaById(mediaId);
+
+        if (media == null || string.IsNullOrWhiteSpace(media.Url) || media.Url == "#")
+        {
+            return string.Empty;
+        }
+
+        return AppendImageSize(media.Url, width, height);
+    }
+
+    private IContent GetContent(string id, string? expectedAlias)
+    {
+        IContent? content = null;
+
+        if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
+        {
+            content = _contentService.GetById(intId);
+        }
+        else if (Guid.TryParse(id, out var key))
+        {
+            content = _contentService.GetById(key);
+        }
+
+        if (content == null)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.NotFound);
+        }
+
+        if (!string.IsNullOrWhiteSpace(expectedAlias) && !content.ContentType.Alias.Equals(expectedAlias, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        return content;
+    }
+
+    private static string AppendImageSize(string url, int width, int height)
+    {
+        var separator = url.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+        return string.Concat(url, separator, "width=", Math.Max(width, 1).ToString(CultureInfo.InvariantCulture), "&height=", Math.Max(height, 1).ToString(CultureInfo.InvariantCulture));
+    }
+
+    private VariantManagerProduct MapProduct(IContent product)
+    {
+        var stores = LoadVariantStores(product);
+        var groupFieldDefinitions = GetVariantGroupFieldDefinitions();
+        var variantFieldDefinitions = GetVariantFieldDefinitions();
+        var groups = GetChildren(product.Id, "ekmProductVariantGroup")
+            .Select(group => MapGroup(group, stores, groupFieldDefinitions, variantFieldDefinitions))
+            .ToList();
+
+        return new VariantManagerProduct
+        {
+            Id = product.Id,
+            Key = product.Key,
+            Name = product.Name ?? string.Empty,
+            Title = GetDisplayTitle(GetTitleValues(product, "title", LoadLanguages()), product.Name ?? string.Empty),
+            Sku = GetStringValue(product, "sku"),
+            VariantCount = groups.Sum(x => x.Variants.Count),
+            Languages = LoadLanguages(),
+            Stores = stores,
+            VariantGroupFields = groupFieldDefinitions,
+            VariantFields = variantFieldDefinitions,
+            Groups = groups,
+        };
+    }
+
+    private VariantManagerGroup MapGroup(IContent group, IReadOnlyList<VariantManagerStore> stores)
+        => MapGroup(group, stores, GetVariantGroupFieldDefinitions(), GetVariantFieldDefinitions());
+
+    private VariantManagerGroup MapGroup(
+        IContent group,
+        IReadOnlyList<VariantManagerStore> stores,
+        IReadOnlyList<VariantManagerCustomFieldDefinition> groupFieldDefinitions,
+        IReadOnlyList<VariantManagerCustomFieldDefinition> variantFieldDefinitions)
+    {
+        return new VariantManagerGroup
+        {
+            Id = group.Id,
+            Key = group.Key,
+            Name = group.Name ?? string.Empty,
+            Title = GetDisplayTitle(GetTitleValues(group, "title", LoadLanguages()), group.Name ?? string.Empty),
+            TitleValues = GetTitleValues(group, "title", LoadLanguages()),
+            Color = GetStringValue(group, "color"),
+            Images = GetStringValue(group, "images"),
+            SortOrder = group.SortOrder,
+            Published = group.Published,
+            CustomFields = GetCustomFields(group, groupFieldDefinitions),
+            Variants = GetChildren(group.Id, "ekmProductVariant").Select(variant => MapVariant(variant, stores, variantFieldDefinitions)).ToList(),
+        };
+    }
+
+    private VariantManagerVariant MapVariant(IContent variant, IReadOnlyList<VariantManagerStore> stores)
+        => MapVariant(variant, stores, GetVariantFieldDefinitions());
+
+    private VariantManagerVariant MapVariant(IContent variant, IReadOnlyList<VariantManagerStore> stores, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        return new VariantManagerVariant
+        {
+            Id = variant.Id,
+            Key = variant.Key,
+            Name = variant.Name ?? string.Empty,
+            Title = GetDisplayTitle(GetTitleValues(variant, "title", LoadLanguages()), variant.Name ?? string.Empty),
+            TitleValues = GetTitleValues(variant, "title", LoadLanguages()),
+            Sku = GetStringValue(variant, "sku"),
+            Images = GetStringValue(variant, "images"),
+            PriceValues = GetPriceValues(variant, stores),
+            StockValues = GetStockValues(variant),
+            CustomFields = GetCustomFields(variant, fieldDefinitions),
+            SortOrder = variant.SortOrder,
+            Published = variant.Published,
+        };
+    }
+
+    private IReadOnlyList<IContent> GetChildren(int parentId, string contentTypeAlias)
+    {
+        return _contentService.GetPagedChildren(parentId, 0, int.MaxValue, out _)
+            .Where(x => !x.Trashed && x.ContentType.Alias.Equals(contentTypeAlias, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.Name)
+            .ToList();
+    }
+
+    private int CountVariants(IContent product)
+    {
+        return GetChildren(product.Id, "ekmProductVariantGroup")
+            .Sum(group => GetChildren(group.Id, "ekmProductVariant").Count);
+    }
+
+    private IContent GetOrCreateVariantGroup(IContent product, VariantManagerGroup groupModel)
+    {
+        if (groupModel.Id > 0)
+        {
+            return GetContent(groupModel.Id.ToString(CultureInfo.InvariantCulture), "ekmProductVariantGroup");
+        }
+
+        var title = GetDisplayTitle(NormalizeTitleValues(groupModel.TitleValues, groupModel.Title, "Variant group"), "Variant group");
+        return _contentService.Create(title, product.Id, "ekmProductVariantGroup");
+    }
+
+    private IContent GetOrCreateVariant(IContent group, VariantManagerVariant variantModel)
+    {
+        if (variantModel.Id > 0)
+        {
+            return GetContent(variantModel.Id.ToString(CultureInfo.InvariantCulture), "ekmProductVariant");
+        }
+
+        var title = GetDisplayTitle(NormalizeTitleValues(variantModel.TitleValues, variantModel.Title, "Variant"), "Variant");
+        return _contentService.Create(title, group.Id, "ekmProductVariant");
+    }
+
+    private static void ApplyVariantValues(IContent variant, VariantManagerVariant variantModel, IReadOnlyList<VariantManagerStore> stores, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var variantTitleValues = NormalizeTitleValues(variantModel.TitleValues, variantModel.Title, variant.Name ?? "Variant");
+        var variantTitle = GetDisplayTitle(variantTitleValues, variant.Name ?? "Variant");
+        variant.Name = variantTitle;
+        variant.SetProperty("title", ToObjectDictionary(variantTitleValues));
+        variant.SetValue("sku", variantModel.Sku ?? string.Empty);
+        variant.SetValue("images", variantModel.Images ?? string.Empty);
+        ApplyCustomFields(variant, variantModel.CustomFields, fieldDefinitions);
+        ApplyPriceValues(variant, variantModel.PriceValues, stores);
+    }
+
+    private static void ApplyPriceValues(IContent variant, CurrencyPriceRoot? priceValues, IReadOnlyList<VariantManagerStore> stores)
+    {
+        variant.SetValue("price", JsonConvert.SerializeObject(NormalizePriceValues(GetPriceValues(variant, stores), stores)));
+
+        foreach (var priceValue in NormalizePriceValues(priceValues, stores))
+        {
+            foreach (var price in priceValue.Value)
+            {
+                variant.SetPrice(priceValue.Key, price.Currency, price.Price ?? 0);
+            }
+        }
+    }
+
+    private bool HasVariantContentChanges(IContent variant, VariantManagerVariant variantModel, IReadOnlyList<VariantManagerStore> stores, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var titleValues = NormalizeTitleValues(variantModel.TitleValues, variantModel.Title, variant.Name ?? "Variant");
+
+        return !DictionariesEqual(GetTitleValues(variant, "title", LoadLanguages()), titleValues)
+            || !string.Equals(GetStringValue(variant, "sku"), variantModel.Sku ?? string.Empty, StringComparison.Ordinal)
+            || !string.Equals(GetStringValue(variant, "images"), variantModel.Images ?? string.Empty, StringComparison.Ordinal)
+            || variant.SortOrder != variantModel.SortOrder
+            || !CustomFieldsEqual(variant, variantModel.CustomFields, fieldDefinitions)
+            || !PriceValuesEqual(GetPriceValues(variant, stores), variantModel.PriceValues, stores);
+    }
+
+    private static bool DictionariesEqual(IDictionary<string, string> left, IDictionary<string, string> right)
+    {
+        return left.Count == right.Count
+            && left.All(x => right.TryGetValue(x.Key, out var value) && string.Equals(x.Value, value, StringComparison.Ordinal));
+    }
+
+    private static bool PriceValuesEqual(CurrencyPriceRoot left, CurrencyPriceRoot? right, IReadOnlyList<VariantManagerStore> stores)
+    {
+        return JsonConvert.SerializeObject(NormalizePriceValues(left, stores)) == JsonConvert.SerializeObject(NormalizePriceValues(right, stores));
+    }
+
+    private static async Task ApplyStockValuesAsync(Guid key, IReadOnlyList<StockRequest>? stockValues)
+    {
+        foreach (var stock in stockValues ?? Array.Empty<StockRequest>())
+        {
+            if (string.IsNullOrWhiteSpace(stock.StoreAlias))
+            {
+                await API.Stock.Instance.SetStockAsync(key, stock.Value ?? 0).ConfigureAwait(false);
+            }
+            else
+            {
+                await API.Stock.Instance.SetStockAsync(key, stock.StoreAlias, stock.Value ?? 0).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static void ApplyGroupValues(IContent group, VariantManagerGroup groupModel, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var groupTitleValues = NormalizeTitleValues(groupModel.TitleValues, groupModel.Title, group.Name ?? "Variant group");
+        var groupTitle = GetDisplayTitle(groupTitleValues, group.Name ?? "Variant group");
+        group.Name = groupTitle;
+        group.SetProperty("title", ToObjectDictionary(groupTitleValues));
+        group.SetValue("color", groupModel.Color ?? string.Empty);
+        group.SetValue("images", groupModel.Images ?? string.Empty);
+        ApplyCustomFields(group, groupModel.CustomFields, fieldDefinitions);
+    }
+
+    private void ApplyVariantValues(IContent variant, string title, string sku, string images, string price, string stock, IReadOnlyList<VariantManagerStore> stores)
+    {
+        ApplyVariantValues(variant, new VariantManagerVariant
+        {
+            Title = title,
+            Sku = sku,
+            Images = images,
+            PriceValues = ParsePriceValues(price),
+            StockValues = ParseStockValues(stock),
+        }, stores, Array.Empty<VariantManagerCustomFieldDefinition>());
+    }
+
+    private IReadOnlyList<VariantManagerCustomFieldDefinition> GetVariantGroupFieldDefinitions()
+        => GetCustomFieldDefinitions("ekmProductVariantGroup", _variantAppOptions.VariantGroups);
+
+    private IReadOnlyList<VariantManagerCustomFieldDefinition> GetVariantFieldDefinitions()
+        => GetCustomFieldDefinitions("ekmProductVariant", _variantAppOptions.Variants);
+
+    private IReadOnlyList<VariantManagerCustomFieldDefinition> GetCustomFieldDefinitions(string contentTypeAlias, IReadOnlyList<string> aliases)
+    {
+        if (aliases.Count == 0)
+        {
+            return Array.Empty<VariantManagerCustomFieldDefinition>();
+        }
+
+        var contentType = _contentTypeService.Get(contentTypeAlias);
+        if (contentType == null)
+        {
+            return Array.Empty<VariantManagerCustomFieldDefinition>();
+        }
+
+        var definitions = new List<VariantManagerCustomFieldDefinition>();
+        foreach (var alias in aliases.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var property = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+            if (property == null || !IsTextStringProperty(property))
+            {
+                continue;
+            }
+
+            definitions.Add(new VariantManagerCustomFieldDefinition
+            {
+                Alias = property.Alias,
+                Label = property.Name ?? property.Alias,
+                Required = property.Mandatory,
+            });
+        }
+
+        return definitions;
+    }
+
+    private static bool IsTextStringProperty(IPropertyType property)
+        => string.Equals(property.PropertyEditorAlias, "Umbraco.TextBox", StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<VariantManagerCustomField> GetCustomFields(IContent content, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+        => fieldDefinitions
+            .Select(field => new VariantManagerCustomField
+            {
+                Alias = field.Alias,
+                Label = field.Label,
+                Required = field.Required,
+                Value = content.GetValue<string>(field.Alias) ?? string.Empty,
+            })
+            .ToList();
+
+    private static void ApplyCustomFields(IContent content, IReadOnlyList<VariantManagerCustomField>? customFields, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var values = (customFields ?? Array.Empty<VariantManagerCustomField>())
+            .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.First().Value ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in fieldDefinitions)
+        {
+            values.TryGetValue(field.Alias, out var value);
+            value ??= string.Empty;
+
+            if (field.Required && string.IsNullOrWhiteSpace(value))
+            {
+                throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+            }
+
+            content.SetValue(field.Alias, value);
+        }
+    }
+
+    private static bool CustomFieldsEqual(IContent content, IReadOnlyList<VariantManagerCustomField>? customFields, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var values = (customFields ?? Array.Empty<VariantManagerCustomField>())
+            .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.First().Value ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+
+        return fieldDefinitions.All(field => values.TryGetValue(field.Alias, out var value)
+            && string.Equals(content.GetValue<string>(field.Alias) ?? string.Empty, value ?? string.Empty, StringComparison.Ordinal));
+    }
+
+    private IReadOnlyList<VariantManagerStore> LoadVariantStores(IContent product)
+    {
+        var enabledStores = GetEnabledStores(product).ToList();
+
+        return enabledStores
+            .Select(store => new VariantManagerStore
+            {
+                Alias = store.Alias,
+                Title = store.Title,
+                Currencies = store.Currencies.ToList(),
+            })
+            .ToList();
+    }
+
+    private IEnumerable<IStore> GetEnabledStores(IContent product)
+    {
+        var allStores = API.Store.Instance.GetAllStores().ToList();
+        var node = _nodeService.NodeById(product.Id, true);
+
+        if (node == null)
+        {
+            return allStores;
+        }
+
+        var ancestors = _nodeService.GetAllCatalogAncestors(node);
+        var stores = new List<IStore>();
+
+        foreach (var store in allStores)
+        {
+            var alias = store.Alias;
+
+            if (node.Properties.GetValue("disable", alias).IsBoolean())
+            {
+                continue;
+            }
+
+            if (ancestors.Any(ancestor => ancestor.Properties.GetValue("disable", alias).IsBoolean()))
+            {
+                continue;
+            }
+
+            stores.Add(store);
+        }
+
+        return stores;
+    }
+
+    private static IDictionary<string, string> GetTitleValues(IContent content, string alias, IReadOnlyList<UmbracoLanguage> languages)
+    {
+        var property = ParsePropertyValue(content.GetValue<string>(alias));
+        IDictionary<string, string> values;
+
+        if (property?.Values == null)
+        {
+            var value = content.GetValue<string>(alias) ?? string.Empty;
+            values = string.IsNullOrWhiteSpace(value)
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string> { [string.Empty] = value };
+        }
+        else
+        {
+            values = property.Values.ToDictionary(x => x.Key, x => x.Value?.ToString() ?? string.Empty);
+        }
+
+        var displayValue = GetDisplayTitle(values, string.Empty);
+        if (!string.IsNullOrWhiteSpace(displayValue))
+        {
+            foreach (var language in languages)
+            {
+                values.TryAdd(language.IsoCode, displayValue);
+            }
+        }
+
+        return values;
+    }
+
+    private static PropertyValue? ParsePropertyValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        try
+        {
+            var propertyValue = value.InvariantContains("values") ? value : "{\"values\":" + value + "}";
+            return JsonConvert.DeserializeObject<PropertyValue>(propertyValue);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string GetDisplayTitle(IDictionary<string, string> values, string fallback)
+    {
+        return values.Values.FirstOrDefault(x => !string.IsNullOrWhiteSpace(x)) ?? fallback;
+    }
+
+    private static Dictionary<string, object> CreateTitleValues(string title, IReadOnlyList<UmbracoLanguage> languages)
+    {
+        return languages.Count == 0
+            ? new Dictionary<string, object> { [string.Empty] = title }
+            : languages.ToDictionary(x => x.IsoCode, _ => (object)title);
+    }
+
+    private static IDictionary<string, string> NormalizeTitleValues(IDictionary<string, string>? values, string? title, string fallback)
+    {
+        if (values != null && values.Any(x => !string.IsNullOrWhiteSpace(x.Value)))
+        {
+            return values.ToDictionary(x => x.Key, x => x.Value ?? string.Empty);
+        }
+
+        return new Dictionary<string, string> { [string.Empty] = GetRequiredTitle(title, fallback) };
+    }
+
+    private static Dictionary<string, object> ToObjectDictionary(IDictionary<string, string> values)
+    {
+        return values.ToDictionary(x => x.Key, x => (object)x.Value);
+    }
+
+    private static CurrencyPriceRoot GetPriceValues(IContent content, IReadOnlyList<VariantManagerStore> stores)
+    {
+        var item = new Umbraco10Content(content, Guid.Empty);
+        var root = new CurrencyPriceRoot();
+
+        foreach (var store in stores)
+        {
+            var prices = new List<CurrencyPrice>();
+
+            foreach (var currency in store.Currencies)
+            {
+                if (string.IsNullOrWhiteSpace(currency.CurrencyValue))
+                {
+                    continue;
+                }
+
+                prices.Add(new CurrencyPrice(item.GetPrice(store.Alias, currency.CurrencyValue), currency.CurrencyValue));
+            }
+
+            if (prices.Count > 0)
+            {
+                root[store.Alias] = prices;
+            }
+        }
+
+        return root;
+    }
+
+    private static CurrencyPriceRoot ParsePriceValues(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return new CurrencyPriceRoot();
+        }
+
+        try
+        {
+            return JsonConvert.DeserializeObject<CurrencyPriceRoot>(value) ?? new CurrencyPriceRoot();
+        }
+        catch (JsonException)
+        {
+            return new CurrencyPriceRoot();
+        }
+    }
+
+    private static CurrencyPriceRoot NormalizePriceValues(CurrencyPriceRoot? values, IReadOnlyList<VariantManagerStore> stores)
+    {
+        if (values == null || values.Count == 0)
+        {
+            return new CurrencyPriceRoot();
+        }
+
+        var storeAliases = stores
+            .Select(x => x.Alias)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToList();
+        var normalized = new CurrencyPriceRoot();
+
+        foreach (var storeAlias in storeAliases)
+        {
+            var prices = new Dictionary<string, CurrencyPrice>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var pair in values.Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)))
+            {
+                foreach (var price in pair.Value.Where(x => !string.IsNullOrWhiteSpace(x.Currency)))
+                {
+                    prices[price.Currency] = new CurrencyPrice(price.Price ?? 0, price.Currency);
+                }
+            }
+
+            if (prices.Count > 0)
+            {
+                normalized[storeAlias] = prices.Values.ToList();
+            }
+        }
+
+        return normalized;
+    }
+
+    private static IReadOnlyList<StockRequest> GetStockValues(IContent content)
+    {
+        var stores = API.Store.Instance.GetAllStores().ToList();
+
+        if (Configuration.Instance.PerStoreStock && stores.Count > 1)
+        {
+            return stores
+                .Select(store => new StockRequest
+                {
+                    StoreAlias = store.Alias,
+                    Value = API.Stock.Instance.GetStock(content.Key, store.Alias),
+                })
+                .ToList();
+        }
+
+        return new[]
+        {
+            new StockRequest
+            {
+                StoreAlias = string.Empty,
+                Value = API.Stock.Instance.GetStock(content.Key),
+            },
+        };
+    }
+
+    private static IReadOnlyList<StockRequest> ParseStockValues(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Array.Empty<StockRequest>();
+        }
+
+        try
+        {
+            return JsonConvert.DeserializeObject<IReadOnlyList<StockRequest>>(value) ?? Array.Empty<StockRequest>();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<StockRequest>();
+        }
+    }
+
+    private void SaveContent(IContent content, bool publish)
+    {
+        if (publish)
+        {
+            _contentService.SaveAndPublish(content);
+            return;
+        }
+
+        _contentService.Save(content);
+    }
+
+    private static string GetStringValue(IContent content, string alias)
+    {
+        return content.GetValue<string>(alias) ?? string.Empty;
+    }
+
+    private static string GetRequiredTitle(string? title, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(title) ? fallback : title.Trim();
+    }
+
+    private IReadOnlyList<UmbracoLanguage> LoadLanguages()
+    {
+        return _localizationService.GetAllLanguages()
+            .OrderByDescending(x => x.IsDefault)
+            .ThenBy(x => x.CultureName)
+            .Select(x => new UmbracoLanguage()
+            {
+                Culture = x.CultureInfo ?? CultureInfo.InvariantCulture,
+                CultureName = x.CultureName ?? string.Empty,
+                IsoCode = x.IsoCode,
+            })
+            .ToList();
+    }
+
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Ekom.AspNetCore;
 using Ekom.Services;
 using Ekom.Tracking;
 using Ekom.Umb.Services;
+using Ekom.Umb.VariantApp.Services;
 using EkomCore.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -29,6 +30,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<NodeService>();
         services.AddTransient<IMetafieldService, MetafieldService>();
         services.AddTransient<IUmbracoService, UmbracoService>();
+        services.AddTransient<IVariantAppService, VariantAppService>();
         services.AddTransient<IUrlService, UrlService>();
         services.AddScoped<BackofficeUserAccessor>();
         services.AddScoped<ISecurityService, SecurityService>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
@@ -89,13 +89,26 @@ internal static class ImportContentExtensions
                 ? currencyPriceRoot
                 : JsonConvert.DeserializeObject<CurrencyPriceRoot>(fieldValue) ?? currencyPriceRoot;
 
-            if (!currencyPriceRoot.TryGetValue(storeAlias, out var storeItems))
+            var storeItems = currencyPriceRoot
+                .Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase))
+                .SelectMany(x => x.Value)
+                .GroupBy(x => x.Currency, StringComparer.OrdinalIgnoreCase)
+                .Select(x => x.Last())
+                .ToList();
+
+            foreach (var key in currencyPriceRoot.Keys.Where(x => x.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)).ToList())
             {
-                currencyPriceRoot.Add(storeAlias, new List<CurrencyPrice> { new(price, currency) });
+                currencyPriceRoot.Remove(key);
+            }
+
+            if (storeItems.Count == 0)
+            {
+                storeItems.Add(new CurrencyPrice(price, currency));
+                currencyPriceRoot.Add(storeAlias, storeItems);
             }
             else
             {
-                var priceObject = storeItems.FirstOrDefault(x => x.Currency == currency);
+                var priceObject = storeItems.FirstOrDefault(x => x.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase));
                 if (priceObject == null)
                 {
                     storeItems.Add(new CurrencyPrice(price, currency));
@@ -104,6 +117,8 @@ internal static class ImportContentExtensions
                 {
                     priceObject.Price = price;
                 }
+
+                currencyPriceRoot.Add(storeAlias, storeItems);
             }
 
             content.SetValue("price", JsonConvert.SerializeObject(currencyPriceRoot));

--- a/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Controllers/VariantAppController.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Controllers/VariantAppController.cs
@@ -1,0 +1,84 @@
+using Ekom.ActionFilters;
+using Ekom.Authorization;
+using Ekom.Umb.VariantApp.Models;
+using Ekom.Umb.VariantApp.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ekom.Umb.VariantApp.Controllers;
+
+[Route("ekom/backoffice/Variants")]
+[CamelCaseJson]
+public sealed class VariantAppController : ControllerBase
+{
+    private readonly IVariantAppService _variantAppService;
+
+    public VariantAppController(IVariantAppService variantAppService)
+    {
+        _variantAppService = variantAppService;
+    }
+
+    [HttpGet]
+    [Route("{productId}")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerProduct GetProductVariants([FromRoute] string productId)
+        => _variantAppService.GetProductVariants(productId);
+
+    [HttpGet]
+    [Route("{productId}/Count")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerCount GetVariantCount([FromRoute] string productId)
+        => _variantAppService.GetVariantCount(productId);
+
+    [HttpPost]
+    [Route("Groups")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerGroup CreateVariantGroup([FromBody] VariantManagerGroupRequest request)
+        => _variantAppService.CreateVariantGroup(request);
+
+    [HttpPost]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public Task<VariantManagerVariant> CreateVariant([FromBody] VariantManagerVariantRequest request)
+        => _variantAppService.CreateVariantAsync(request);
+
+    [HttpPost]
+    [Route("Save")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public Task<VariantManagerProduct> SaveProductVariants([FromBody] VariantManagerSaveRequest request)
+        => _variantAppService.SaveProductVariantsAsync(request);
+
+    [HttpPost]
+    [Route("Groups/Save")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public VariantManagerGroup SaveVariantGroup([FromBody] VariantManagerGroupSaveRequest request)
+        => _variantAppService.SaveVariantGroup(request);
+
+    [HttpPost]
+    [Route("Items/Save")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public Task<VariantManagerVariant> SaveVariant([FromBody] VariantManagerVariantSaveRequest request)
+        => _variantAppService.SaveVariantAsync(request);
+
+    [HttpGet]
+    [Route("Media/Thumbnail")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public IActionResult GetMediaThumbnail([FromQuery] string mediaId, [FromQuery] int width = 38, [FromQuery] int height = 38)
+    {
+        var url = _variantAppService.GetMediaThumbnailPath(mediaId, width, height);
+        return string.IsNullOrWhiteSpace(url) ? NotFound() : Redirect(url);
+    }
+
+    [HttpDelete]
+    [Route("{nodeId}")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public bool DeleteVariantNode([FromRoute] string nodeId)
+        => _variantAppService.DeleteVariantNode(nodeId);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Models/VariantAppModels.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Models/VariantAppModels.cs
@@ -1,0 +1,117 @@
+using Ekom.Models;
+using Ekom.Models.Umbraco;
+
+namespace Ekom.Umb.VariantApp.Models;
+
+public sealed class VariantManagerProduct
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Sku { get; set; } = string.Empty;
+    public int VariantCount { get; set; }
+    public IReadOnlyList<UmbracoLanguage> Languages { get; set; } = Array.Empty<UmbracoLanguage>();
+    public IReadOnlyList<VariantManagerStore> Stores { get; set; } = Array.Empty<VariantManagerStore>();
+    public IReadOnlyList<VariantManagerCustomFieldDefinition> VariantGroupFields { get; set; } = Array.Empty<VariantManagerCustomFieldDefinition>();
+    public IReadOnlyList<VariantManagerCustomFieldDefinition> VariantFields { get; set; } = Array.Empty<VariantManagerCustomFieldDefinition>();
+    public IReadOnlyList<VariantManagerGroup> Groups { get; set; } = Array.Empty<VariantManagerGroup>();
+}
+
+public sealed class VariantManagerCount
+{
+    public int Count { get; set; }
+}
+
+public sealed class VariantManagerStore
+{
+    public string Alias { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public IReadOnlyList<CurrencyModel> Currencies { get; set; } = Array.Empty<CurrencyModel>();
+}
+
+public class VariantManagerCustomFieldDefinition
+{
+    public string Alias { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public bool Required { get; set; }
+}
+
+public sealed class VariantManagerCustomField : VariantManagerCustomFieldDefinition
+{
+    public string Value { get; set; } = string.Empty;
+}
+
+public sealed class VariantManagerGroup
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public IDictionary<string, string> TitleValues { get; set; } = new Dictionary<string, string>();
+    public string Color { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+    public bool Changed { get; set; }
+    public bool Published { get; set; }
+    public IReadOnlyList<VariantManagerCustomField> CustomFields { get; set; } = Array.Empty<VariantManagerCustomField>();
+    public IReadOnlyList<VariantManagerVariant> Variants { get; set; } = Array.Empty<VariantManagerVariant>();
+}
+
+public sealed class VariantManagerVariant
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public IDictionary<string, string> TitleValues { get; set; } = new Dictionary<string, string>();
+    public string Sku { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public CurrencyPriceRoot PriceValues { get; set; } = new();
+    public IReadOnlyList<StockRequest> StockValues { get; set; } = Array.Empty<StockRequest>();
+    public IReadOnlyList<VariantManagerCustomField> CustomFields { get; set; } = Array.Empty<VariantManagerCustomField>();
+    public int SortOrder { get; set; }
+    public bool Changed { get; set; }
+    public bool Published { get; set; }
+}
+
+public sealed class VariantManagerGroupRequest
+{
+    public string ProductId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Color { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+}
+
+public sealed class VariantManagerVariantRequest
+{
+    public string GroupId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Sku { get; set; } = string.Empty;
+    public string Images { get; set; } = string.Empty;
+    public string Price { get; set; } = string.Empty;
+    public string Stock { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+}
+
+public sealed class VariantManagerSaveRequest
+{
+    public string ProductId { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+    public IReadOnlyList<VariantManagerGroup> Groups { get; set; } = Array.Empty<VariantManagerGroup>();
+}
+
+public sealed class VariantManagerGroupSaveRequest
+{
+    public string ProductId { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+    public VariantManagerGroup Group { get; set; } = new();
+}
+
+public sealed class VariantManagerVariantSaveRequest
+{
+    public string GroupId { get; set; } = string.Empty;
+    public bool Publish { get; set; }
+    public VariantManagerVariant Variant { get; set; } = new();
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/IVariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/IVariantAppService.cs
@@ -1,0 +1,16 @@
+using Ekom.Umb.VariantApp.Models;
+
+namespace Ekom.Umb.VariantApp.Services;
+
+public interface IVariantAppService
+{
+    VariantManagerProduct GetProductVariants(string productId);
+    VariantManagerCount GetVariantCount(string productId);
+    VariantManagerGroup CreateVariantGroup(VariantManagerGroupRequest request);
+    Task<VariantManagerVariant> CreateVariantAsync(VariantManagerVariantRequest request);
+    Task<VariantManagerProduct> SaveProductVariantsAsync(VariantManagerSaveRequest request);
+    VariantManagerGroup SaveVariantGroup(VariantManagerGroupSaveRequest request);
+    Task<VariantManagerVariant> SaveVariantAsync(VariantManagerVariantSaveRequest request);
+    string GetMediaThumbnailPath(string mediaId, int width, int height);
+    bool DeleteVariantNode(string nodeId);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/VariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/VariantAppService.cs
@@ -1,0 +1,794 @@
+using Ekom.Models;
+using Ekom.Models.Umbraco;
+using Ekom.Services;
+using Ekom.Umb.Models;
+using Ekom.Umb.VariantApp.Models;
+using Ekom.Utilities;
+using Newtonsoft.Json;
+using System.Globalization;
+using System.Net;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Ekom.Umb.VariantApp.Services;
+
+internal sealed class VariantAppService : IVariantAppService
+{
+    private readonly IContentService _contentService;
+    private readonly IContentTypeService _contentTypeService;
+    private readonly INodeService _nodeService;
+    private readonly ILocalizationService _localizationService;
+    private readonly VariantAppOptions _variantAppOptions;
+
+    public VariantAppService(
+        IContentService contentService,
+        IContentTypeService contentTypeService,
+        INodeService nodeService,
+        ILocalizationService localizationService,
+        IOptions<EkomOptions> options)
+    {
+        _contentService = contentService;
+        _contentTypeService = contentTypeService;
+        _nodeService = nodeService;
+        _localizationService = localizationService;
+        _variantAppOptions = options.Value.VariantApp;
+    }
+
+    public VariantManagerProduct GetProductVariants(string productId)
+    {
+        var product = GetContent(productId, "ekmProduct");
+        return MapProduct(product);
+    }
+
+    public VariantManagerCount GetVariantCount(string productId)
+    {
+        var product = GetContent(productId, "ekmProduct");
+        return new VariantManagerCount
+        {
+            Count = CountVariants(product),
+        };
+    }
+
+    public VariantManagerGroup CreateVariantGroup(VariantManagerGroupRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var product = GetContent(request.ProductId, "ekmProduct");
+        var title = GetRequiredTitle(request.Title, "Variant group");
+        var group = _contentService.Create(title, product.Id, "ekmProductVariantGroup");
+
+        group.SetProperty("title", CreateTitleValues(title, LoadLanguages()));
+        group.SetValue("color", request.Color ?? string.Empty);
+        group.SetValue("images", request.Images ?? string.Empty);
+        SaveContent(group, request.Publish);
+
+        return MapGroup(group, LoadVariantStores(product));
+    }
+
+    public async Task<VariantManagerVariant> CreateVariantAsync(VariantManagerVariantRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var group = GetContent(request.GroupId, "ekmProductVariantGroup");
+        var title = GetRequiredTitle(request.Title, "Variant");
+        var variant = _contentService.Create(title, group.Id, "ekmProductVariant");
+
+        var product = GetContent(group.ParentId.ToString(CultureInfo.InvariantCulture), "ekmProduct");
+        var stores = LoadVariantStores(product);
+
+        ApplyVariantValues(variant, request.Title, request.Sku, request.Images, request.Price, request.Stock, stores);
+        SaveContent(variant, request.Publish);
+        await ApplyStockValuesAsync(variant.Key, ParseStockValues(request.Stock)).ConfigureAwait(false);
+
+        return MapVariant(variant, stores);
+    }
+
+    public async Task<VariantManagerProduct> SaveProductVariantsAsync(VariantManagerSaveRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var product = GetContent(request.ProductId, "ekmProduct");
+        var stores = LoadVariantStores(product);
+
+        foreach (var groupModel in request.Groups)
+        {
+            var group = GetOrCreateVariantGroup(product, groupModel);
+
+            if (group.ParentId != product.Id)
+            {
+                continue;
+            }
+
+                var groupFieldDefinitions = GetVariantGroupFieldDefinitions();
+                if (groupModel.Changed || groupModel.Id <= 0)
+                {
+                    ApplyGroupValues(group, groupModel, groupFieldDefinitions);
+                    group.SortOrder = groupModel.SortOrder;
+                    SaveContent(group, request.Publish);
+                }
+
+                var variantFieldDefinitions = GetVariantFieldDefinitions();
+                foreach (var variantModel in groupModel.Variants)
+                {
+                var isNewVariant = variantModel.Id <= 0;
+                var variant = GetOrCreateVariant(group, variantModel);
+
+                if (variant.ParentId != group.Id)
+                {
+                    continue;
+                }
+
+                if (isNewVariant || HasVariantContentChanges(variant, variantModel, stores, variantFieldDefinitions))
+                {
+                    ApplyVariantValues(variant, variantModel, stores, variantFieldDefinitions);
+                    variant.SortOrder = variantModel.SortOrder;
+                    SaveContent(variant, request.Publish);
+                }
+
+                await ApplyStockValuesAsync(variant.Key, variantModel.StockValues).ConfigureAwait(false);
+            }
+        }
+
+        return MapProduct(product);
+    }
+
+    public VariantManagerGroup SaveVariantGroup(VariantManagerGroupSaveRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var product = GetContent(request.ProductId, "ekmProduct");
+        var group = GetOrCreateVariantGroup(product, request.Group);
+
+        if (group.ParentId != product.Id)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        ApplyGroupValues(group, request.Group, GetVariantGroupFieldDefinitions());
+        SaveContent(group, request.Publish);
+
+        return MapGroup(group, LoadVariantStores(product));
+    }
+
+    public async Task<VariantManagerVariant> SaveVariantAsync(VariantManagerVariantSaveRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var group = GetContent(request.GroupId, "ekmProductVariantGroup");
+        var variant = GetOrCreateVariant(group, request.Variant);
+        var product = GetContent(group.ParentId.ToString(CultureInfo.InvariantCulture), "ekmProduct");
+        var stores = LoadVariantStores(product);
+
+        if (variant.ParentId != group.Id)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        var variantFieldDefinitions = GetVariantFieldDefinitions();
+        if (request.Variant.Id <= 0 || HasVariantContentChanges(variant, request.Variant, stores, variantFieldDefinitions))
+        {
+            ApplyVariantValues(variant, request.Variant, stores, variantFieldDefinitions);
+            SaveContent(variant, request.Publish);
+        }
+
+        await ApplyStockValuesAsync(variant.Key, request.Variant.StockValues).ConfigureAwait(false);
+
+        return MapVariant(variant, stores);
+    }
+
+    public bool DeleteVariantNode(string nodeId)
+    {
+        var content = GetContent(nodeId, null);
+
+        if (content.ContentType.Alias is not ("ekmProductVariant" or "ekmProductVariantGroup"))
+        {
+            return false;
+        }
+
+        _contentService.MoveToRecycleBin(content);
+        return true;
+    }
+
+    public string GetMediaThumbnailPath(string mediaId, int width, int height)
+    {
+        var media = _nodeService.MediaById(mediaId);
+
+        if (media == null || string.IsNullOrWhiteSpace(media.Url) || media.Url == "#")
+        {
+            return string.Empty;
+        }
+
+        return AppendImageSize(media.Url, width, height);
+    }
+
+    private IContent GetContent(string id, string? expectedAlias)
+    {
+        IContent? content = null;
+
+        if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
+        {
+            content = _contentService.GetById(intId);
+        }
+        else if (Guid.TryParse(id, out var key))
+        {
+            content = _contentService.GetById(key);
+        }
+
+        if (content == null)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.NotFound);
+        }
+
+        if (!string.IsNullOrWhiteSpace(expectedAlias) && !content.ContentType.Alias.Equals(expectedAlias, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        return content;
+    }
+
+    private static string AppendImageSize(string url, int width, int height)
+    {
+        var separator = url.Contains('?', StringComparison.Ordinal) ? '&' : '?';
+        return string.Concat(url, separator, "width=", Math.Max(width, 1).ToString(CultureInfo.InvariantCulture), "&height=", Math.Max(height, 1).ToString(CultureInfo.InvariantCulture));
+    }
+
+    private VariantManagerProduct MapProduct(IContent product)
+    {
+        var stores = LoadVariantStores(product);
+        var groupFieldDefinitions = GetVariantGroupFieldDefinitions();
+        var variantFieldDefinitions = GetVariantFieldDefinitions();
+        var groups = GetChildren(product.Id, "ekmProductVariantGroup")
+            .Select(group => MapGroup(group, stores, groupFieldDefinitions, variantFieldDefinitions))
+            .ToList();
+
+        return new VariantManagerProduct
+        {
+            Id = product.Id,
+            Key = product.Key,
+            Name = product.Name ?? string.Empty,
+            Title = GetDisplayTitle(GetTitleValues(product, "title", LoadLanguages()), product.Name ?? string.Empty),
+            Sku = GetStringValue(product, "sku"),
+            VariantCount = groups.Sum(x => x.Variants.Count),
+            Languages = LoadLanguages(),
+            Stores = stores,
+            VariantGroupFields = groupFieldDefinitions,
+            VariantFields = variantFieldDefinitions,
+            Groups = groups,
+        };
+    }
+
+    private VariantManagerGroup MapGroup(IContent group, IReadOnlyList<VariantManagerStore> stores)
+        => MapGroup(group, stores, GetVariantGroupFieldDefinitions(), GetVariantFieldDefinitions());
+
+    private VariantManagerGroup MapGroup(
+        IContent group,
+        IReadOnlyList<VariantManagerStore> stores,
+        IReadOnlyList<VariantManagerCustomFieldDefinition> groupFieldDefinitions,
+        IReadOnlyList<VariantManagerCustomFieldDefinition> variantFieldDefinitions)
+    {
+        return new VariantManagerGroup
+        {
+            Id = group.Id,
+            Key = group.Key,
+            Name = group.Name ?? string.Empty,
+            Title = GetDisplayTitle(GetTitleValues(group, "title", LoadLanguages()), group.Name ?? string.Empty),
+            TitleValues = GetTitleValues(group, "title", LoadLanguages()),
+            Color = GetStringValue(group, "color"),
+            Images = GetStringValue(group, "images"),
+            SortOrder = group.SortOrder,
+            Published = group.Published,
+            CustomFields = GetCustomFields(group, groupFieldDefinitions),
+            Variants = GetChildren(group.Id, "ekmProductVariant").Select(variant => MapVariant(variant, stores, variantFieldDefinitions)).ToList(),
+        };
+    }
+
+    private VariantManagerVariant MapVariant(IContent variant, IReadOnlyList<VariantManagerStore> stores)
+        => MapVariant(variant, stores, GetVariantFieldDefinitions());
+
+    private VariantManagerVariant MapVariant(IContent variant, IReadOnlyList<VariantManagerStore> stores, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        return new VariantManagerVariant
+        {
+            Id = variant.Id,
+            Key = variant.Key,
+            Name = variant.Name ?? string.Empty,
+            Title = GetDisplayTitle(GetTitleValues(variant, "title", LoadLanguages()), variant.Name ?? string.Empty),
+            TitleValues = GetTitleValues(variant, "title", LoadLanguages()),
+            Sku = GetStringValue(variant, "sku"),
+            Images = GetStringValue(variant, "images"),
+            PriceValues = GetPriceValues(variant, stores),
+            StockValues = GetStockValues(variant),
+            CustomFields = GetCustomFields(variant, fieldDefinitions),
+            SortOrder = variant.SortOrder,
+            Published = variant.Published,
+        };
+    }
+
+    private IReadOnlyList<IContent> GetChildren(int parentId, string contentTypeAlias)
+    {
+        return _contentService.GetPagedChildren(parentId, 0, int.MaxValue, out _)
+            .Where(x => !x.Trashed && x.ContentType.Alias.Equals(contentTypeAlias, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.Name)
+            .ToList();
+    }
+
+    private int CountVariants(IContent product)
+    {
+        return GetChildren(product.Id, "ekmProductVariantGroup")
+            .Sum(group => GetChildren(group.Id, "ekmProductVariant").Count);
+    }
+
+    private IContent GetOrCreateVariantGroup(IContent product, VariantManagerGroup groupModel)
+    {
+        if (groupModel.Id > 0)
+        {
+            return GetContent(groupModel.Id.ToString(CultureInfo.InvariantCulture), "ekmProductVariantGroup");
+        }
+
+        var title = GetDisplayTitle(NormalizeTitleValues(groupModel.TitleValues, groupModel.Title, "Variant group"), "Variant group");
+        return _contentService.Create(title, product.Id, "ekmProductVariantGroup");
+    }
+
+    private IContent GetOrCreateVariant(IContent group, VariantManagerVariant variantModel)
+    {
+        if (variantModel.Id > 0)
+        {
+            return GetContent(variantModel.Id.ToString(CultureInfo.InvariantCulture), "ekmProductVariant");
+        }
+
+        var title = GetDisplayTitle(NormalizeTitleValues(variantModel.TitleValues, variantModel.Title, "Variant"), "Variant");
+        return _contentService.Create(title, group.Id, "ekmProductVariant");
+    }
+
+    private static void ApplyVariantValues(IContent variant, VariantManagerVariant variantModel, IReadOnlyList<VariantManagerStore> stores, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var variantTitleValues = NormalizeTitleValues(variantModel.TitleValues, variantModel.Title, variant.Name ?? "Variant");
+        var variantTitle = GetDisplayTitle(variantTitleValues, variant.Name ?? "Variant");
+        variant.Name = variantTitle;
+        variant.SetProperty("title", ToObjectDictionary(variantTitleValues));
+        variant.SetValue("sku", variantModel.Sku ?? string.Empty);
+        variant.SetValue("images", variantModel.Images ?? string.Empty);
+        ApplyCustomFields(variant, variantModel.CustomFields, fieldDefinitions);
+        ApplyPriceValues(variant, variantModel.PriceValues, stores);
+    }
+
+    private static void ApplyPriceValues(IContent variant, CurrencyPriceRoot? priceValues, IReadOnlyList<VariantManagerStore> stores)
+    {
+        variant.SetValue("price", JsonConvert.SerializeObject(NormalizePriceValues(GetPriceValues(variant, stores), stores)));
+
+        foreach (var priceValue in NormalizePriceValues(priceValues, stores))
+        {
+            foreach (var price in priceValue.Value)
+            {
+                variant.SetPrice(priceValue.Key, price.Currency, price.Price ?? 0);
+            }
+        }
+    }
+
+    private bool HasVariantContentChanges(IContent variant, VariantManagerVariant variantModel, IReadOnlyList<VariantManagerStore> stores, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var titleValues = NormalizeTitleValues(variantModel.TitleValues, variantModel.Title, variant.Name ?? "Variant");
+
+        return !DictionariesEqual(GetTitleValues(variant, "title", LoadLanguages()), titleValues)
+            || !string.Equals(GetStringValue(variant, "sku"), variantModel.Sku ?? string.Empty, StringComparison.Ordinal)
+            || !string.Equals(GetStringValue(variant, "images"), variantModel.Images ?? string.Empty, StringComparison.Ordinal)
+            || variant.SortOrder != variantModel.SortOrder
+            || !CustomFieldsEqual(variant, variantModel.CustomFields, fieldDefinitions)
+            || !PriceValuesEqual(GetPriceValues(variant, stores), variantModel.PriceValues, stores);
+    }
+
+    private static bool DictionariesEqual(IDictionary<string, string> left, IDictionary<string, string> right)
+    {
+        return left.Count == right.Count
+            && left.All(x => right.TryGetValue(x.Key, out var value) && string.Equals(x.Value, value, StringComparison.Ordinal));
+    }
+
+    private static bool PriceValuesEqual(CurrencyPriceRoot left, CurrencyPriceRoot? right, IReadOnlyList<VariantManagerStore> stores)
+    {
+        return JsonConvert.SerializeObject(NormalizePriceValues(left, stores)) == JsonConvert.SerializeObject(NormalizePriceValues(right, stores));
+    }
+
+    private static async Task ApplyStockValuesAsync(Guid key, IReadOnlyList<StockRequest>? stockValues)
+    {
+        foreach (var stock in stockValues ?? Array.Empty<StockRequest>())
+        {
+            if (string.IsNullOrWhiteSpace(stock.StoreAlias))
+            {
+                await API.Stock.Instance.SetStockAsync(key, stock.Value ?? 0).ConfigureAwait(false);
+            }
+            else
+            {
+                await API.Stock.Instance.SetStockAsync(key, stock.StoreAlias, stock.Value ?? 0).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static void ApplyGroupValues(IContent group, VariantManagerGroup groupModel, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var groupTitleValues = NormalizeTitleValues(groupModel.TitleValues, groupModel.Title, group.Name ?? "Variant group");
+        var groupTitle = GetDisplayTitle(groupTitleValues, group.Name ?? "Variant group");
+        group.Name = groupTitle;
+        group.SetProperty("title", ToObjectDictionary(groupTitleValues));
+        group.SetValue("color", groupModel.Color ?? string.Empty);
+        group.SetValue("images", groupModel.Images ?? string.Empty);
+        ApplyCustomFields(group, groupModel.CustomFields, fieldDefinitions);
+    }
+
+    private void ApplyVariantValues(IContent variant, string title, string sku, string images, string price, string stock, IReadOnlyList<VariantManagerStore> stores)
+    {
+        ApplyVariantValues(variant, new VariantManagerVariant
+        {
+            Title = title,
+            Sku = sku,
+            Images = images,
+            PriceValues = ParsePriceValues(price),
+            StockValues = ParseStockValues(stock),
+        }, stores, Array.Empty<VariantManagerCustomFieldDefinition>());
+    }
+
+    private IReadOnlyList<VariantManagerCustomFieldDefinition> GetVariantGroupFieldDefinitions()
+        => GetCustomFieldDefinitions("ekmProductVariantGroup", _variantAppOptions.VariantGroups);
+
+    private IReadOnlyList<VariantManagerCustomFieldDefinition> GetVariantFieldDefinitions()
+        => GetCustomFieldDefinitions("ekmProductVariant", _variantAppOptions.Variants);
+
+    private IReadOnlyList<VariantManagerCustomFieldDefinition> GetCustomFieldDefinitions(string contentTypeAlias, IReadOnlyList<string> aliases)
+    {
+        if (aliases.Count == 0)
+        {
+            return Array.Empty<VariantManagerCustomFieldDefinition>();
+        }
+
+        var contentType = _contentTypeService.Get(contentTypeAlias);
+        if (contentType == null)
+        {
+            return Array.Empty<VariantManagerCustomFieldDefinition>();
+        }
+
+        var definitions = new List<VariantManagerCustomFieldDefinition>();
+        foreach (var alias in aliases.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var property = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+            if (property == null || !IsTextStringProperty(property))
+            {
+                continue;
+            }
+
+            definitions.Add(new VariantManagerCustomFieldDefinition
+            {
+                Alias = property.Alias,
+                Label = property.Name ?? property.Alias,
+                Required = property.Mandatory,
+            });
+        }
+
+        return definitions;
+    }
+
+    private static bool IsTextStringProperty(IPropertyType property)
+        => string.Equals(property.PropertyEditorAlias, "Umbraco.TextBox", StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<VariantManagerCustomField> GetCustomFields(IContent content, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+        => fieldDefinitions
+            .Select(field => new VariantManagerCustomField
+            {
+                Alias = field.Alias,
+                Label = field.Label,
+                Required = field.Required,
+                Value = content.GetValue<string>(field.Alias) ?? string.Empty,
+            })
+            .ToList();
+
+    private static void ApplyCustomFields(IContent content, IReadOnlyList<VariantManagerCustomField>? customFields, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var values = (customFields ?? Array.Empty<VariantManagerCustomField>())
+            .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.First().Value ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in fieldDefinitions)
+        {
+            values.TryGetValue(field.Alias, out var value);
+            value ??= string.Empty;
+
+            if (field.Required && string.IsNullOrWhiteSpace(value))
+            {
+                throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+            }
+
+            content.SetValue(field.Alias, value);
+        }
+    }
+
+    private static bool CustomFieldsEqual(IContent content, IReadOnlyList<VariantManagerCustomField>? customFields, IReadOnlyList<VariantManagerCustomFieldDefinition> fieldDefinitions)
+    {
+        var values = (customFields ?? Array.Empty<VariantManagerCustomField>())
+            .GroupBy(x => x.Alias, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(x => x.Key, x => x.First().Value ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+
+        return fieldDefinitions.All(field => values.TryGetValue(field.Alias, out var value)
+            && string.Equals(content.GetValue<string>(field.Alias) ?? string.Empty, value ?? string.Empty, StringComparison.Ordinal));
+    }
+
+    private IReadOnlyList<VariantManagerStore> LoadVariantStores(IContent product)
+    {
+        var enabledStores = GetEnabledStores(product).ToList();
+
+        return enabledStores
+            .Select(store => new VariantManagerStore
+            {
+                Alias = store.Alias,
+                Title = store.Title,
+                Currencies = store.Currencies.ToList(),
+            })
+            .ToList();
+    }
+
+    private IEnumerable<IStore> GetEnabledStores(IContent product)
+    {
+        var allStores = API.Store.Instance.GetAllStores().ToList();
+        var node = _nodeService.NodeById(product.Id, true);
+
+        if (node == null)
+        {
+            return allStores;
+        }
+
+        var ancestors = _nodeService.GetAllCatalogAncestors(node);
+        var stores = new List<IStore>();
+
+        foreach (var store in allStores)
+        {
+            var alias = store.Alias;
+
+            if (node.Properties.GetValue("disable", alias).IsBoolean())
+            {
+                continue;
+            }
+
+            if (ancestors.Any(ancestor => ancestor.Properties.GetValue("disable", alias).IsBoolean()))
+            {
+                continue;
+            }
+
+            stores.Add(store);
+        }
+
+        return stores;
+    }
+
+    private static IDictionary<string, string> GetTitleValues(IContent content, string alias, IReadOnlyList<UmbracoLanguage> languages)
+    {
+        var property = ParsePropertyValue(content.GetValue<string>(alias));
+        IDictionary<string, string> values;
+
+        if (property?.Values == null)
+        {
+            var value = content.GetValue<string>(alias) ?? string.Empty;
+            values = string.IsNullOrWhiteSpace(value)
+                ? new Dictionary<string, string>()
+                : new Dictionary<string, string> { [string.Empty] = value };
+        }
+        else
+        {
+            values = property.Values.ToDictionary(x => x.Key, x => x.Value?.ToString() ?? string.Empty);
+        }
+
+        var displayValue = GetDisplayTitle(values, string.Empty);
+        if (!string.IsNullOrWhiteSpace(displayValue))
+        {
+            foreach (var language in languages)
+            {
+                values.TryAdd(language.IsoCode, displayValue);
+            }
+        }
+
+        return values;
+    }
+
+    private static PropertyValue? ParsePropertyValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        try
+        {
+            var propertyValue = value.InvariantContains("values") ? value : "{\"values\":" + value + "}";
+            return JsonConvert.DeserializeObject<PropertyValue>(propertyValue);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string GetDisplayTitle(IDictionary<string, string> values, string fallback)
+    {
+        return values.Values.FirstOrDefault(x => !string.IsNullOrWhiteSpace(x)) ?? fallback;
+    }
+
+    private static Dictionary<string, object> CreateTitleValues(string title, IReadOnlyList<UmbracoLanguage> languages)
+    {
+        return languages.Count == 0
+            ? new Dictionary<string, object> { [string.Empty] = title }
+            : languages.ToDictionary(x => x.IsoCode, _ => (object)title);
+    }
+
+    private static IDictionary<string, string> NormalizeTitleValues(IDictionary<string, string>? values, string? title, string fallback)
+    {
+        if (values != null && values.Any(x => !string.IsNullOrWhiteSpace(x.Value)))
+        {
+            return values.ToDictionary(x => x.Key, x => x.Value ?? string.Empty);
+        }
+
+        return new Dictionary<string, string> { [string.Empty] = GetRequiredTitle(title, fallback) };
+    }
+
+    private static Dictionary<string, object> ToObjectDictionary(IDictionary<string, string> values)
+    {
+        return values.ToDictionary(x => x.Key, x => (object)x.Value);
+    }
+
+    private static CurrencyPriceRoot GetPriceValues(IContent content, IReadOnlyList<VariantManagerStore> stores)
+    {
+        var item = new Umbraco17Content(content, Guid.Empty);
+        var root = new CurrencyPriceRoot();
+
+        foreach (var store in stores)
+        {
+            var prices = new List<CurrencyPrice>();
+
+            foreach (var currency in store.Currencies)
+            {
+                if (string.IsNullOrWhiteSpace(currency.CurrencyValue))
+                {
+                    continue;
+                }
+
+                prices.Add(new CurrencyPrice(item.GetPrice(store.Alias, currency.CurrencyValue), currency.CurrencyValue));
+            }
+
+            if (prices.Count > 0)
+            {
+                root[store.Alias] = prices;
+            }
+        }
+
+        return root;
+    }
+
+    private static CurrencyPriceRoot ParsePriceValues(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return new CurrencyPriceRoot();
+        }
+
+        try
+        {
+            return JsonConvert.DeserializeObject<CurrencyPriceRoot>(value) ?? new CurrencyPriceRoot();
+        }
+        catch (JsonException)
+        {
+            return new CurrencyPriceRoot();
+        }
+    }
+
+    private static CurrencyPriceRoot NormalizePriceValues(CurrencyPriceRoot? values, IReadOnlyList<VariantManagerStore> stores)
+    {
+        if (values == null || values.Count == 0)
+        {
+            return new CurrencyPriceRoot();
+        }
+
+        var storeAliases = stores
+            .Select(x => x.Alias)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToList();
+        var normalized = new CurrencyPriceRoot();
+
+        foreach (var storeAlias in storeAliases)
+        {
+            var prices = new Dictionary<string, CurrencyPrice>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var pair in values.Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)))
+            {
+                foreach (var price in pair.Value.Where(x => !string.IsNullOrWhiteSpace(x.Currency)))
+                {
+                    prices[price.Currency] = new CurrencyPrice(price.Price ?? 0, price.Currency);
+                }
+            }
+
+            if (prices.Count > 0)
+            {
+                normalized[storeAlias] = prices.Values.ToList();
+            }
+        }
+
+        return normalized;
+    }
+
+    private static IReadOnlyList<StockRequest> GetStockValues(IContent content)
+    {
+        var stores = API.Store.Instance.GetAllStores().ToList();
+
+        if (Configuration.Instance.PerStoreStock && stores.Count > 1)
+        {
+            return stores
+                .Select(store => new StockRequest
+                {
+                    StoreAlias = store.Alias,
+                    Value = API.Stock.Instance.GetStock(content.Key, store.Alias),
+                })
+                .ToList();
+        }
+
+        return new[]
+        {
+            new StockRequest
+            {
+                StoreAlias = string.Empty,
+                Value = API.Stock.Instance.GetStock(content.Key),
+            },
+        };
+    }
+
+    private static IReadOnlyList<StockRequest> ParseStockValues(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Array.Empty<StockRequest>();
+        }
+
+        try
+        {
+            return JsonConvert.DeserializeObject<IReadOnlyList<StockRequest>>(value) ?? Array.Empty<StockRequest>();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<StockRequest>();
+        }
+    }
+
+    private void SaveContent(IContent content, bool publish)
+    {
+        if (publish)
+        {
+            _contentService.Save(content);
+            _contentService.Publish(content, ["*"]);
+            return;
+        }
+
+        _contentService.Save(content);
+    }
+
+    private static string GetStringValue(IContent content, string alias)
+    {
+        return content.GetValue<string>(alias) ?? string.Empty;
+    }
+
+    private static string GetRequiredTitle(string? title, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(title) ? fallback : title.Trim();
+    }
+
+    private IReadOnlyList<UmbracoLanguage> LoadLanguages()
+    {
+        return _localizationService.GetAllLanguages()
+            .OrderByDescending(x => x.IsDefault)
+            .ThenBy(x => x.CultureName)
+            .Select(x => new UmbracoLanguage
+            {
+                Culture = x.CultureInfo ?? CultureInfo.InvariantCulture,
+                CultureName = x.CultureName ?? string.Empty,
+                IsoCode = x.IsoCode,
+            })
+            .ToList();
+    }
+
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/country-picker.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/country-picker.element.js
@@ -69,7 +69,7 @@ class d extends HTMLElement {
       const o = document.createElement("option");
       o.value = a, o.textContent = this.getCountryLabel(n, a), e.append(o);
     }
-    this.select.replaceChildren(e), this.internalValue.length === 0 && this.select.options.length > 0 && (this.internalValue = ((t = this.select.options[0]) == null ? void 0 : t.value) ?? "", this.emitChange()), this.syncValue();
+    this.select.replaceChildren(e), this.internalValue.length === 0 && this.select.options.length > 0 && (this.internalValue = ((t = this.select.options[0]) == null ? void 0 : t.value) ?? ""), this.syncValue();
   }
   setCountryValue() {
     this.readonly || this.select == null || (this.internalValue = this.select.value, this.emitChange());

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
@@ -54,6 +54,44 @@ const e = [
     ]
   },
   {
+    type: "workspaceView",
+    alias: "Ekom.WorkspaceView.Product.Variants",
+    name: "Ekom Product Variants Workspace View",
+    element: "/App_Plugins/Ekom/dist/variants-workspace-view.element.js",
+    weight: 90,
+    meta: {
+      label: "Variants",
+      pathname: "variants",
+      icon: "icon-layers-alt"
+    },
+    conditions: [
+      {
+        alias: "Umb.Condition.WorkspaceAlias",
+        match: "Umb.Workspace.Document"
+      },
+      {
+        alias: "Umb.Condition.WorkspaceContentTypeAlias",
+        match: "ekmProduct"
+      }
+    ]
+  },
+  {
+    type: "workspaceFooterApp",
+    alias: "Ekom.WorkspaceFooterApp.Product.VariantCount",
+    name: "Ekom Product Variant Count Workspace Footer App",
+    element: "/App_Plugins/Ekom/dist/variant-count-workspace-footer-app.element.js",
+    conditions: [
+      {
+        alias: "Umb.Condition.WorkspaceAlias",
+        match: "Umb.Workspace.Document"
+      },
+      {
+        alias: "Umb.Condition.WorkspaceContentTypeAlias",
+        match: "ekmProduct"
+      }
+    ]
+  },
+  {
     type: "propertyEditorSchema",
     alias: "Ekom.Cache",
     name: "Ekom Cache Editor",

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/metafield-picker.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/metafield-picker.element.js
@@ -39,7 +39,7 @@ class m extends HTMLElement {
         this.fetchJson("/ekom/backoffice/Languages"),
         this.fetchJson("/ekom/backoffice/Metafields")
       ]);
-      this.languages = e, this.fields = t, this.ensureFieldValues(), this.renderFields(), this.setStatus(""), this.emitChange();
+      this.languages = e, this.fields = t, this.ensureFieldValues(), this.renderFields(), this.setStatus("");
     } catch (e) {
       const t = e instanceof Error ? e.message : "Could not load metafields.";
       this.setStatus(t, !0);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/price-editor.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/price-editor.element.js
@@ -40,7 +40,7 @@ class y extends HTMLElement {
         this.fetchJson("/ekom/backoffice/Config"),
         this.fetchJson(`/ekom/backoffice/Stores/${this.getNodeId()}`)
       ]);
-      this.showStoreFieldsets = e.perStoreStock !== !1, this.stores = t, this.internalValue = this.ensurePriceStructure(this.normalizeValue(this.rawValue)), this.renderPrices(), this.setStatus(""), this.emitChange();
+      this.showStoreFieldsets = e.perStoreStock !== !1, this.stores = t, this.internalValue = this.ensurePriceStructure(this.normalizeValue(this.rawValue)), this.renderPrices(), this.setStatus("");
     } catch (e) {
       const t = e instanceof Error ? e.message : "Could not load prices.";
       this.setStatus(t, !0);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/range-editor.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/range-editor.element.js
@@ -35,7 +35,7 @@ class g extends HTMLElement {
   async loadStores() {
     this.setStatus("Loading ranges...");
     try {
-      this.stores = await this.fetchJson(`/ekom/backoffice/Stores/${this.getNodeId()}`), this.internalValue = this.ensureRangeStructure(this.normalizeValue(this.rawValue)), this.renderRanges(), this.setStatus(""), this.emitChange();
+      this.stores = await this.fetchJson(`/ekom/backoffice/Stores/${this.getNodeId()}`), this.internalValue = this.ensureRangeStructure(this.normalizeValue(this.rawValue)), this.renderRanges(), this.setStatus("");
     } catch (e) {
       const t = e instanceof Error ? e.message : "Could not load ranges.";
       this.setStatus(t, !0);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/stock-editor.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/stock-editor.element.js
@@ -34,7 +34,7 @@ class h extends HTMLElement {
     this.setStatus("Loading stock...");
     try {
       const t = await this.fetchJson("/ekom/backoffice/Config"), e = this.getContentKey();
-      this.stocks = t.perStoreStock ? await this.loadPerStoreStock(e) : [await this.loadStockItem(e, "")], this.renderStock(), this.setStatus(""), this.emitChange();
+      this.stocks = t.perStoreStock ? await this.loadPerStoreStock(e) : [await this.loadStockItem(e, "")], this.renderStock(), this.setStatus("");
     } catch (t) {
       const e = t instanceof Error ? t.message : "Could not load stock.";
       this.setStatus(e, !0);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variant-count-workspace-footer-app.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variant-count-workspace-footer-app.element.js
@@ -1,0 +1,104 @@
+var h = Object.defineProperty;
+var p = (s, n, t) => n in s ? h(s, n, { enumerable: !0, configurable: !0, writable: !0, value: t }) : s[n] = t;
+var i = (s, n, t) => p(s, typeof n != "symbol" ? n + "" : n, t);
+import { UmbElementMixin as m } from "@umbraco-cms/backoffice/element-api";
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT as f } from "@umbraco-cms/backoffice/document";
+import { UMB_WORKSPACE_EDITOR_CONTEXT as k } from "@umbraco-cms/backoffice/workspace";
+const c = "ekom-variant-count", d = "Ekom.WorkspaceView.Product.Variants";
+class w extends m(HTMLElement) {
+  constructor() {
+    super(...arguments);
+    i(this, "documentWorkspaceContext");
+    i(this, "workspaceEditorContext");
+    i(this, "productId", "");
+    i(this, "requestId", 0);
+  }
+  connectedCallback() {
+    super.connectedCallback(), this.style.display = "none", this.consumeContext(k, (t) => {
+      this.workspaceEditorContext = t, this.updateBadge();
+    }), this.consumeContext(f, (t) => {
+      if (t == null)
+        return;
+      this.documentWorkspaceContext = t;
+      const e = t.getUnique();
+      e != null && (this.productId = e), this.observe(t.unique, (o) => {
+        o == null || o === this.productId || (this.productId = o, this.updateBadge());
+      }, "ekomVariantCountProductId"), this.updateBadge();
+    });
+  }
+  disconnectedCallback() {
+    this.requestId++, this.setBadge(0), super.disconnectedCallback();
+  }
+  async updateBadge() {
+    var o;
+    const t = this.productId || ((o = this.documentWorkspaceContext) == null ? void 0 : o.getUnique()) || "", e = ++this.requestId;
+    if (!t) {
+      await this.setBadge(0).catch(() => {
+      });
+      return;
+    }
+    try {
+      const a = await this.fetchJson(`/ekom/backoffice/Variants/${encodeURIComponent(t)}/Count`);
+      if (e !== this.requestId)
+        return;
+      await this.setBadge(a.count), this.setTabBadge(a.count);
+    } catch {
+      e === this.requestId && (await this.setBadge(0).catch(() => {
+      }), this.setTabBadge(0));
+    }
+  }
+  async setBadge(t) {
+    var o;
+    const e = await ((o = this.workspaceEditorContext) == null ? void 0 : o.getViewContext(d));
+    e != null && (e.hints.has(c) && e.hints.removeOne(c), t > 0 && e.hints.addOne({
+      unique: c,
+      text: String(t),
+      color: "default"
+    }));
+  }
+  setTabBadge(t) {
+    const e = () => {
+      var u;
+      const o = l(`[data-mark="workspace:view-link:${d}"]`);
+      if (o == null)
+        return !1;
+      if ((u = o.querySelector("[data-ekom-variant-count-badge]")) == null || u.remove(), t <= 0)
+        return !0;
+      const a = o.querySelector('[slot="icon"]');
+      if (a == null)
+        return !1;
+      const r = document.createElement("umb-badge");
+      return r.setAttribute("data-ekom-variant-count-badge", ""), r.setAttribute("color", "default"), r.textContent = String(t), a.append(r), !0;
+    };
+    e() || (window.setTimeout(e, 100), window.setTimeout(e, 500));
+  }
+  async fetchJson(t) {
+    const e = await fetch(t, {
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json"
+      }
+    });
+    if (!e.ok)
+      throw new Error(`Request failed with status ${e.status}`);
+    return await e.json();
+  }
+}
+function l(s, n = document) {
+  const t = n.querySelector(s);
+  if (t != null)
+    return t;
+  const e = n.querySelectorAll("*");
+  for (const o of e) {
+    if (o.shadowRoot == null)
+      continue;
+    const a = l(s, o.shadowRoot);
+    if (a != null)
+      return a;
+  }
+  return null;
+}
+customElements.define("ekom-variant-count-workspace-footer-app", w);
+export {
+  w as default
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
@@ -1,0 +1,990 @@
+var T = Object.defineProperty;
+var F = (i, o, t) => o in i ? T(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
+var l = (i, o, t) => F(i, typeof o != "symbol" ? o + "" : o, t);
+import { UmbElementMixin as M } from "@umbraco-cms/backoffice/element-api";
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT as O, UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT as B } from "@umbraco-cms/backoffice/document";
+import "@umbraco-cms/backoffice/imaging";
+import "@umbraco-cms/backoffice/media";
+import { UMB_NOTIFICATION_CONTEXT as W } from "@umbraco-cms/backoffice/notification";
+import { UMB_WORKSPACE_VIEW_CONTEXT as j } from "@umbraco-cms/backoffice/workspace";
+const V = "00000000-0000-0000-0000-000000000000", m = "ekom-variant-count";
+class R extends M(HTMLElement) {
+  constructor() {
+    super(...arguments);
+    l(this, "notificationContext");
+    l(this, "workspaceViewContext");
+    l(this, "product");
+    l(this, "loading", !0);
+    l(this, "saving", !1);
+    l(this, "error", "");
+    l(this, "productId", "");
+    l(this, "activeLanguage", "");
+    l(this, "nextDraftId", -1);
+    l(this, "drawer");
+    l(this, "expandedGroupIds", /* @__PURE__ */ new Set());
+    l(this, "selectedGroupIds", /* @__PURE__ */ new Set());
+    l(this, "selectedVariantIds", /* @__PURE__ */ new Set());
+    l(this, "deletedNodeIds", /* @__PURE__ */ new Set());
+    l(this, "groupSnapshots", /* @__PURE__ */ new Map());
+    l(this, "variantSnapshots", /* @__PURE__ */ new Map());
+    l(this, "draggedGroupId");
+    l(this, "draggedVariant");
+    l(this, "documentWorkspaceContext");
+    l(this, "originalRequestSave");
+    l(this, "originalRequestSubmit");
+    l(this, "originalSaveAndPublish");
+    l(this, "publishingWorkspaceContext");
+    l(this, "originalPublishingSaveAndPublish");
+    l(this, "onKeydown", (t) => {
+      t.key !== "Escape" || this.drawer == null || (t.stopPropagation(), this.syncMediaPickers(), this.drawer = void 0, this.render());
+    });
+  }
+  connectedCallback() {
+    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(W, (t) => {
+      this.notificationContext = t;
+    }), this.consumeContext(j, (t) => {
+      this.workspaceViewContext = t, this.updateWorkspaceViewBadge();
+    }), this.consumeContext(O, (t) => {
+      if (t == null)
+        return;
+      const e = t.getUnique();
+      e != null && (this.productId = e), this.patchDocumentSave(t), this.observe(t.unique, (a) => {
+        a == null || a === this.productId || (this.productId = a, this.load());
+      }, "ekomVariantProductId");
+    }), this.consumeContext(B, (t) => {
+      t != null && this.patchPublishingSave(t);
+    }), this.productId = this.getProductIdFromUrl(), this.render(), this.productId && this.load();
+  }
+  disconnectedCallback() {
+    window.removeEventListener("keydown", this.onKeydown), this.restoreDocumentSave(), this.restorePublishingSave(), super.disconnectedCallback();
+  }
+  patchDocumentSave(t) {
+    this.documentWorkspaceContext !== t && (this.restoreDocumentSave(), this.documentWorkspaceContext = t, t.requestSave != null && (this.originalRequestSave = t.requestSave.bind(t), t.requestSave = async () => {
+      var e;
+      await ((e = this.originalRequestSave) == null ? void 0 : e.call(this)), await this.saveAfterDocumentSave();
+    }), t.requestSubmit != null && (this.originalRequestSubmit = t.requestSubmit.bind(t), t.requestSubmit = async () => {
+      var e;
+      await ((e = this.originalRequestSubmit) == null ? void 0 : e.call(this)), await this.saveAfterDocumentSave();
+    }), t.saveAndPublish != null && (this.originalSaveAndPublish = t.saveAndPublish.bind(t), t.saveAndPublish = async () => {
+      var e;
+      await ((e = this.originalSaveAndPublish) == null ? void 0 : e.call(this)), await this.saveAfterDocumentSave();
+    }));
+  }
+  restoreDocumentSave() {
+    this.documentWorkspaceContext != null && (this.originalRequestSave != null && (this.documentWorkspaceContext.requestSave = this.originalRequestSave), this.originalRequestSubmit != null && (this.documentWorkspaceContext.requestSubmit = this.originalRequestSubmit), this.originalSaveAndPublish != null && (this.documentWorkspaceContext.saveAndPublish = this.originalSaveAndPublish), this.documentWorkspaceContext = void 0, this.originalRequestSave = void 0, this.originalRequestSubmit = void 0, this.originalSaveAndPublish = void 0);
+  }
+  patchPublishingSave(t) {
+    this.publishingWorkspaceContext !== t && (this.restorePublishingSave(), this.publishingWorkspaceContext = t, t.saveAndPublish != null && (this.originalPublishingSaveAndPublish = t.saveAndPublish.bind(t), t.saveAndPublish = async () => {
+      var e;
+      await ((e = this.originalPublishingSaveAndPublish) == null ? void 0 : e.call(this)), await this.saveAfterDocumentSave();
+    }));
+  }
+  restorePublishingSave() {
+    this.publishingWorkspaceContext != null && (this.originalPublishingSaveAndPublish != null && (this.publishingWorkspaceContext.saveAndPublish = this.originalPublishingSaveAndPublish), this.publishingWorkspaceContext = void 0, this.originalPublishingSaveAndPublish = void 0);
+  }
+  async saveAfterDocumentSave() {
+    this.syncMediaPickers(), this.product != null && this.hasChanges() && await this.save();
+  }
+  async load() {
+    var e;
+    const t = this.getProductId();
+    if (!t) {
+      this.loading = !1, this.error = "Could not determine the current product id.", this.showError(this.error), this.render();
+      return;
+    }
+    this.loading = !0, this.error = "", this.render();
+    try {
+      this.product = await this.fetchJson(`/ekom/backoffice/Variants/${encodeURIComponent(t)}`), this.activeLanguage = ((e = this.product.languages[0]) == null ? void 0 : e.isoCode) ?? "", this.drawer = void 0, this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.deletedNodeIds.clear(), this.expandedGroupIds.clear(), this.product.groups.length === 1 && this.expandedGroupIds.add(this.product.groups[0].id), this.resetSnapshots(), this.updateWorkspaceViewBadge();
+    } catch (a) {
+      this.product = void 0, this.updateWorkspaceViewBadge(), this.error = $(a, "Could not load variants."), this.showError(this.error);
+    } finally {
+      this.loading = !1, this.render();
+    }
+  }
+  addGroup() {
+    if (this.product == null)
+      return;
+    const t = this.nextDraftId--, e = {
+      id: t,
+      key: V,
+      name: "New group",
+      title: "",
+      titleValues: this.createEmptyTitleValues(),
+      color: "",
+      images: "",
+      sortOrder: this.product.groups.length,
+      published: !1,
+      customFields: q(this.product.variantGroupFields),
+      variants: []
+    };
+    this.product.groups = [...this.product.groups, e], this.expandedGroupIds.add(t), this.drawer = { type: "group", groupId: t }, this.render();
+  }
+  addVariant(t) {
+    var r;
+    const e = this.getGroup(t);
+    if (e == null)
+      return;
+    const a = this.nextDraftId--, s = {
+      id: a,
+      key: V,
+      name: "New variant",
+      title: "",
+      titleValues: this.createEmptyTitleValues(),
+      sku: "",
+      images: "",
+      priceValues: {},
+      stockValues: this.createEmptyStockValues(),
+      customFields: q(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
+      sortOrder: e.variants.length,
+      published: !1
+    };
+    e.variants = [...e.variants, s], this.expandedGroupIds.add(t), this.drawer = { type: "variant", groupId: t, variantId: a }, this.render();
+  }
+  async save() {
+    var e;
+    if (this.syncMediaPickers(), !this.validateAllCustomFields())
+      return;
+    if (this.product == null || !this.hasChanges()) {
+      this.showNotification("default", "Variants", "No changes to save.");
+      return;
+    }
+    const t = this.product.groups.map((a) => this.getChangedGroupForSave(a)).filter((a) => a != null);
+    this.saving = !0, this.error = "", this.render();
+    try {
+      for (const a of this.deletedNodeIds)
+        await this.deleteJson(`/ekom/backoffice/Variants/${encodeURIComponent(String(a))}`);
+      t.length > 0 ? this.product = await this.postJson("/ekom/backoffice/Variants/Save", {
+        productId: this.getProductId(),
+        publish: !0,
+        groups: t
+      }) : await this.load(), this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.deletedNodeIds.clear(), this.drawer = void 0, this.expandedGroupIds.clear(), ((e = this.product) == null ? void 0 : e.groups.length) === 1 && this.expandedGroupIds.add(this.product.groups[0].id), this.resetSnapshots(), this.updateWorkspaceViewBadge(), this.showSuccess("Variant changes were saved.");
+    } catch (a) {
+      this.error = $(a, "Action failed."), this.showError(this.error);
+    } finally {
+      this.saving = !1, this.render();
+    }
+  }
+  deleteSelected() {
+    if (this.product == null)
+      return;
+    const t = this.selectedGroupIds.size + this.selectedVariantIds.size;
+    if (!(t === 0 || !window.confirm(`Delete ${t} selected item${t === 1 ? "" : "s"}?`))) {
+      for (const e of this.product.groups) {
+        this.selectedGroupIds.has(e.id) && !h(e.id) && this.deletedNodeIds.add(e.id);
+        for (const a of e.variants)
+          this.selectedVariantIds.has(a.id) && !h(a.id) && this.deletedNodeIds.add(a.id);
+      }
+      this.product.groups = this.product.groups.filter((e) => !this.selectedGroupIds.has(e.id)).map((e) => ({
+        ...e,
+        variants: e.variants.filter((a) => !this.selectedVariantIds.has(a.id))
+      })), this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.drawer = void 0, this.render();
+    }
+  }
+  deleteDrawerItem() {
+    if (this.product == null || this.drawer == null)
+      return;
+    const t = this.drawer, e = t.type === "group", a = e ? "variant group" : "variant";
+    if (window.confirm(`Delete this ${a}?`)) {
+      if (e) {
+        const s = this.getGroup(t.groupId);
+        s != null && !h(s.id) && this.deletedNodeIds.add(s.id), this.product.groups = this.product.groups.filter((r) => r.id !== t.groupId);
+      } else {
+        const s = this.getGroup(t.groupId), r = this.getVariant(t.groupId, t.variantId);
+        r != null && !h(r.id) && this.deletedNodeIds.add(r.id), s != null && (s.variants = s.variants.filter((n) => n.id !== t.variantId));
+      }
+      this.drawer = void 0, this.render();
+    }
+  }
+  updateGroupTitle(t, e) {
+    const a = this.getGroup(t);
+    a != null && (a.titleValues = { ...a.titleValues, [this.activeLanguage]: e }, a.title = y(a.titleValues) || a.name, this.updateSaveButtonState());
+  }
+  updateGroupImages(t, e) {
+    const a = this.getGroup(t);
+    a != null && (a.images = e, this.updateSaveButtonState());
+  }
+  updateVariantTitle(t, e, a) {
+    const s = this.getVariant(t, e);
+    s != null && (s.titleValues = { ...s.titleValues, [this.activeLanguage]: a }, s.title = y(s.titleValues) || s.name, this.updateSaveButtonState());
+  }
+  updateVariant(t, e, a, s) {
+    const r = this.getVariant(t, e);
+    r != null && (r[a] = s, this.updateSaveButtonState());
+  }
+  updatePrice(t, e, a, s, r) {
+    const n = this.getVariant(t, e);
+    if (n == null)
+      return;
+    const d = [...n.priceValues[a] ?? []], c = Number(r) || 0, p = d.find((g) => v(g) === s);
+    p != null ? (p.Price = c, p.price = c) : d.push({ Currency: s, Price: c }), n.priceValues = { ...n.priceValues, [a]: d }, this.updateSaveButtonState();
+  }
+  updateStock(t, e, a, s) {
+    const r = this.getVariant(t, e);
+    if (r == null)
+      return;
+    const n = Number(s) || 0;
+    let d = !1;
+    const c = r.stockValues.map((p) => p.storeAlias !== a ? p : (d = !0, { ...p, value: n }));
+    d || c.push({ storeAlias: a, value: n }), r.stockValues = c, this.updateSaveButtonState();
+  }
+  hasChanges() {
+    var t;
+    return this.deletedNodeIds.size > 0 || (((t = this.product) == null ? void 0 : t.groups) ?? []).some((e) => this.isGroupChanged(e) || e.variants.some((a) => this.isVariantChanged(a)));
+  }
+  updateWorkspaceViewBadge() {
+    var e;
+    if (this.workspaceViewContext == null)
+      return;
+    this.workspaceViewContext.hints.has(m) && this.workspaceViewContext.hints.removeOne(m);
+    const t = ((e = this.product) == null ? void 0 : e.variantCount) ?? 0;
+    t > 0 && this.workspaceViewContext.hints.addOne({
+      unique: m,
+      text: String(t),
+      color: "default"
+    });
+  }
+  getChangedGroupForSave(t) {
+    const e = t.variants.filter((a) => this.isVariantChanged(a)).map((a) => {
+      var s;
+      return {
+        ...a,
+        priceValues: H(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
+        changed: !0
+      };
+    });
+    return !this.isGroupChanged(t) && e.length === 0 ? null : {
+      ...t,
+      changed: this.isGroupChanged(t),
+      variants: e
+    };
+  }
+  isGroupChanged(t) {
+    return h(t.id) || this.groupSnapshots.get(t.id) !== G(t);
+  }
+  isVariantChanged(t) {
+    return h(t.id) || this.variantSnapshots.get(t.id) !== N(t);
+  }
+  getGroup(t) {
+    var e;
+    return (e = this.product) == null ? void 0 : e.groups.find((a) => a.id === t);
+  }
+  getVariant(t, e) {
+    var a;
+    return (a = this.getGroup(t)) == null ? void 0 : a.variants.find((s) => s.id === e);
+  }
+  resetSnapshots() {
+    var t;
+    this.groupSnapshots.clear(), this.variantSnapshots.clear();
+    for (const e of ((t = this.product) == null ? void 0 : t.groups) ?? []) {
+      this.groupSnapshots.set(e.id, G(e));
+      for (const a of e.variants)
+        this.variantSnapshots.set(a.id, N(a));
+    }
+  }
+  createEmptyTitleValues() {
+    var e;
+    const t = {};
+    for (const a of ((e = this.product) == null ? void 0 : e.languages) ?? [])
+      t[a.isoCode ?? ""] = "";
+    return t;
+  }
+  createEmptyStockValues() {
+    var t;
+    return (((t = this.product) == null ? void 0 : t.stores) ?? []).map((e) => ({ storeAlias: e.alias ?? "", value: 0 }));
+  }
+  showSuccess(t) {
+    this.showNotification("positive", "Success", t);
+  }
+  showError(t) {
+    this.showNotification("danger", "Error", t);
+  }
+  showNotification(t, e, a) {
+    if (this.notificationContext) {
+      this.notificationContext.peek(t, {
+        data: {
+          headline: e,
+          message: a
+        }
+      });
+      return;
+    }
+    t === "danger" && console.error(`${e}: ${a}`);
+  }
+  render() {
+    this.innerHTML = `
+      <style>${X}</style>
+      <section class="ekm-variant-editor">
+        ${this.renderTopBar()}
+        ${this.error ? `<p class="status status--error">${u(this.error)}</p>` : ""}
+        ${this.loading ? "<uui-loader></uui-loader><p>Loading variants...</p>" : this.renderBody()}
+        ${this.renderDrawer()}
+      </section>
+    `, this.bindEvents();
+  }
+  renderTopBar() {
+    const t = this.selectedGroupIds.size + this.selectedVariantIds.size, e = this.hasChanges();
+    return `
+      <div class="top-bar">
+        <div class="selection-actions">
+          ${t > 0 ? `
+            <span>${t} selected</span>
+            <uui-button look="secondary" color="danger" data-action="delete-selected" ${this.saving ? "disabled" : ""}>Delete</uui-button>
+          ` : ""}
+        </div>
+        <div class="main-actions">
+          <uui-button look="primary" data-action="create-group" ${this.saving ? "disabled" : ""}>Add group</uui-button>
+          <uui-button look="primary" color="positive" data-action="save" ${this.saving || !e ? "disabled" : ""}>Save variant changes</uui-button>
+        </div>
+      </div>
+    `;
+  }
+  renderBody() {
+    return this.product == null ? "" : this.product.groups.length === 0 ? `
+        <uui-box headline="No variants yet">
+          <p>Create a variant group to start adding product variants.</p>
+          <uui-button look="primary" data-action="create-group">Create variant group</uui-button>
+        </uui-box>
+      ` : `
+      <div class="group-list">
+        ${this.product.groups.map((t) => this.renderGroup(t)).join("")}
+      </div>
+    `;
+  }
+  renderGroup(t) {
+    const e = this.expandedGroupIds.has(t.id), a = this.getTitle(t, "New group"), s = U(t);
+    return `
+      <article class="group-card ${h(t.id) ? "is-draft" : ""}" draggable="true" data-drag-group-id="${t.id}">
+        <div class="group-header">
+          <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+          <input type="checkbox" data-select-group data-group-id="${t.id}" ${this.selectedGroupIds.has(t.id) ? "checked" : ""} aria-label="Select group">
+          <button type="button" class="group-toggle" data-action="toggle-group" data-group-id="${t.id}" aria-label="Toggle group">${e ? "▼" : "►"}</button>
+          <button type="button" class="thumb thumb--button" data-action="toggle-group" data-group-id="${t.id}">${E(s, a)}</button>
+          <button type="button" class="group-title" data-action="toggle-group" data-group-id="${t.id}">${u(a)}</button>
+          <span class="count">${t.variants.length} variants</span>
+          ${h(t.id) ? '<span class="badge">draft</span>' : ""}
+          <div class="group-header-actions">
+            <uui-button compact look="secondary" data-action="edit-group" data-group-id="${t.id}">Edit group</uui-button>
+            <uui-button compact look="secondary" data-action="create-variant" data-group-id="${t.id}">Add variant</uui-button>
+          </div>
+        </div>
+        ${e ? this.renderVariants(t) : ""}
+      </article>
+    `;
+  }
+  renderVariants(t) {
+    return `
+      <div class="variant-table">
+        <div class="variant-head">
+          <span></span><span></span><span></span><span>Title</span><span>SKU</span><span class="variant-price-cell">Price</span><span class="variant-stock-cell">Stock</span><span></span>
+        </div>
+        ${t.variants.map((e) => this.renderVariant(t, e)).join("")}
+      </div>
+    `;
+  }
+  renderVariant(t, e) {
+    return `
+      <div class="variant-row ${h(e.id) ? "is-draft" : ""}" draggable="true" data-drag-group-id="${t.id}" data-drag-variant-id="${e.id}">
+        <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+        <input type="checkbox" data-select-variant data-variant-id="${e.id}" ${this.selectedVariantIds.has(e.id) ? "checked" : ""} aria-label="Select variant">
+        <span class="thumb">${E(k(e.images), this.getTitle(e, "New variant"))}</span>
+        <strong>${u(this.getTitle(e, "New variant"))}${h(e.id) ? ' <span class="badge">draft</span>' : ""}</strong>
+        <span>${u(e.sku)}</span>
+        <span class="variant-price-cell">${u(this.getDefaultPrice(e))}</span>
+        <span class="variant-stock-cell">${u(this.getTotalStock(e))}</span>
+        <uui-button compact look="secondary" data-action="edit-variant" data-group-id="${t.id}" data-variant-id="${e.id}">Edit</uui-button>
+      </div>
+    `;
+  }
+  renderDrawer() {
+    if (this.drawer == null || this.product == null)
+      return "";
+    const t = this.getGroup(this.drawer.groupId);
+    if (t == null)
+      return "";
+    if (this.drawer.type === "group")
+      return this.renderGroupDrawer(t);
+    const e = this.getVariant(this.drawer.groupId, this.drawer.variantId);
+    return e == null ? "" : this.renderVariantDrawer(t, e);
+  }
+  renderGroupDrawer(t) {
+    var e;
+    return `
+      <div class="drawer-backdrop" data-action="close-drawer"></div>
+      <aside class="drawer">
+        ${this.renderDrawerHeader(this.getTitle(t, "New group"), "variant group", t)}
+        <div class="drawer-body">
+          ${this.renderTitleField("Group title", ((e = t.titleValues) == null ? void 0 : e[this.activeLanguage]) ?? "", "data-group-title", t.id)}
+          ${this.renderCustomFields(t.customFields, t.id)}
+          ${this.renderMediaPicker("Images", t.images, "data-group-images", t.id)}
+          <p class="hint">Group images apply to all variants unless a variant has its own.</p>
+        </div>
+        ${this.renderDrawerFooter()}
+      </aside>
+    `;
+  }
+  renderVariantDrawer(t, e) {
+    var a;
+    return `
+      <div class="drawer-backdrop" data-action="close-drawer"></div>
+      <aside class="drawer">
+        ${this.renderDrawerHeader(this.getTitle(e, "New variant"), `${this.getTitle(t, "Group")} / variant`, e)}
+        <div class="drawer-body">
+          ${this.renderTitleField("Title", ((a = e.titleValues) == null ? void 0 : a[this.activeLanguage]) ?? "", "data-variant-title", t.id, e.id)}
+          <label>SKU<input data-variant-field="sku" data-group-id="${t.id}" data-variant-id="${e.id}" value="${u(e.sku)}"></label>
+          ${this.renderCustomFields(e.customFields, t.id, e.id)}
+          ${this.renderPriceTable(t.id, e)}
+          ${this.renderStockTable(t.id, e)}
+          ${this.renderMediaPicker("Images", e.images, "data-variant-images", t.id, e.id)}
+        </div>
+        ${this.renderDrawerFooter()}
+      </aside>
+    `;
+  }
+  renderDrawerHeader(t, e, a) {
+    const s = !h(a.id) && a.key ? `/umbraco/section/content/workspace/document/edit/${a.key}` : "";
+    return `
+      <header class="drawer-header">
+        <div class="drawer-title">
+          <h2>${u(t)}</h2>
+          <p>${u(e)}</p>
+        </div>
+        <div class="drawer-header-actions">
+          ${s ? `<uui-button compact look="secondary" href="${s}" target="_blank" rel="noopener" title="Open node in new tab" aria-label="Open node in new tab"><span class="edit-icon" aria-hidden="true">✎</span></uui-button>` : ""}
+          <button type="button" class="close-button" data-action="close-drawer" aria-label="Close">×</button>
+        </div>
+      </header>
+    `;
+  }
+  renderDrawerFooter() {
+    return `
+      <footer class="drawer-footer">
+        <div class="drawer-footer-left">
+          <button type="button" class="danger-button" data-action="delete-drawer-item">Delete</button>
+        </div>
+        <div class="drawer-footer-right">
+          <uui-button look="secondary" data-action="close-drawer">Close</uui-button>
+          <uui-button look="primary" color="positive" data-action="save-drawer">Save</uui-button>
+        </div>
+      </footer>
+    `;
+  }
+  renderTitleField(t, e, a, s, r = 0) {
+    return `
+      <label>${u(t)}
+        ${this.renderLanguageMiniTabs()}
+        <input ${a} data-group-id="${s}" data-variant-id="${r}" value="${u(e)}">
+      </label>
+    `;
+  }
+  renderLanguageMiniTabs() {
+    var e;
+    const t = ((e = this.product) == null ? void 0 : e.languages) ?? [];
+    return t.length <= 1 ? "" : `
+      <div class="mini-tabs">
+        ${t.map((a) => {
+      const s = a.isoCode ?? "";
+      return `<button type="button" data-action="set-language" data-tab-value="${u(s)}" class="mini-tab ${s === this.activeLanguage ? "active" : ""}">${u(z(a))}</button>`;
+    }).join("")}
+      </div>
+    `;
+  }
+  renderCustomFields(t, e, a = 0) {
+    return t != null && t.length ? t.map((s) => `
+      <label>${u(s.label)}${s.required ? " *" : ""}
+        <input data-custom-field data-custom-field-alias="${u(s.alias)}" data-group-id="${e}" data-variant-id="${a}" value="${u(s.value ?? "")}" ${s.required ? "required" : ""}>
+      </label>
+    `).join("") : "";
+  }
+  renderPriceTable(t, e) {
+    var a;
+    return `
+      <section>
+        <h3>Prices</h3>
+        <table>
+          <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
+          <tbody>
+            ${(((a = this.product) == null ? void 0 : a.stores) ?? []).flatMap((s) => (s.currencies ?? []).map((r) => {
+      var p, g;
+      const n = s.alias ?? "", d = r.currencyValue ?? "", c = S((g = (p = e.priceValues) == null ? void 0 : p[n]) == null ? void 0 : g.find((D) => v(D) === d));
+      return `<tr><td>${u(s.title ?? n)}</td><td>${u(r.isoCurrencySymbol ?? d)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${u(n)}" data-price-currency="${u(d)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(c)}"></td></tr>`;
+    })).join("")}
+          </tbody>
+        </table>
+      </section>
+    `;
+  }
+  renderStockTable(t, e) {
+    var s, r;
+    const a = e.stockValues.length > 0 ? e.stockValues : this.createEmptyStockValues();
+    if (a.length <= 1) {
+      const n = ((s = a[0]) == null ? void 0 : s.value) ?? 0, d = ((r = a[0]) == null ? void 0 : r.storeAlias) ?? "";
+      return `<label>Stock<input class="numeric" type="number" min="0" step="any" data-stock data-stock-store="${u(d)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(n)}"></label>`;
+    }
+    return `
+      <section>
+        <h3>Stock</h3>
+        <table>
+          <thead><tr><th>Store</th><th>Stock</th></tr></thead>
+          <tbody>
+            ${a.map((n) => `<tr><td>${u(this.getStoreTitle(n.storeAlias))}</td><td><input class="numeric" type="number" min="0" step="any" data-stock data-stock-store="${u(n.storeAlias)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(n.value)}"></td></tr>`).join("")}
+          </tbody>
+        </table>
+      </section>
+    `;
+  }
+  renderMediaPicker(t, e, a, s, r = 0) {
+    return `
+      <div class="media-field">
+        <span class="field-label">${u(t)}</span>
+        <umb-input-media ${a} max="100" value="${u(e ?? "")}" data-group-id="${s}" data-variant-id="${r}" data-value="${u(e ?? "")}"></umb-input-media>
+      </div>
+    `;
+  }
+  bindEvents() {
+    var t, e, a, s;
+    this.querySelectorAll('[data-action="create-group"]').forEach((r) => {
+      r.addEventListener("click", () => this.addGroup());
+    }), (t = this.querySelector('[data-action="save"]')) == null || t.addEventListener("click", () => void this.save()), (e = this.querySelector('[data-action="delete-selected"]')) == null || e.addEventListener("click", () => this.deleteSelected()), (a = this.querySelector('[data-action="delete-drawer-item"]')) == null || a.addEventListener("click", () => this.deleteDrawerItem()), (s = this.querySelector('[data-action="save-drawer"]')) == null || s.addEventListener("click", () => {
+      this.syncMediaPickers(), this.validateDrawerCustomFields() && (this.drawer = void 0, this.render());
+    }), this.querySelectorAll('[data-action="close-drawer"]').forEach((r) => {
+      r.addEventListener("click", () => {
+        this.syncMediaPickers(), this.drawer = void 0, this.render();
+      });
+    }), this.querySelectorAll('[data-action="set-language"]').forEach((r) => {
+      r.addEventListener("click", (n) => {
+        n.preventDefault(), n.stopPropagation(), this.setActiveLanguage(r.dataset.tabValue ?? "");
+      });
+    }), this.querySelectorAll('[data-action="toggle-group"]').forEach((r) => {
+      r.addEventListener("click", () => this.toggleGroup(Number(r.dataset.groupId)));
+    }), this.querySelectorAll('[data-action="edit-group"]').forEach((r) => {
+      r.addEventListener("click", () => {
+        this.drawer = { type: "group", groupId: Number(r.dataset.groupId) }, this.render();
+      });
+    }), this.querySelectorAll('[data-action="create-variant"]').forEach((r) => {
+      r.addEventListener("click", () => this.addVariant(Number(r.dataset.groupId)));
+    }), this.querySelectorAll('[data-action="edit-variant"]').forEach((r) => {
+      r.addEventListener("click", () => {
+        const n = r;
+        this.drawer = { type: "variant", groupId: Number(n.dataset.groupId), variantId: Number(n.dataset.variantId) }, this.render();
+      });
+    }), this.querySelectorAll("[data-select-group]").forEach((r) => {
+      r.addEventListener("change", () => {
+        this.toggleSet(this.selectedGroupIds, Number(r.dataset.groupId), r.checked), this.render();
+      });
+    }), this.querySelectorAll("[data-select-variant]").forEach((r) => {
+      r.addEventListener("change", () => {
+        this.toggleSet(this.selectedVariantIds, Number(r.dataset.variantId), r.checked), this.render();
+      });
+    }), this.querySelectorAll("[data-group-title]").forEach((r) => {
+      r.addEventListener("input", (n) => {
+        n.stopPropagation(), this.updateGroupTitle(Number(r.dataset.groupId), r.value);
+      });
+    }), this.querySelectorAll("[data-variant-title]").forEach((r) => {
+      r.addEventListener("input", (n) => {
+        n.stopPropagation(), this.updateVariantTitle(Number(r.dataset.groupId), Number(r.dataset.variantId), r.value);
+      });
+    }), this.querySelectorAll("[data-variant-field]").forEach((r) => {
+      r.addEventListener("input", (n) => {
+        n.stopPropagation(), this.updateVariant(Number(r.dataset.groupId), Number(r.dataset.variantId), "sku", r.value);
+      });
+    }), this.querySelectorAll("[data-custom-field]").forEach((r) => {
+      r.addEventListener("input", (n) => {
+        n.stopPropagation(), this.updateCustomField(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.customFieldAlias ?? "", r.value);
+      });
+    }), this.querySelectorAll("[data-price]").forEach((r) => {
+      r.addEventListener("input", (n) => {
+        n.stopPropagation(), this.updatePrice(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.priceStore ?? "", r.dataset.priceCurrency ?? "", r.value);
+      });
+    }), this.querySelectorAll("[data-stock]").forEach((r) => {
+      r.addEventListener("input", (n) => {
+        n.stopPropagation(), this.updateStock(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.stockStore ?? "", r.value);
+      });
+    }), this.bindDragAndDrop(), this.bindMediaPickers();
+  }
+  bindDragAndDrop() {
+    this.querySelectorAll(".group-card[data-drag-group-id]").forEach((t) => {
+      t.addEventListener("dragstart", (e) => {
+        var a, s;
+        this.draggedGroupId = Number(t.dataset.dragGroupId), (a = e.dataTransfer) == null || a.setData("text/plain", `group:${this.draggedGroupId}`), (s = e.dataTransfer) == null || s.setDragImage(t, 20, 20);
+      }), t.addEventListener("dragover", (e) => {
+        this.draggedGroupId != null && e.preventDefault();
+      }), t.addEventListener("drop", (e) => {
+        e.preventDefault(), this.reorderGroup(this.draggedGroupId, Number(t.dataset.dragGroupId)), this.draggedGroupId = void 0;
+      }), t.addEventListener("dragend", () => {
+        this.draggedGroupId = void 0;
+      });
+    }), this.querySelectorAll(".variant-row[data-drag-variant-id]").forEach((t) => {
+      t.addEventListener("dragstart", (e) => {
+        var a;
+        this.draggedVariant = {
+          groupId: Number(t.dataset.dragGroupId),
+          variantId: Number(t.dataset.dragVariantId)
+        }, e.stopPropagation(), (a = e.dataTransfer) == null || a.setData("text/plain", `variant:${this.draggedVariant.groupId}:${this.draggedVariant.variantId}`);
+      }), t.addEventListener("dragover", (e) => {
+        var a;
+        ((a = this.draggedVariant) == null ? void 0 : a.groupId) === Number(t.dataset.dragGroupId) && (e.preventDefault(), e.stopPropagation());
+      }), t.addEventListener("drop", (e) => {
+        e.preventDefault(), e.stopPropagation(), this.reorderVariant(this.draggedVariant, Number(t.dataset.dragGroupId), Number(t.dataset.dragVariantId)), this.draggedVariant = void 0;
+      }), t.addEventListener("dragend", (e) => {
+        e.stopPropagation(), this.draggedVariant = void 0;
+      });
+    });
+  }
+  bindMediaPickers() {
+    this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
+      const e = t, a = t.dataset.value ?? "", s = I(a);
+      e.value = s.join(","), e.selection = s, _(e), t.addEventListener("change", async (r) => {
+        const n = Number(t.dataset.groupId), d = Number(t.dataset.variantId);
+        r.stopPropagation(), await Promise.resolve();
+        const c = P(e);
+        await f(e), d !== 0 ? this.updateVariant(n, d, "images", c) : this.updateGroupImages(n, c);
+      });
+    });
+  }
+  syncMediaPickers() {
+    this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
+      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = P(e);
+      if (s !== 0) {
+        const d = this.getVariant(a, s);
+        d != null && d.images !== r && (d.images = r);
+        return;
+      }
+      const n = this.getGroup(a);
+      n != null && n.images !== r && (n.images = r);
+    }), this.updateSaveButtonState();
+  }
+  updateSaveButtonState() {
+    const t = this.querySelector('[data-action="save"]');
+    t != null && t.toggleAttribute("disabled", this.saving || !this.hasChanges());
+  }
+  updateCustomField(t, e, a, s) {
+    var d;
+    const r = e !== 0 ? this.getVariant(t, e) : this.getGroup(t), n = (d = r == null ? void 0 : r.customFields) == null ? void 0 : d.find((c) => c.alias === a);
+    n != null && (n.value = s), this.updateSaveButtonState();
+  }
+  validateDrawerCustomFields() {
+    if (this.drawer == null)
+      return !0;
+    const t = this.drawer.type === "group" ? this.getGroup(this.drawer.groupId) : this.getVariant(this.drawer.groupId, this.drawer.variantId);
+    return this.validateCustomFields(t == null ? void 0 : t.customFields);
+  }
+  validateAllCustomFields() {
+    var t;
+    for (const e of ((t = this.product) == null ? void 0 : t.groups) ?? []) {
+      if (!this.validateCustomFields(e.customFields, !1))
+        return !1;
+      for (const a of e.variants)
+        if (!this.validateCustomFields(a.customFields, !1))
+          return !1;
+    }
+    return !0;
+  }
+  validateCustomFields(t, e = !0) {
+    const a = t == null ? void 0 : t.find((s) => {
+      var r;
+      return s.required && !((r = s.value) != null && r.trim());
+    });
+    return a == null ? !0 : (this.showError(`${a.label} is required.`), e && this.render(), !1);
+  }
+  reorderGroup(t, e) {
+    this.product == null || t == null || t === e || (this.product.groups = L(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
+      a.sortOrder = s;
+    }), this.render());
+  }
+  reorderVariant(t, e, a) {
+    if (t == null || t.groupId !== e || t.variantId === a)
+      return;
+    const s = this.getGroup(t.groupId);
+    s != null && (s.variants = L(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
+      r.sortOrder = n;
+    }), this.render());
+  }
+  setActiveLanguage(t) {
+    var s, r;
+    if (this.activeLanguage = t, this.querySelectorAll('[data-action="set-language"]').forEach((n) => {
+      n.classList.toggle("active", n.dataset.tabValue === t);
+    }), this.drawer == null)
+      return;
+    if (this.drawer.type === "group") {
+      const n = this.getGroup(this.drawer.groupId), d = this.querySelector("[data-group-title]");
+      n != null && d != null && (d.value = ((s = n.titleValues) == null ? void 0 : s[t]) ?? "");
+      return;
+    }
+    const e = this.getVariant(this.drawer.groupId, this.drawer.variantId), a = this.querySelector("[data-variant-title]");
+    e != null && a != null && (a.value = ((r = e.titleValues) == null ? void 0 : r[t]) ?? "");
+  }
+  toggleGroup(t) {
+    this.expandedGroupIds.has(t) ? this.expandedGroupIds.delete(t) : this.expandedGroupIds.add(t), this.render();
+  }
+  toggleSet(t, e, a) {
+    a ? t.add(e) : t.delete(e);
+  }
+  getTitle(t, e) {
+    var a;
+    return ((a = t.titleValues) == null ? void 0 : a[this.activeLanguage]) || y(t.titleValues) || t.title || t.name || e;
+  }
+  getDefaultPrice(t) {
+    var n, d, c, p;
+    const e = (n = this.product) == null ? void 0 : n.stores[0], a = (d = e == null ? void 0 : e.currencies) == null ? void 0 : d[0];
+    if (e == null || a == null)
+      return "—";
+    const s = S((p = (c = t.priceValues) == null ? void 0 : c[e.alias ?? ""]) == null ? void 0 : p.find((g) => v(g) === (a.currencyValue ?? ""))), r = a.currencySymbol ?? a.isoCurrencySymbol ?? a.currencyValue ?? "";
+    return `${C(s)} ${r}`.trim();
+  }
+  getTotalStock(t) {
+    return t.stockValues.length === 0 ? "0" : C(t.stockValues.reduce((e, a) => e + (Number(a.value) || 0), 0));
+  }
+  getStoreTitle(t) {
+    var e, a;
+    return ((a = (e = this.product) == null ? void 0 : e.stores.find((s) => s.alias === t)) == null ? void 0 : a.title) ?? t;
+  }
+  getProductId() {
+    return this.productId || this.getProductIdFromUrl();
+  }
+  getProductIdFromUrl() {
+    const t = window.location.href, e = t.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    if (e != null)
+      return e[0];
+    const a = t.match(/\/edit\/([^/?#]+)/i);
+    return (a == null ? void 0 : a[1]) ?? "";
+  }
+  async fetchJson(t) {
+    const e = await fetch(t, { credentials: "same-origin", headers: { Accept: "application/json" } });
+    return w(e);
+  }
+  async postJson(t, e) {
+    const a = await fetch(t, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify(e)
+    });
+    return w(a);
+  }
+  async deleteJson(t) {
+    const e = await fetch(t, { method: "DELETE", credentials: "same-origin", headers: { Accept: "application/json" } });
+    await w(e);
+  }
+}
+async function w(i) {
+  if (!i.ok)
+    throw new Error(await i.text() || "Request failed.");
+  if (i.status !== 204)
+    return i.json();
+}
+function $(i, o) {
+  return i instanceof Error && i.message.length > 0 ? i.message : o;
+}
+function u(i) {
+  return String(i ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+function y(i) {
+  return Object.values(i ?? {}).find((o) => o != null && o.trim().length > 0) ?? "";
+}
+function z(i) {
+  return (i.isoCode ?? i.cultureName ?? "").split("-")[0].toUpperCase();
+}
+function v(i) {
+  return i.Currency ?? i.currency ?? "";
+}
+function S(i) {
+  return (i == null ? void 0 : i.Price) ?? (i == null ? void 0 : i.price) ?? 0;
+}
+function C(i) {
+  return new Intl.NumberFormat().format(i);
+}
+function I(i) {
+  const o = String(i ?? "").trim();
+  if (o.length === 0)
+    return [];
+  if (o.startsWith("["))
+    try {
+      return JSON.parse(o).map((e) => String(e.mediaKey ?? e.key ?? "").trim()).filter(Boolean);
+    } catch {
+      return [];
+    }
+  return o.split(",").map((t) => x(t.trim())).filter(Boolean);
+}
+function k(i) {
+  return I(i)[0] ?? "";
+}
+function U(i) {
+  const o = k(i.images);
+  if (o)
+    return o;
+  for (const t of i.variants) {
+    const e = k(t.images);
+    if (e)
+      return e;
+  }
+  return "";
+}
+function E(i, o) {
+  return i ? `<umb-imaging-thumbnail unique="${u(i)}" width="38" height="38" alt="${u(o)}"></umb-imaging-thumbnail>` : "-";
+}
+function x(i) {
+  const o = i.match(/umb:\/\/media\/(.+)$/i);
+  return (o == null ? void 0 : o[1]) ?? i;
+}
+function P(i) {
+  return Array.isArray(i.selection) ? K(i.selection).join(",") : I(i.value ?? "").join(",");
+}
+const A = /* @__PURE__ */ new WeakSet();
+async function _(i) {
+  if (A.has(i)) {
+    await f(i);
+    return;
+  }
+  A.add(i), await f(i);
+  const o = i.shadowRoot;
+  if (o == null)
+    return;
+  const t = () => void J(i), e = () => window.setTimeout(() => void f(i));
+  new MutationObserver(() => void f(i)).observe(o, { childList: !0, subtree: !0 }), o.addEventListener("pointerdown", t, { capture: !0 }), o.addEventListener("dragstart", t, { capture: !0 }), o.addEventListener("dragend", e, { capture: !0 }), o.addEventListener("drop", e, { capture: !0 });
+}
+async function J(i) {
+  var o;
+  await i.updateComplete, await new Promise((t) => window.requestAnimationFrame(t)), (o = i.shadowRoot) == null || o.querySelectorAll("uui-card-media[data-mark]").forEach((t) => {
+    var a;
+    const e = ((a = t.dataset.mark) == null ? void 0 : a.split(":").pop()) ?? "";
+    e && t.setAttribute("detail", e);
+  });
+}
+async function f(i) {
+  var o;
+  await i.updateComplete, await new Promise((t) => window.requestAnimationFrame(t)), (o = i.shadowRoot) == null || o.querySelectorAll("uui-card-media[detail]").forEach((t) => {
+    t.removeAttribute("detail");
+  });
+}
+function K(i) {
+  return i.map((o) => {
+    if (typeof o == "string")
+      return x(o);
+    if (o != null && typeof o == "object") {
+      const t = o;
+      return x(String(t.udi ?? t.key ?? t.unique ?? t.id ?? ""));
+    }
+    return "";
+  }).filter(Boolean);
+}
+function h(i) {
+  return i <= 0;
+}
+function G(i) {
+  return b({
+    titleValues: i.titleValues,
+    images: i.images,
+    customFields: i.customFields,
+    sortOrder: i.sortOrder
+  });
+}
+function N(i) {
+  return b({
+    titleValues: i.titleValues,
+    sku: i.sku,
+    images: i.images,
+    priceValues: i.priceValues,
+    stockValues: i.stockValues,
+    customFields: i.customFields,
+    sortOrder: i.sortOrder
+  });
+}
+function q(i) {
+  return (i ?? []).map((o) => ({
+    ...o,
+    value: ""
+  }));
+}
+function H(i, o) {
+  const t = {};
+  for (const e of o) {
+    const a = e.alias ?? "", s = /* @__PURE__ */ new Map();
+    for (const [r, n] of Object.entries(i ?? {}))
+      if (r.toLowerCase() === a.toLowerCase())
+        for (const d of n) {
+          const c = v(d);
+          c !== "" && s.set(c.toLowerCase(), {
+            Currency: c,
+            Price: S(d)
+          });
+        }
+    s.size > 0 && (t[a] = [...s.values()]);
+  }
+  return t;
+}
+function L(i, o, t) {
+  const e = [...i], a = e.findIndex((n) => n.id === o), s = e.findIndex((n) => n.id === t);
+  if (a < 0 || s < 0)
+    return i;
+  const [r] = e.splice(a, 1);
+  return e.splice(s, 0, r), e;
+}
+function b(i) {
+  if (Array.isArray(i))
+    return `[${i.map(b).join(",")}]`;
+  if (i != null && typeof i == "object") {
+    const o = i;
+    return `{${Object.keys(o).sort().map((t) => `${JSON.stringify(t)}:${b(o[t])}`).join(",")}}`;
+  }
+  return JSON.stringify(i);
+}
+const X = `
+  :host { display: block; padding: var(--uui-size-layout-1, 24px); background: #f4f3f5; color: #1b264f; font-family: Lato, Arial, sans-serif; }
+  .ekm-variant-editor { display: grid; gap: 16px; }
+  .top-bar, .selection-actions, .main-actions, .group-header, .group-header-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .top-bar { background: #f4f3f5; border-bottom: 1px solid #e2e1e6; box-shadow: 0 4px 10px rgba(27, 38, 79, .06); justify-content: space-between; margin: -24px -24px 0; padding: 16px 24px; position: sticky; top: 0; z-index: 10; }
+  .selection-actions { min-height: 32px; }
+  .main-actions { margin-left: auto; justify-content: flex-end; }
+  .group-list { display: grid; gap: 14px; }
+  .group-card { background: #fff; border: 1px solid #e2e1e6; border-radius: 6px; box-shadow: 0 1px 3px rgba(27, 38, 79, .06); overflow: hidden; }
+  .group-card.is-draft, .variant-row.is-draft { background: #f8fbf9; }
+  .group-header { padding: 12px 14px; }
+  .drag-handle { color: #8b8994; cursor: grab; font-weight: 900; letter-spacing: -2px; user-select: none; }
+  [draggable="true"]:active .drag-handle { cursor: grabbing; }
+  .group-toggle, .group-title, .thumb--button, .close-button, .mini-tab { border: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; }
+  .group-title { font-weight: 900; text-align: left; }
+  .thumb { display: inline-flex; width: 38px; height: 38px; align-items: center; justify-content: center; border: 1px solid #e2e1e6; border-radius: 4px; background: #f4f3f5; color: #686570; font-size: 11px; text-transform: uppercase; }
+  .thumb umb-imaging-thumbnail { width: 100%; height: 100%; }
+  .count, .hint { color: #686570; }
+  .badge { border-radius: 999px; padding: 2px 8px; background: #ecf7f1; color: #188a4f; font-size: 11px; font-weight: 700; text-transform: uppercase; }
+  .group-header-actions { margin-left: auto; }
+  .variant-table { border-top: 1px solid #e2e1e6; }
+  .variant-head, .variant-row { display: grid; grid-template-columns: 18px 24px 44px minmax(140px, 1.3fr) minmax(100px, .8fr) minmax(100px, .8fr) minmax(80px, .6fr) auto; gap: 12px; align-items: center; padding: 10px 14px; }
+  .variant-head { background: #f8f7fa; color: #8b8994; font-size: 11px; font-weight: 900; letter-spacing: .04em; text-transform: uppercase; }
+  .variant-row { border-top: 1px solid #e2e1e6; }
+  .variant-price-cell, .variant-stock-cell { text-align: center; }
+  input { box-sizing: border-box; width: 100%; border: 1px solid #c4c2cb; border-radius: 3px; padding: 8px; font: inherit; }
+  input:focus { border-color: #1b264f; outline: none; }
+  input[type="checkbox"] { width: 16px; height: 16px; accent-color: #188a4f; }
+  .status { padding: 12px; background: #fff; border-radius: 3px; }
+  .status--error { color: #d42054; }
+  .drawer-backdrop { position: fixed; inset: 0; background: rgba(27, 38, 79, .35); z-index: 1000; }
+  .drawer { position: fixed; top: 0; right: 0; bottom: 0; z-index: 1001; width: min(460px, 100vw); display: grid; grid-template-rows: auto 1fr auto; background: #fff; box-shadow: -6px 0 24px rgba(27, 38, 79, .18); animation: slide-in .18s ease-out; }
+  .drawer-header, .drawer-footer { display: flex; gap: 12px; align-items: center; justify-content: space-between; padding: 18px; border-bottom: 1px solid #e2e1e6; }
+  .drawer-footer { border-top: 1px solid #e2e1e6; border-bottom: 0; }
+  .drawer-title { min-width: 0; }
+  .drawer-header-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+  .drawer-footer-left, .drawer-footer-right { display: flex; gap: 12px; align-items: center; }
+  .drawer-footer-left { margin-right: auto; }
+  .danger-button { background: #d42054; border: 1px solid #d42054; border-radius: 3px; color: #fff; cursor: pointer; font: inherit; font-weight: 700; padding: 8px 14px; }
+  .danger-button:hover { background: #b51b46; border-color: #b51b46; }
+  .drawer-header h2 { margin: 0; font-size: 20px; }
+  .drawer-header p { margin: 4px 0 0; color: #686570; }
+  .edit-icon { display: inline-block; font-size: 15px; line-height: 1; transform: translateY(-1px); }
+  .drawer-body { display: grid; gap: 18px; align-content: start; overflow: auto; padding: 18px; }
+  label, .media-field { display: grid; gap: 8px; font-weight: 700; }
+  .field-label, h3 { font-weight: 900; margin: 0; }
+  .drawer-body section h3 { font-size: 13px; margin-bottom: 10px; }
+  .mini-tabs { display: inline-flex; gap: 4px; }
+  .mini-tab { padding: 4px 8px; border-bottom: 2px solid transparent; color: #686570; font-weight: 700; }
+  .mini-tab.active { border-bottom-color: #1b264f; color: #1b264f; }
+  table { width: 100%; border-collapse: collapse; }
+  th { background: #f8f7fa; color: #8b8994; font-size: 11px; letter-spacing: .04em; text-align: left; text-transform: uppercase; }
+  th, td { border-bottom: 1px solid #e2e1e6; padding: 8px; }
+  .numeric { text-align: right; }
+  @keyframes slide-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+`;
+customElements.define("ekom-variants-workspace-view", R);
+export {
+  R as default
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
@@ -54,6 +54,44 @@ export const manifests: Array<UmbExtensionManifest> = [
     ],
   },
   {
+    type: 'workspaceView',
+    alias: 'Ekom.WorkspaceView.Product.Variants',
+    name: 'Ekom Product Variants Workspace View',
+    element: '/App_Plugins/Ekom/dist/variants-workspace-view.element.js',
+    weight: 90,
+    meta: {
+      label: 'Variants',
+      pathname: 'variants',
+      icon: 'icon-layers-alt',
+    },
+    conditions: [
+      {
+        alias: 'Umb.Condition.WorkspaceAlias',
+        match: 'Umb.Workspace.Document',
+      },
+      {
+        alias: 'Umb.Condition.WorkspaceContentTypeAlias',
+        match: 'ekmProduct',
+      },
+    ],
+  },
+  {
+    type: 'workspaceFooterApp',
+    alias: 'Ekom.WorkspaceFooterApp.Product.VariantCount',
+    name: 'Ekom Product Variant Count Workspace Footer App',
+    element: '/App_Plugins/Ekom/dist/variant-count-workspace-footer-app.element.js',
+    conditions: [
+      {
+        alias: 'Umb.Condition.WorkspaceAlias',
+        match: 'Umb.Workspace.Document',
+      },
+      {
+        alias: 'Umb.Condition.WorkspaceContentTypeAlias',
+        match: 'ekmProduct',
+      },
+    ],
+  },
+  {
     type: 'propertyEditorSchema',
     alias: 'Ekom.Cache',
     name: 'Ekom Cache Editor',

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/country-picker.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/country-picker.element.ts
@@ -107,7 +107,6 @@ export class EkomCountryPickerElement extends HTMLElement implements UmbProperty
 
     if (this.internalValue.length === 0 && this.select.options.length > 0) {
       this.internalValue = this.select.options[0]?.value ?? '';
-      this.emitChange();
     }
 
     this.syncValue();

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/metafield-picker.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/metafield-picker.element.ts
@@ -80,7 +80,6 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
       this.ensureFieldValues();
       this.renderFields();
       this.setStatus('');
-      this.emitChange();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Could not load metafields.';
       this.setStatus(message, true);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/price-editor.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/price-editor.element.ts
@@ -83,7 +83,6 @@ export class EkomPriceEditorElement extends HTMLElement implements UmbPropertyEd
       this.internalValue = this.ensurePriceStructure(this.normalizeValue(this.rawValue));
       this.renderPrices();
       this.setStatus('');
-      this.emitChange();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Could not load prices.';
       this.setStatus(message, true);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/range-editor.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/range-editor.element.ts
@@ -69,7 +69,6 @@ export class EkomRangeEditorElement extends HTMLElement implements UmbPropertyEd
       this.internalValue = this.ensureRangeStructure(this.normalizeValue(this.rawValue));
       this.renderRanges();
       this.setStatus('');
-      this.emitChange();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Could not load ranges.';
       this.setStatus(message, true);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/stock-editor.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/stock-editor.element.ts
@@ -69,7 +69,6 @@ export class EkomStockEditorElement extends HTMLElement implements UmbPropertyEd
 
       this.renderStock();
       this.setStatus('');
-      this.emitChange();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Could not load stock.';
       this.setStatus(message, true);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variant-count-workspace-footer-app.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variant-count-workspace-footer-app.element.ts
@@ -1,0 +1,190 @@
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/document';
+import { UMB_WORKSPACE_EDITOR_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+
+const VARIANT_COUNT_HINT = 'ekom-variant-count';
+const VARIANTS_WORKSPACE_VIEW_ALIAS = 'Ekom.WorkspaceView.Product.Variants';
+
+type VariantCountResponse = {
+  count: number;
+};
+
+type DocumentWorkspaceContext = typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
+type WorkspaceEditorContext = typeof UMB_WORKSPACE_EDITOR_CONTEXT.TYPE;
+
+class EkomVariantCountWorkspaceFooterAppElement extends UmbElementMixin(HTMLElement) {
+  private documentWorkspaceContext?: DocumentWorkspaceContext;
+  private workspaceEditorContext?: WorkspaceEditorContext;
+  private productId = '';
+  private requestId = 0;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.style.display = 'none';
+
+    this.consumeContext(UMB_WORKSPACE_EDITOR_CONTEXT, context => {
+      this.workspaceEditorContext = context;
+      void this.updateBadge();
+    });
+
+    this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, context => {
+      if (context == null) {
+        return;
+      }
+
+      this.documentWorkspaceContext = context;
+
+      const unique = context.getUnique();
+      if (unique != null) {
+        this.productId = unique;
+      }
+
+      this.observe(context.unique, value => {
+        if (value == null || value === this.productId) {
+          return;
+        }
+
+        this.productId = value;
+        void this.updateBadge();
+      }, 'ekomVariantCountProductId');
+
+      void this.updateBadge();
+    });
+  }
+
+  override disconnectedCallback(): void {
+    this.requestId++;
+    void this.setBadge(0);
+    super.disconnectedCallback();
+  }
+
+  private async updateBadge(): Promise<void> {
+    const productId = this.productId || this.documentWorkspaceContext?.getUnique() || '';
+    const requestId = ++this.requestId;
+
+    if (!productId) {
+      await this.setBadge(0).catch(() => undefined);
+      return;
+    }
+
+    try {
+      const result = await this.fetchJson<VariantCountResponse>(`/ekom/backoffice/Variants/${encodeURIComponent(productId)}/Count`);
+
+      if (requestId !== this.requestId) {
+        return;
+      }
+
+      await this.setBadge(result.count);
+      this.setTabBadge(result.count);
+    } catch {
+      if (requestId === this.requestId) {
+        await this.setBadge(0).catch(() => undefined);
+        this.setTabBadge(0);
+      }
+    }
+  }
+
+  private async setBadge(count: number): Promise<void> {
+    const viewContext = await this.workspaceEditorContext?.getViewContext(VARIANTS_WORKSPACE_VIEW_ALIAS);
+
+    if (viewContext == null) {
+      return;
+    }
+
+    if (viewContext.hints.has(VARIANT_COUNT_HINT)) {
+      viewContext.hints.removeOne(VARIANT_COUNT_HINT);
+    }
+
+    if (count > 0) {
+      viewContext.hints.addOne({
+        unique: VARIANT_COUNT_HINT,
+        text: String(count),
+        color: 'default',
+      });
+    }
+  }
+
+  private setTabBadge(count: number): void {
+    const apply = (): boolean => {
+      const tab = querySelectorDeep(`[data-mark="workspace:view-link:${VARIANTS_WORKSPACE_VIEW_ALIAS}"]`);
+
+      if (tab == null) {
+        return false;
+      }
+
+      tab.querySelector('[data-ekom-variant-count-badge]')?.remove();
+
+      if (count <= 0) {
+        return true;
+      }
+
+      const iconSlot = tab.querySelector('[slot="icon"]');
+      if (iconSlot == null) {
+        return false;
+      }
+
+      const badge = document.createElement('umb-badge');
+      badge.setAttribute('data-ekom-variant-count-badge', '');
+      badge.setAttribute('color', 'default');
+      badge.textContent = String(count);
+      iconSlot.append(badge);
+
+      return true;
+    };
+
+    if (apply()) {
+      return;
+    }
+
+    window.setTimeout(apply, 100);
+    window.setTimeout(apply, 500);
+  }
+
+  private async fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    return await response.json() as T;
+  }
+}
+
+function querySelectorDeep(selector: string, root: ParentNode = document): Element | null {
+  const match = root.querySelector(selector);
+
+  if (match != null) {
+    return match;
+  }
+
+  const elements = root.querySelectorAll('*');
+
+  for (const element of elements) {
+    if (element.shadowRoot == null) {
+      continue;
+    }
+
+    const shadowMatch = querySelectorDeep(selector, element.shadowRoot);
+    if (shadowMatch != null) {
+      return shadowMatch;
+    }
+  }
+
+  return null;
+}
+
+customElements.define('ekom-variant-count-workspace-footer-app', EkomVariantCountWorkspaceFooterAppElement);
+
+export default EkomVariantCountWorkspaceFooterAppElement;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ekom-variant-count-workspace-footer-app': EkomVariantCountWorkspaceFooterAppElement;
+  }
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
@@ -1,0 +1,1757 @@
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT, UMB_DOCUMENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/document';
+import '@umbraco-cms/backoffice/imaging';
+import '@umbraco-cms/backoffice/media';
+import { UMB_NOTIFICATION_CONTEXT, type UmbNotificationColor } from '@umbraco-cms/backoffice/notification';
+import { UMB_WORKSPACE_VIEW_CONTEXT } from '@umbraco-cms/backoffice/workspace';
+
+type VariantProduct = {
+  id: number;
+  key: string;
+  name: string;
+  title: string;
+  sku: string;
+  variantCount: number;
+  languages: VariantLanguage[];
+  stores: VariantStore[];
+  variantGroupFields: CustomFieldDefinition[];
+  variantFields: CustomFieldDefinition[];
+  groups: VariantGroup[];
+};
+
+type CustomFieldDefinition = {
+  alias: string;
+  label: string;
+  required: boolean;
+};
+
+type CustomField = CustomFieldDefinition & {
+  value: string;
+};
+
+type VariantLanguage = {
+  isoCode?: string;
+  cultureName?: string;
+};
+
+type VariantStore = {
+  alias?: string;
+  title?: string;
+  currencies?: VariantCurrency[];
+};
+
+type VariantCurrency = {
+  currencyValue?: string;
+  currencySymbol?: string;
+  isoCurrencySymbol?: string;
+};
+
+type CurrencyPrice = {
+  Currency?: string;
+  Price?: number;
+  currency?: string;
+  price?: number;
+};
+
+type StockItem = {
+  storeAlias: string;
+  value: number;
+};
+
+type VariantGroup = {
+  id: number;
+  key: string;
+  name: string;
+  title: string;
+  titleValues: Record<string, string>;
+  color: string;
+  images: string;
+  sortOrder: number;
+  changed?: boolean;
+  published: boolean;
+  customFields: CustomField[];
+  variants: VariantItem[];
+};
+
+type VariantItem = {
+  id: number;
+  key: string;
+  name: string;
+  title: string;
+  titleValues: Record<string, string>;
+  sku: string;
+  images: string;
+  priceValues: Record<string, CurrencyPrice[]>;
+  stockValues: StockItem[];
+  customFields: CustomField[];
+  sortOrder: number;
+  changed?: boolean;
+  published: boolean;
+};
+
+type DrawerState =
+  | { type: 'group'; groupId: number }
+  | { type: 'variant'; groupId: number; variantId: number };
+
+const EMPTY_GUID = '00000000-0000-0000-0000-000000000000';
+const VARIANT_COUNT_HINT = 'ekom-variant-count';
+
+type DocumentWorkspaceSaveContext = {
+  requestSave?: () => Promise<void>;
+  requestSubmit?: () => Promise<void>;
+  saveAndPublish?: () => Promise<void>;
+};
+
+class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
+  private notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
+  private workspaceViewContext?: typeof UMB_WORKSPACE_VIEW_CONTEXT.TYPE;
+  private product?: VariantProduct;
+  private loading = true;
+  private saving = false;
+  private error = '';
+  private productId = '';
+  private activeLanguage = '';
+  private nextDraftId = -1;
+  private drawer?: DrawerState;
+  private readonly expandedGroupIds = new Set<number>();
+  private readonly selectedGroupIds = new Set<number>();
+  private readonly selectedVariantIds = new Set<number>();
+  private readonly deletedNodeIds = new Set<number>();
+  private readonly groupSnapshots = new Map<number, string>();
+  private readonly variantSnapshots = new Map<number, string>();
+  private draggedGroupId?: number;
+  private draggedVariant?: { groupId: number; variantId: number };
+  private documentWorkspaceContext?: DocumentWorkspaceSaveContext;
+  private originalRequestSave?: () => Promise<void>;
+  private originalRequestSubmit?: () => Promise<void>;
+  private originalSaveAndPublish?: () => Promise<void>;
+  private publishingWorkspaceContext?: DocumentWorkspaceSaveContext;
+  private originalPublishingSaveAndPublish?: () => Promise<void>;
+  private readonly onKeydown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape' || this.drawer == null) {
+      return;
+    }
+
+    event.stopPropagation();
+    this.syncMediaPickers();
+    this.drawer = undefined;
+    this.render();
+  };
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener('keydown', this.onKeydown);
+    this.consumeContext(UMB_NOTIFICATION_CONTEXT, context => {
+      this.notificationContext = context;
+    });
+
+    this.consumeContext(UMB_WORKSPACE_VIEW_CONTEXT, context => {
+      this.workspaceViewContext = context;
+      this.updateWorkspaceViewBadge();
+    });
+
+    this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, context => {
+      if (context == null) {
+        return;
+      }
+
+      const unique = context.getUnique();
+      if (unique != null) {
+        this.productId = unique;
+      }
+
+      this.patchDocumentSave(context as DocumentWorkspaceSaveContext);
+
+      this.observe(context.unique, value => {
+        if (value == null || value === this.productId) {
+          return;
+        }
+
+        this.productId = value;
+        void this.load();
+      }, 'ekomVariantProductId');
+    });
+
+    this.consumeContext(UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT, context => {
+      if (context == null) {
+        return;
+      }
+
+      this.patchPublishingSave(context as DocumentWorkspaceSaveContext);
+    });
+
+    this.productId = this.getProductIdFromUrl();
+    this.render();
+    if (this.productId) {
+      void this.load();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    window.removeEventListener('keydown', this.onKeydown);
+    this.restoreDocumentSave();
+    this.restorePublishingSave();
+    super.disconnectedCallback();
+  }
+
+  private patchDocumentSave(context: DocumentWorkspaceSaveContext): void {
+    if (this.documentWorkspaceContext === context) {
+      return;
+    }
+
+    this.restoreDocumentSave();
+    this.documentWorkspaceContext = context;
+
+    if (context.requestSave != null) {
+      this.originalRequestSave = context.requestSave.bind(context);
+      context.requestSave = async () => {
+        await this.originalRequestSave?.();
+        await this.saveAfterDocumentSave();
+      };
+    }
+
+    if (context.requestSubmit != null) {
+      this.originalRequestSubmit = context.requestSubmit.bind(context);
+      context.requestSubmit = async () => {
+        await this.originalRequestSubmit?.();
+        await this.saveAfterDocumentSave();
+      };
+    }
+
+    if (context.saveAndPublish != null) {
+      this.originalSaveAndPublish = context.saveAndPublish.bind(context);
+      context.saveAndPublish = async () => {
+        await this.originalSaveAndPublish?.();
+        await this.saveAfterDocumentSave();
+      };
+    }
+  }
+
+  private restoreDocumentSave(): void {
+    if (this.documentWorkspaceContext == null) {
+      return;
+    }
+
+    if (this.originalRequestSave != null) {
+      this.documentWorkspaceContext.requestSave = this.originalRequestSave;
+    }
+
+    if (this.originalRequestSubmit != null) {
+      this.documentWorkspaceContext.requestSubmit = this.originalRequestSubmit;
+    }
+
+    if (this.originalSaveAndPublish != null) {
+      this.documentWorkspaceContext.saveAndPublish = this.originalSaveAndPublish;
+    }
+
+    this.documentWorkspaceContext = undefined;
+    this.originalRequestSave = undefined;
+    this.originalRequestSubmit = undefined;
+    this.originalSaveAndPublish = undefined;
+  }
+
+  private patchPublishingSave(context: DocumentWorkspaceSaveContext): void {
+    if (this.publishingWorkspaceContext === context) {
+      return;
+    }
+
+    this.restorePublishingSave();
+    this.publishingWorkspaceContext = context;
+
+    if (context.saveAndPublish != null) {
+      this.originalPublishingSaveAndPublish = context.saveAndPublish.bind(context);
+      context.saveAndPublish = async () => {
+        await this.originalPublishingSaveAndPublish?.();
+        await this.saveAfterDocumentSave();
+      };
+    }
+  }
+
+  private restorePublishingSave(): void {
+    if (this.publishingWorkspaceContext == null) {
+      return;
+    }
+
+    if (this.originalPublishingSaveAndPublish != null) {
+      this.publishingWorkspaceContext.saveAndPublish = this.originalPublishingSaveAndPublish;
+    }
+
+    this.publishingWorkspaceContext = undefined;
+    this.originalPublishingSaveAndPublish = undefined;
+  }
+
+  private async saveAfterDocumentSave(): Promise<void> {
+    this.syncMediaPickers();
+
+    if (this.product != null && this.hasChanges()) {
+      await this.save();
+    }
+  }
+
+  private async load(): Promise<void> {
+    const productId = this.getProductId();
+
+    if (!productId) {
+      this.loading = false;
+      this.error = 'Could not determine the current product id.';
+      this.showError(this.error);
+      this.render();
+      return;
+    }
+
+    this.loading = true;
+    this.error = '';
+    this.render();
+
+    try {
+      this.product = await this.fetchJson<VariantProduct>(`/ekom/backoffice/Variants/${encodeURIComponent(productId)}`);
+      this.activeLanguage = this.product.languages[0]?.isoCode ?? '';
+      this.drawer = undefined;
+      this.selectedGroupIds.clear();
+      this.selectedVariantIds.clear();
+      this.deletedNodeIds.clear();
+      this.expandedGroupIds.clear();
+      if (this.product.groups.length === 1) {
+        this.expandedGroupIds.add(this.product.groups[0].id);
+      }
+      this.resetSnapshots();
+      this.updateWorkspaceViewBadge();
+    } catch (error) {
+      this.product = undefined;
+      this.updateWorkspaceViewBadge();
+      this.error = getErrorMessage(error, 'Could not load variants.');
+      this.showError(this.error);
+    } finally {
+      this.loading = false;
+      this.render();
+    }
+  }
+
+  private addGroup(): void {
+    if (this.product == null) {
+      return;
+    }
+
+    const id = this.nextDraftId--;
+    const group: VariantGroup = {
+      id,
+      key: EMPTY_GUID,
+      name: 'New group',
+      title: '',
+      titleValues: this.createEmptyTitleValues(),
+      color: '',
+      images: '',
+      sortOrder: this.product.groups.length,
+      published: false,
+      customFields: createCustomFields(this.product.variantGroupFields),
+      variants: [],
+    };
+
+    this.product.groups = [...this.product.groups, group];
+    this.expandedGroupIds.add(id);
+    this.drawer = { type: 'group', groupId: id };
+    this.render();
+  }
+
+  private addVariant(groupId: number): void {
+    const group = this.getGroup(groupId);
+
+    if (group == null) {
+      return;
+    }
+
+    const id = this.nextDraftId--;
+    const variant: VariantItem = {
+      id,
+      key: EMPTY_GUID,
+      name: 'New variant',
+      title: '',
+      titleValues: this.createEmptyTitleValues(),
+      sku: '',
+      images: '',
+      priceValues: {},
+      stockValues: this.createEmptyStockValues(),
+      customFields: createCustomFields(this.product?.variantFields ?? []),
+      sortOrder: group.variants.length,
+      published: false,
+    };
+
+    group.variants = [...group.variants, variant];
+    this.expandedGroupIds.add(groupId);
+    this.drawer = { type: 'variant', groupId, variantId: id };
+    this.render();
+  }
+
+  private async save(): Promise<void> {
+    this.syncMediaPickers();
+
+    if (!this.validateAllCustomFields()) {
+      return;
+    }
+
+    if (this.product == null || !this.hasChanges()) {
+      this.showNotification('default', 'Variants', 'No changes to save.');
+      return;
+    }
+
+    const groups = this.product.groups
+      .map(group => this.getChangedGroupForSave(group))
+      .filter(group => group != null);
+
+    this.saving = true;
+    this.error = '';
+    this.render();
+
+    try {
+      for (const id of this.deletedNodeIds) {
+        await this.deleteJson(`/ekom/backoffice/Variants/${encodeURIComponent(String(id))}`);
+      }
+
+      if (groups.length > 0) {
+        this.product = await this.postJson<VariantProduct>('/ekom/backoffice/Variants/Save', {
+          productId: this.getProductId(),
+          publish: true,
+          groups,
+        });
+      } else {
+        await this.load();
+      }
+
+      this.selectedGroupIds.clear();
+      this.selectedVariantIds.clear();
+      this.deletedNodeIds.clear();
+      this.drawer = undefined;
+      this.expandedGroupIds.clear();
+      if (this.product?.groups.length === 1) {
+        this.expandedGroupIds.add(this.product.groups[0].id);
+      }
+      this.resetSnapshots();
+      this.updateWorkspaceViewBadge();
+      this.showSuccess('Variant changes were saved.');
+    } catch (error) {
+      this.error = getErrorMessage(error, 'Action failed.');
+      this.showError(this.error);
+    } finally {
+      this.saving = false;
+      this.render();
+    }
+  }
+
+  private deleteSelected(): void {
+    if (this.product == null) {
+      return;
+    }
+
+    const selectedCount = this.selectedGroupIds.size + this.selectedVariantIds.size;
+
+    if (selectedCount === 0 || !window.confirm(`Delete ${selectedCount} selected item${selectedCount === 1 ? '' : 's'}?`)) {
+      return;
+    }
+
+    for (const group of this.product.groups) {
+      if (this.selectedGroupIds.has(group.id) && !isDraft(group.id)) {
+        this.deletedNodeIds.add(group.id);
+      }
+
+      for (const variant of group.variants) {
+        if (this.selectedVariantIds.has(variant.id) && !isDraft(variant.id)) {
+          this.deletedNodeIds.add(variant.id);
+        }
+      }
+    }
+
+    this.product.groups = this.product.groups
+      .filter(group => !this.selectedGroupIds.has(group.id))
+      .map(group => ({
+        ...group,
+        variants: group.variants.filter(variant => !this.selectedVariantIds.has(variant.id)),
+      }));
+
+    this.selectedGroupIds.clear();
+    this.selectedVariantIds.clear();
+    this.drawer = undefined;
+    this.render();
+  }
+
+  private deleteDrawerItem(): void {
+    if (this.product == null || this.drawer == null) {
+      return;
+    }
+
+    const drawer = this.drawer;
+    const isGroup = drawer.type === 'group';
+    const label = isGroup ? 'variant group' : 'variant';
+
+    if (!window.confirm(`Delete this ${label}?`)) {
+      return;
+    }
+
+    if (isGroup) {
+      const group = this.getGroup(drawer.groupId);
+
+      if (group != null && !isDraft(group.id)) {
+        this.deletedNodeIds.add(group.id);
+      }
+
+      this.product.groups = this.product.groups.filter(item => item.id !== drawer.groupId);
+    } else {
+      const group = this.getGroup(drawer.groupId);
+      const variant = this.getVariant(drawer.groupId, drawer.variantId);
+
+      if (variant != null && !isDraft(variant.id)) {
+        this.deletedNodeIds.add(variant.id);
+      }
+
+      if (group != null) {
+        group.variants = group.variants.filter(item => item.id !== drawer.variantId);
+      }
+    }
+
+    this.drawer = undefined;
+    this.render();
+  }
+
+  private updateGroupTitle(groupId: number, value: string): void {
+    const group = this.getGroup(groupId);
+
+    if (group != null) {
+      group.titleValues = { ...group.titleValues, [this.activeLanguage]: value };
+      group.title = getFirstValue(group.titleValues) || group.name;
+      this.updateSaveButtonState();
+    }
+  }
+
+  private updateGroupImages(groupId: number, value: string): void {
+    const group = this.getGroup(groupId);
+
+    if (group != null) {
+      group.images = value;
+      this.updateSaveButtonState();
+    }
+  }
+
+  private updateVariantTitle(groupId: number, variantId: number, value: string): void {
+    const variant = this.getVariant(groupId, variantId);
+
+    if (variant != null) {
+      variant.titleValues = { ...variant.titleValues, [this.activeLanguage]: value };
+      variant.title = getFirstValue(variant.titleValues) || variant.name;
+      this.updateSaveButtonState();
+    }
+  }
+
+  private updateVariant(groupId: number, variantId: number, field: 'sku' | 'images', value: string): void {
+    const variant = this.getVariant(groupId, variantId);
+
+    if (variant != null) {
+      variant[field] = value;
+      this.updateSaveButtonState();
+    }
+  }
+
+  private updatePrice(groupId: number, variantId: number, storeAlias: string, currency: string, value: string): void {
+    const variant = this.getVariant(groupId, variantId);
+
+    if (variant == null) {
+      return;
+    }
+
+    const prices = [...(variant.priceValues[storeAlias] ?? [])];
+    const price = Number(value) || 0;
+    const existing = prices.find(item => getCurrency(item) === currency);
+
+    if (existing != null) {
+      existing.Price = price;
+      existing.price = price;
+    } else {
+      prices.push({ Currency: currency, Price: price });
+    }
+
+    variant.priceValues = { ...variant.priceValues, [storeAlias]: prices };
+    this.updateSaveButtonState();
+  }
+
+  private updateStock(groupId: number, variantId: number, storeAlias: string, value: string): void {
+    const variant = this.getVariant(groupId, variantId);
+
+    if (variant == null) {
+      return;
+    }
+
+    const stock = Number(value) || 0;
+    let updated = false;
+    const stocks = variant.stockValues.map(item => {
+      if (item.storeAlias !== storeAlias) {
+        return item;
+      }
+
+      updated = true;
+      return { ...item, value: stock };
+    });
+
+    if (!updated) {
+      stocks.push({ storeAlias, value: stock });
+    }
+
+    variant.stockValues = stocks;
+    this.updateSaveButtonState();
+  }
+
+  private hasChanges(): boolean {
+    return this.deletedNodeIds.size > 0 || (this.product?.groups ?? []).some(group => this.isGroupChanged(group) || group.variants.some(variant => this.isVariantChanged(variant)));
+  }
+
+  private updateWorkspaceViewBadge(): void {
+    if (this.workspaceViewContext == null) {
+      return;
+    }
+
+    if (this.workspaceViewContext.hints.has(VARIANT_COUNT_HINT)) {
+      this.workspaceViewContext.hints.removeOne(VARIANT_COUNT_HINT);
+    }
+
+    const count = this.product?.variantCount ?? 0;
+    if (count > 0) {
+      this.workspaceViewContext.hints.addOne({
+        unique: VARIANT_COUNT_HINT,
+        text: String(count),
+        color: 'default',
+      });
+    }
+  }
+
+  private getChangedGroupForSave(group: VariantGroup): VariantGroup | null {
+    const variants = group.variants
+      .filter(variant => this.isVariantChanged(variant))
+      .map(variant => ({
+        ...variant,
+        priceValues: normalizePriceValues(variant.priceValues, this.product?.stores ?? []),
+        changed: true,
+      }));
+
+    if (!this.isGroupChanged(group) && variants.length === 0) {
+      return null;
+    }
+
+    return {
+      ...group,
+      changed: this.isGroupChanged(group),
+      variants,
+    };
+  }
+
+  private isGroupChanged(group: VariantGroup): boolean {
+    return isDraft(group.id) || this.groupSnapshots.get(group.id) !== snapshotGroup(group);
+  }
+
+  private isVariantChanged(variant: VariantItem): boolean {
+    return isDraft(variant.id) || this.variantSnapshots.get(variant.id) !== snapshotVariant(variant);
+  }
+
+  private getGroup(groupId: number): VariantGroup | undefined {
+    return this.product?.groups.find(group => group.id === groupId);
+  }
+
+  private getVariant(groupId: number, variantId: number): VariantItem | undefined {
+    return this.getGroup(groupId)?.variants.find(item => item.id === variantId);
+  }
+
+  private resetSnapshots(): void {
+    this.groupSnapshots.clear();
+    this.variantSnapshots.clear();
+
+    for (const group of this.product?.groups ?? []) {
+      this.groupSnapshots.set(group.id, snapshotGroup(group));
+
+      for (const variant of group.variants) {
+        this.variantSnapshots.set(variant.id, snapshotVariant(variant));
+      }
+    }
+  }
+
+  private createEmptyTitleValues(): Record<string, string> {
+    const values: Record<string, string> = {};
+
+    for (const language of this.product?.languages ?? []) {
+      values[language.isoCode ?? ''] = '';
+    }
+
+    return values;
+  }
+
+  private createEmptyStockValues(): StockItem[] {
+    return (this.product?.stores ?? []).map(store => ({ storeAlias: store.alias ?? '', value: 0 }));
+  }
+
+  private showSuccess(message: string): void {
+    this.showNotification('positive', 'Success', message);
+  }
+
+  private showError(message: string): void {
+    this.showNotification('danger', 'Error', message);
+  }
+
+  private showNotification(color: UmbNotificationColor, headline: string, message: string): void {
+    if (this.notificationContext) {
+      this.notificationContext.peek(color, {
+        data: {
+          headline,
+          message,
+        },
+      });
+      return;
+    }
+
+    if (color === 'danger') {
+      console.error(`${headline}: ${message}`);
+    }
+  }
+
+  private render(): void {
+    this.innerHTML = `
+      <style>${styles}</style>
+      <section class="ekm-variant-editor">
+        ${this.renderTopBar()}
+        ${this.error ? `<p class="status status--error">${escapeHtml(this.error)}</p>` : ''}
+        ${this.loading ? '<uui-loader></uui-loader><p>Loading variants...</p>' : this.renderBody()}
+        ${this.renderDrawer()}
+      </section>
+    `;
+
+    this.bindEvents();
+  }
+
+  private renderTopBar(): string {
+    const selectedCount = this.selectedGroupIds.size + this.selectedVariantIds.size;
+    const dirty = this.hasChanges();
+
+    return `
+      <div class="top-bar">
+        <div class="selection-actions">
+          ${selectedCount > 0 ? `
+            <span>${selectedCount} selected</span>
+            <uui-button look="secondary" color="danger" data-action="delete-selected" ${this.saving ? 'disabled' : ''}>Delete</uui-button>
+          ` : ''}
+        </div>
+        <div class="main-actions">
+          <uui-button look="primary" data-action="create-group" ${this.saving ? 'disabled' : ''}>Add group</uui-button>
+          <uui-button look="primary" color="positive" data-action="save" ${this.saving || !dirty ? 'disabled' : ''}>Save variant changes</uui-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderBody(): string {
+    if (this.product == null) {
+      return '';
+    }
+
+    if (this.product.groups.length === 0) {
+      return `
+        <uui-box headline="No variants yet">
+          <p>Create a variant group to start adding product variants.</p>
+          <uui-button look="primary" data-action="create-group">Create variant group</uui-button>
+        </uui-box>
+      `;
+    }
+
+    return `
+      <div class="group-list">
+        ${this.product.groups.map(group => this.renderGroup(group)).join('')}
+      </div>
+    `;
+  }
+
+  private renderGroup(group: VariantGroup): string {
+    const expanded = this.expandedGroupIds.has(group.id);
+    const title = this.getTitle(group, 'New group');
+    const thumbnailImage = getGroupThumbnailImage(group);
+
+    return `
+      <article class="group-card ${isDraft(group.id) ? 'is-draft' : ''}" draggable="true" data-drag-group-id="${group.id}">
+        <div class="group-header">
+          <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+          <input type="checkbox" data-select-group data-group-id="${group.id}" ${this.selectedGroupIds.has(group.id) ? 'checked' : ''} aria-label="Select group">
+          <button type="button" class="group-toggle" data-action="toggle-group" data-group-id="${group.id}" aria-label="Toggle group">${expanded ? '▼' : '►'}</button>
+          <button type="button" class="thumb thumb--button" data-action="toggle-group" data-group-id="${group.id}">${renderThumbnail(thumbnailImage, title)}</button>
+          <button type="button" class="group-title" data-action="toggle-group" data-group-id="${group.id}">${escapeHtml(title)}</button>
+          <span class="count">${group.variants.length} variants</span>
+          ${isDraft(group.id) ? '<span class="badge">draft</span>' : ''}
+          <div class="group-header-actions">
+            <uui-button compact look="secondary" data-action="edit-group" data-group-id="${group.id}">Edit group</uui-button>
+            <uui-button compact look="secondary" data-action="create-variant" data-group-id="${group.id}">Add variant</uui-button>
+          </div>
+        </div>
+        ${expanded ? this.renderVariants(group) : ''}
+      </article>
+    `;
+  }
+
+  private renderVariants(group: VariantGroup): string {
+    return `
+      <div class="variant-table">
+        <div class="variant-head">
+          <span></span><span></span><span></span><span>Title</span><span>SKU</span><span class="variant-price-cell">Price</span><span class="variant-stock-cell">Stock</span><span></span>
+        </div>
+        ${group.variants.map(variant => this.renderVariant(group, variant)).join('')}
+      </div>
+    `;
+  }
+
+  private renderVariant(group: VariantGroup, variant: VariantItem): string {
+    return `
+      <div class="variant-row ${isDraft(variant.id) ? 'is-draft' : ''}" draggable="true" data-drag-group-id="${group.id}" data-drag-variant-id="${variant.id}">
+        <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+        <input type="checkbox" data-select-variant data-variant-id="${variant.id}" ${this.selectedVariantIds.has(variant.id) ? 'checked' : ''} aria-label="Select variant">
+        <span class="thumb">${renderThumbnail(getFirstImage(variant.images), this.getTitle(variant, 'New variant'))}</span>
+        <strong>${escapeHtml(this.getTitle(variant, 'New variant'))}${isDraft(variant.id) ? ' <span class="badge">draft</span>' : ''}</strong>
+        <span>${escapeHtml(variant.sku)}</span>
+        <span class="variant-price-cell">${escapeHtml(this.getDefaultPrice(variant))}</span>
+        <span class="variant-stock-cell">${escapeHtml(this.getTotalStock(variant))}</span>
+        <uui-button compact look="secondary" data-action="edit-variant" data-group-id="${group.id}" data-variant-id="${variant.id}">Edit</uui-button>
+      </div>
+    `;
+  }
+
+  private renderDrawer(): string {
+    if (this.drawer == null || this.product == null) {
+      return '';
+    }
+
+    const group = this.getGroup(this.drawer.groupId);
+
+    if (group == null) {
+      return '';
+    }
+
+    if (this.drawer.type === 'group') {
+      return this.renderGroupDrawer(group);
+    }
+
+    const variant = this.getVariant(this.drawer.groupId, this.drawer.variantId);
+    return variant == null ? '' : this.renderVariantDrawer(group, variant);
+  }
+
+  private renderGroupDrawer(group: VariantGroup): string {
+    return `
+      <div class="drawer-backdrop" data-action="close-drawer"></div>
+      <aside class="drawer">
+        ${this.renderDrawerHeader(this.getTitle(group, 'New group'), 'variant group', group)}
+        <div class="drawer-body">
+          ${this.renderTitleField('Group title', group.titleValues?.[this.activeLanguage] ?? '', 'data-group-title', group.id)}
+          ${this.renderCustomFields(group.customFields, group.id)}
+          ${this.renderMediaPicker('Images', group.images, 'data-group-images', group.id)}
+          <p class="hint">Group images apply to all variants unless a variant has its own.</p>
+        </div>
+        ${this.renderDrawerFooter()}
+      </aside>
+    `;
+  }
+
+  private renderVariantDrawer(group: VariantGroup, variant: VariantItem): string {
+    return `
+      <div class="drawer-backdrop" data-action="close-drawer"></div>
+      <aside class="drawer">
+        ${this.renderDrawerHeader(this.getTitle(variant, 'New variant'), `${this.getTitle(group, 'Group')} / variant`, variant)}
+        <div class="drawer-body">
+          ${this.renderTitleField('Title', variant.titleValues?.[this.activeLanguage] ?? '', 'data-variant-title', group.id, variant.id)}
+          <label>SKU<input data-variant-field="sku" data-group-id="${group.id}" data-variant-id="${variant.id}" value="${escapeHtml(variant.sku)}"></label>
+          ${this.renderCustomFields(variant.customFields, group.id, variant.id)}
+          ${this.renderPriceTable(group.id, variant)}
+          ${this.renderStockTable(group.id, variant)}
+          ${this.renderMediaPicker('Images', variant.images, 'data-variant-images', group.id, variant.id)}
+        </div>
+        ${this.renderDrawerFooter()}
+      </aside>
+    `;
+  }
+
+  private renderDrawerHeader(title: string, subtitle: string, item: VariantGroup | VariantItem): string {
+    const href = !isDraft(item.id) && item.key ? `/umbraco/section/content/workspace/document/edit/${item.key}` : '';
+
+    return `
+      <header class="drawer-header">
+        <div class="drawer-title">
+          <h2>${escapeHtml(title)}</h2>
+          <p>${escapeHtml(subtitle)}</p>
+        </div>
+        <div class="drawer-header-actions">
+          ${href ? `<uui-button compact look="secondary" href="${href}" target="_blank" rel="noopener" title="Open node in new tab" aria-label="Open node in new tab"><span class="edit-icon" aria-hidden="true">✎</span></uui-button>` : ''}
+          <button type="button" class="close-button" data-action="close-drawer" aria-label="Close">×</button>
+        </div>
+      </header>
+    `;
+  }
+
+  private renderDrawerFooter(): string {
+    return `
+      <footer class="drawer-footer">
+        <div class="drawer-footer-left">
+          <button type="button" class="danger-button" data-action="delete-drawer-item">Delete</button>
+        </div>
+        <div class="drawer-footer-right">
+          <uui-button look="secondary" data-action="close-drawer">Close</uui-button>
+          <uui-button look="primary" color="positive" data-action="save-drawer">Save</uui-button>
+        </div>
+      </footer>
+    `;
+  }
+
+  private renderTitleField(label: string, value: string, attribute: string, groupId: number, variantId = 0): string {
+    return `
+      <label>${escapeHtml(label)}
+        ${this.renderLanguageMiniTabs()}
+        <input ${attribute} data-group-id="${groupId}" data-variant-id="${variantId}" value="${escapeHtml(value)}">
+      </label>
+    `;
+  }
+
+  private renderLanguageMiniTabs(): string {
+    const languages = this.product?.languages ?? [];
+
+    if (languages.length <= 1) {
+      return '';
+    }
+
+    return `
+      <div class="mini-tabs">
+        ${languages.map(language => {
+          const value = language.isoCode ?? '';
+          return `<button type="button" data-action="set-language" data-tab-value="${escapeHtml(value)}" class="mini-tab ${value === this.activeLanguage ? 'active' : ''}">${escapeHtml(getLanguageLabel(language))}</button>`;
+        }).join('')}
+      </div>
+    `;
+  }
+
+  private renderCustomFields(fields: CustomField[] | undefined, groupId: number, variantId = 0): string {
+    if (!fields?.length) {
+      return '';
+    }
+
+    return fields.map(field => `
+      <label>${escapeHtml(field.label)}${field.required ? ' *' : ''}
+        <input data-custom-field data-custom-field-alias="${escapeHtml(field.alias)}" data-group-id="${groupId}" data-variant-id="${variantId}" value="${escapeHtml(field.value ?? '')}" ${field.required ? 'required' : ''}>
+      </label>
+    `).join('');
+  }
+
+  private renderPriceTable(groupId: number, variant: VariantItem): string {
+    return `
+      <section>
+        <h3>Prices</h3>
+        <table>
+          <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
+          <tbody>
+            ${(this.product?.stores ?? []).flatMap(store => (store.currencies ?? []).map(currency => {
+              const storeAlias = store.alias ?? '';
+              const currencyValue = currency.currencyValue ?? '';
+              const price = getPrice(variant.priceValues?.[storeAlias]?.find(item => getCurrency(item) === currencyValue));
+              return `<tr><td>${escapeHtml(store.title ?? storeAlias)}</td><td>${escapeHtml(currency.isoCurrencySymbol ?? currencyValue)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${escapeHtml(storeAlias)}" data-price-currency="${escapeHtml(currencyValue)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(price)}"></td></tr>`;
+            })).join('')}
+          </tbody>
+        </table>
+      </section>
+    `;
+  }
+
+  private renderStockTable(groupId: number, variant: VariantItem): string {
+    const stockItems = variant.stockValues.length > 0 ? variant.stockValues : this.createEmptyStockValues();
+
+    if (stockItems.length <= 1) {
+      const stock = stockItems[0]?.value ?? 0;
+      const storeAlias = stockItems[0]?.storeAlias ?? '';
+      return `<label>Stock<input class="numeric" type="number" min="0" step="any" data-stock data-stock-store="${escapeHtml(storeAlias)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(stock)}"></label>`;
+    }
+
+    return `
+      <section>
+        <h3>Stock</h3>
+        <table>
+          <thead><tr><th>Store</th><th>Stock</th></tr></thead>
+          <tbody>
+            ${stockItems.map(stock => `<tr><td>${escapeHtml(this.getStoreTitle(stock.storeAlias))}</td><td><input class="numeric" type="number" min="0" step="any" data-stock data-stock-store="${escapeHtml(stock.storeAlias)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(stock.value)}"></td></tr>`).join('')}
+          </tbody>
+        </table>
+      </section>
+    `;
+  }
+
+  private renderMediaPicker(label: string, value: string, attribute: string, groupId: number, variantId = 0): string {
+    return `
+      <div class="media-field">
+        <span class="field-label">${escapeHtml(label)}</span>
+        <umb-input-media ${attribute} max="100" value="${escapeHtml(value ?? '')}" data-group-id="${groupId}" data-variant-id="${variantId}" data-value="${escapeHtml(value ?? '')}"></umb-input-media>
+      </div>
+    `;
+  }
+
+  private bindEvents(): void {
+    this.querySelectorAll('[data-action="create-group"]').forEach(button => {
+      button.addEventListener('click', () => this.addGroup());
+    });
+
+    this.querySelector('[data-action="save"]')?.addEventListener('click', () => void this.save());
+    this.querySelector('[data-action="delete-selected"]')?.addEventListener('click', () => this.deleteSelected());
+    this.querySelector('[data-action="delete-drawer-item"]')?.addEventListener('click', () => this.deleteDrawerItem());
+
+    this.querySelector('[data-action="save-drawer"]')?.addEventListener('click', () => {
+      this.syncMediaPickers();
+
+      if (!this.validateDrawerCustomFields()) {
+        return;
+      }
+
+      this.drawer = undefined;
+      this.render();
+    });
+
+    this.querySelectorAll('[data-action="close-drawer"]').forEach(button => {
+      button.addEventListener('click', () => {
+        this.syncMediaPickers();
+        this.drawer = undefined;
+        this.render();
+      });
+    });
+
+    this.querySelectorAll('[data-action="set-language"]').forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.setActiveLanguage((button as HTMLElement).dataset.tabValue ?? '');
+      });
+    });
+
+    this.querySelectorAll('[data-action="toggle-group"]').forEach(button => {
+      button.addEventListener('click', () => this.toggleGroup(Number((button as HTMLElement).dataset.groupId)));
+    });
+
+    this.querySelectorAll('[data-action="edit-group"]').forEach(button => {
+      button.addEventListener('click', () => {
+        this.drawer = { type: 'group', groupId: Number((button as HTMLElement).dataset.groupId) };
+        this.render();
+      });
+    });
+
+    this.querySelectorAll('[data-action="create-variant"]').forEach(button => {
+      button.addEventListener('click', () => this.addVariant(Number((button as HTMLElement).dataset.groupId)));
+    });
+
+    this.querySelectorAll('[data-action="edit-variant"]').forEach(button => {
+      button.addEventListener('click', () => {
+        const element = button as HTMLElement;
+        this.drawer = { type: 'variant', groupId: Number(element.dataset.groupId), variantId: Number(element.dataset.variantId) };
+        this.render();
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-select-group]').forEach(field => {
+      field.addEventListener('change', () => {
+        this.toggleSet(this.selectedGroupIds, Number(field.dataset.groupId), field.checked);
+        this.render();
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-select-variant]').forEach(field => {
+      field.addEventListener('change', () => {
+        this.toggleSet(this.selectedVariantIds, Number(field.dataset.variantId), field.checked);
+        this.render();
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-group-title]').forEach(field => {
+      field.addEventListener('input', event => {
+        event.stopPropagation();
+        this.updateGroupTitle(Number(field.dataset.groupId), field.value);
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-variant-title]').forEach(field => {
+      field.addEventListener('input', event => {
+        event.stopPropagation();
+        this.updateVariantTitle(Number(field.dataset.groupId), Number(field.dataset.variantId), field.value);
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-variant-field]').forEach(field => {
+      field.addEventListener('input', event => {
+        event.stopPropagation();
+        this.updateVariant(Number(field.dataset.groupId), Number(field.dataset.variantId), 'sku', field.value);
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-custom-field]').forEach(field => {
+      field.addEventListener('input', event => {
+        event.stopPropagation();
+        this.updateCustomField(Number(field.dataset.groupId), Number(field.dataset.variantId), field.dataset.customFieldAlias ?? '', field.value);
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-price]').forEach(field => {
+      field.addEventListener('input', event => {
+        event.stopPropagation();
+        this.updatePrice(Number(field.dataset.groupId), Number(field.dataset.variantId), field.dataset.priceStore ?? '', field.dataset.priceCurrency ?? '', field.value);
+      });
+    });
+
+    this.querySelectorAll<HTMLInputElement>('[data-stock]').forEach(field => {
+      field.addEventListener('input', event => {
+        event.stopPropagation();
+        this.updateStock(Number(field.dataset.groupId), Number(field.dataset.variantId), field.dataset.stockStore ?? '', field.value);
+      });
+    });
+
+    this.bindDragAndDrop();
+    this.bindMediaPickers();
+  }
+
+  private bindDragAndDrop(): void {
+    this.querySelectorAll<HTMLElement>('.group-card[data-drag-group-id]').forEach(card => {
+      card.addEventListener('dragstart', event => {
+        this.draggedGroupId = Number(card.dataset.dragGroupId);
+        event.dataTransfer?.setData('text/plain', `group:${this.draggedGroupId}`);
+        event.dataTransfer?.setDragImage(card, 20, 20);
+      });
+
+      card.addEventListener('dragover', event => {
+        if (this.draggedGroupId != null) {
+          event.preventDefault();
+        }
+      });
+
+      card.addEventListener('drop', event => {
+        event.preventDefault();
+        this.reorderGroup(this.draggedGroupId, Number(card.dataset.dragGroupId));
+        this.draggedGroupId = undefined;
+      });
+
+      card.addEventListener('dragend', () => {
+        this.draggedGroupId = undefined;
+      });
+    });
+
+    this.querySelectorAll<HTMLElement>('.variant-row[data-drag-variant-id]').forEach(row => {
+      row.addEventListener('dragstart', event => {
+        this.draggedVariant = {
+          groupId: Number(row.dataset.dragGroupId),
+          variantId: Number(row.dataset.dragVariantId),
+        };
+        event.stopPropagation();
+        event.dataTransfer?.setData('text/plain', `variant:${this.draggedVariant.groupId}:${this.draggedVariant.variantId}`);
+      });
+
+      row.addEventListener('dragover', event => {
+        if (this.draggedVariant?.groupId === Number(row.dataset.dragGroupId)) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      });
+
+      row.addEventListener('drop', event => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.reorderVariant(this.draggedVariant, Number(row.dataset.dragGroupId), Number(row.dataset.dragVariantId));
+        this.draggedVariant = undefined;
+      });
+
+      row.addEventListener('dragend', event => {
+        event.stopPropagation();
+        this.draggedVariant = undefined;
+      });
+    });
+  }
+
+  private bindMediaPickers(): void {
+    this.querySelectorAll<HTMLElement>('[data-group-images], [data-variant-images]').forEach(field => {
+      const mediaPicker = field as HTMLElement & { value?: string; selection?: string[] };
+      const value = field.dataset.value ?? '';
+      const selection = splitImages(value);
+      mediaPicker.value = selection.join(',');
+      mediaPicker.selection = selection;
+      void setupMediaPickerSorterDetailPatch(mediaPicker);
+      field.addEventListener('change', async event => {
+        const groupId = Number(field.dataset.groupId);
+        const variantId = Number(field.dataset.variantId);
+        event.stopPropagation();
+
+        await Promise.resolve();
+
+        const nextValue = getMediaPickerValue(mediaPicker);
+        await clearMediaPickerSorterDetails(mediaPicker);
+
+        if (variantId !== 0) {
+          this.updateVariant(groupId, variantId, 'images', nextValue);
+        } else {
+          this.updateGroupImages(groupId, nextValue);
+        }
+      });
+    });
+  }
+
+  private syncMediaPickers(): void {
+    this.querySelectorAll<HTMLElement>('[data-group-images], [data-variant-images]').forEach(field => {
+      const mediaPicker = field as HTMLElement & { value?: string; selection?: string[] };
+      const groupId = Number(field.dataset.groupId);
+      const variantId = Number(field.dataset.variantId);
+      const nextValue = getMediaPickerValue(mediaPicker);
+
+      if (variantId !== 0) {
+        const variant = this.getVariant(groupId, variantId);
+
+        if (variant != null && variant.images !== nextValue) {
+          variant.images = nextValue;
+        }
+
+        return;
+      }
+
+      const group = this.getGroup(groupId);
+
+      if (group != null && group.images !== nextValue) {
+        group.images = nextValue;
+      }
+    });
+
+    this.updateSaveButtonState();
+  }
+
+  private updateSaveButtonState(): void {
+    const saveButton = this.querySelector<HTMLElement>('[data-action="save"]');
+
+    if (saveButton != null) {
+      saveButton.toggleAttribute('disabled', this.saving || !this.hasChanges());
+    }
+  }
+
+  private updateCustomField(groupId: number, variantId: number, alias: string, value: string): void {
+    const item = variantId !== 0
+      ? this.getVariant(groupId, variantId)
+      : this.getGroup(groupId);
+
+    const field = item?.customFields?.find(customField => customField.alias === alias);
+    if (field != null) {
+      field.value = value;
+    }
+
+    this.updateSaveButtonState();
+  }
+
+  private validateDrawerCustomFields(): boolean {
+    if (this.drawer == null) {
+      return true;
+    }
+
+    const item = this.drawer.type === 'group'
+      ? this.getGroup(this.drawer.groupId)
+      : this.getVariant(this.drawer.groupId, this.drawer.variantId);
+
+    return this.validateCustomFields(item?.customFields);
+  }
+
+  private validateAllCustomFields(): boolean {
+    for (const group of this.product?.groups ?? []) {
+      if (!this.validateCustomFields(group.customFields, false)) {
+        return false;
+      }
+
+      for (const variant of group.variants) {
+        if (!this.validateCustomFields(variant.customFields, false)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private validateCustomFields(fields: CustomField[] | undefined, render = true): boolean {
+    const missing = fields?.find(field => field.required && !field.value?.trim());
+
+    if (missing == null) {
+      return true;
+    }
+
+    this.showError(`${missing.label} is required.`);
+    if (render) {
+      this.render();
+    }
+
+    return false;
+  }
+
+  private reorderGroup(sourceId: number | undefined, targetId: number): void {
+    if (this.product == null || sourceId == null || sourceId === targetId) {
+      return;
+    }
+
+    this.product.groups = reorderById(this.product.groups, sourceId, targetId);
+    this.product.groups.forEach((group, index) => {
+      group.sortOrder = index;
+    });
+    this.render();
+  }
+
+  private reorderVariant(source: { groupId: number; variantId: number } | undefined, targetGroupId: number, targetVariantId: number): void {
+    if (source == null || source.groupId !== targetGroupId || source.variantId === targetVariantId) {
+      return;
+    }
+
+    const group = this.getGroup(source.groupId);
+
+    if (group == null) {
+      return;
+    }
+
+    group.variants = reorderById(group.variants, source.variantId, targetVariantId);
+    group.variants.forEach((variant, index) => {
+      variant.sortOrder = index;
+    });
+    this.render();
+  }
+
+  private setActiveLanguage(value: string): void {
+    this.activeLanguage = value;
+
+    this.querySelectorAll<HTMLElement>('[data-action="set-language"]').forEach(button => {
+      button.classList.toggle('active', button.dataset.tabValue === value);
+    });
+
+    if (this.drawer == null) {
+      return;
+    }
+
+    if (this.drawer.type === 'group') {
+      const group = this.getGroup(this.drawer.groupId);
+      const field = this.querySelector<HTMLInputElement>('[data-group-title]');
+
+      if (group != null && field != null) {
+        field.value = group.titleValues?.[value] ?? '';
+      }
+
+      return;
+    }
+
+    const variant = this.getVariant(this.drawer.groupId, this.drawer.variantId);
+    const field = this.querySelector<HTMLInputElement>('[data-variant-title]');
+
+    if (variant != null && field != null) {
+      field.value = variant.titleValues?.[value] ?? '';
+    }
+  }
+
+  private toggleGroup(groupId: number): void {
+    if (this.expandedGroupIds.has(groupId)) {
+      this.expandedGroupIds.delete(groupId);
+    } else {
+      this.expandedGroupIds.add(groupId);
+    }
+
+    this.render();
+  }
+
+  private toggleSet(set: Set<number>, id: number, selected: boolean): void {
+    if (selected) {
+      set.add(id);
+    } else {
+      set.delete(id);
+    }
+  }
+
+  private getTitle(item: VariantGroup | VariantItem, fallback: string): string {
+    return item.titleValues?.[this.activeLanguage] || getFirstValue(item.titleValues) || item.title || item.name || fallback;
+  }
+
+  private getDefaultPrice(variant: VariantItem): string {
+    const store = this.product?.stores[0];
+    const currency = store?.currencies?.[0];
+
+    if (store == null || currency == null) {
+      return '—';
+    }
+
+    const value = getPrice(variant.priceValues?.[store.alias ?? '']?.find(item => getCurrency(item) === (currency.currencyValue ?? '')));
+    const symbol = currency.currencySymbol ?? currency.isoCurrencySymbol ?? currency.currencyValue ?? '';
+    return `${formatNumber(value)} ${symbol}`.trim();
+  }
+
+  private getTotalStock(variant: VariantItem): string {
+    if (variant.stockValues.length === 0) {
+      return '0';
+    }
+
+    return formatNumber(variant.stockValues.reduce((total, stock) => total + (Number(stock.value) || 0), 0));
+  }
+
+  private getStoreTitle(alias: string): string {
+    return this.product?.stores.find(store => store.alias === alias)?.title ?? alias;
+  }
+
+  private getProductId(): string {
+    return this.productId || this.getProductIdFromUrl();
+  }
+
+  private getProductIdFromUrl(): string {
+    const href = window.location.href;
+    const guidMatch = href.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+
+    if (guidMatch != null) {
+      return guidMatch[0];
+    }
+
+    const editSegmentMatch = href.match(/\/edit\/([^/?#]+)/i);
+    return editSegmentMatch?.[1] ?? '';
+  }
+
+  private async fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url, { credentials: 'same-origin', headers: { Accept: 'application/json' } });
+    return parseJsonResponse<T>(response);
+  }
+
+  private async postJson<T = unknown>(url: string, body: unknown): Promise<T> {
+    const response = await fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    return parseJsonResponse<T>(response);
+  }
+
+  private async deleteJson(url: string): Promise<void> {
+    const response = await fetch(url, { method: 'DELETE', credentials: 'same-origin', headers: { Accept: 'application/json' } });
+    await parseJsonResponse(response);
+  }
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new Error(await response.text() || 'Request failed.');
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.length > 0 ? error.message : fallback;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function getFirstValue(values: Record<string, string>): string {
+  return Object.values(values ?? {}).find(value => value != null && value.trim().length > 0) ?? '';
+}
+
+function getLanguageLabel(language: VariantLanguage): string {
+  const value = language.isoCode ?? language.cultureName ?? '';
+  return value.split('-')[0].toUpperCase();
+}
+
+function getCurrency(price: CurrencyPrice): string {
+  return price.Currency ?? price.currency ?? '';
+}
+
+function getPrice(price: CurrencyPrice | undefined): number {
+  return price?.Price ?? price?.price ?? 0;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function splitImages(value: string): string[] {
+  const rawValue = String(value ?? '').trim();
+
+  if (rawValue.length === 0) {
+    return [];
+  }
+
+  if (rawValue.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(rawValue) as Array<Record<string, unknown>>;
+      return parsed
+        .map(item => String(item.mediaKey ?? item.key ?? '').trim())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  return rawValue.split(',').map(item => normalizeMediaIdentifier(item.trim())).filter(Boolean);
+}
+
+function getFirstImage(images: string): string {
+  return splitImages(images)[0] ?? '';
+}
+
+function getGroupThumbnailImage(group: VariantGroup): string {
+  const groupImage = getFirstImage(group.images);
+
+  if (groupImage) {
+    return groupImage;
+  }
+
+  for (const variant of group.variants) {
+    const variantImage = getFirstImage(variant.images);
+
+    if (variantImage) {
+      return variantImage;
+    }
+  }
+
+  return '';
+}
+
+function renderThumbnail(image: string, alt: string): string {
+  if (!image) {
+    return '-';
+  }
+
+  return `<umb-imaging-thumbnail unique="${escapeHtml(image)}" width="38" height="38" alt="${escapeHtml(alt)}"></umb-imaging-thumbnail>`;
+}
+
+function normalizeMediaIdentifier(value: string): string {
+  const udiMatch = value.match(/umb:\/\/media\/(.+)$/i);
+  return udiMatch?.[1] ?? value;
+}
+
+function getMediaPickerValue(mediaPicker: { value?: string; selection?: string[] }): string {
+  if (Array.isArray(mediaPicker.selection)) {
+    return normalizeMediaSelection(mediaPicker.selection).join(',');
+  }
+
+  return splitImages(mediaPicker.value ?? '').join(',');
+}
+
+const patchedMediaPickers = new WeakSet<HTMLElement>();
+
+// Umbraco 17's umb-input-media sorter reads uui-card-media[detail] to find the
+// selected media key, but the component does not render that attribute itself.
+// Add it only while dragging so sorting works without showing GUIDs in the card UI.
+async function setupMediaPickerSorterDetailPatch(mediaPicker: HTMLElement & { updateComplete?: Promise<unknown> }): Promise<void> {
+  if (patchedMediaPickers.has(mediaPicker)) {
+    await clearMediaPickerSorterDetails(mediaPicker);
+    return;
+  }
+
+  patchedMediaPickers.add(mediaPicker);
+  await clearMediaPickerSorterDetails(mediaPicker);
+
+  const shadowRoot = mediaPicker.shadowRoot;
+
+  if (shadowRoot == null) {
+    return;
+  }
+
+  const setDetails = () => void setMediaPickerSorterDetails(mediaPicker);
+  const clearDetails = () => window.setTimeout(() => void clearMediaPickerSorterDetails(mediaPicker));
+  const observer = new MutationObserver(() => void clearMediaPickerSorterDetails(mediaPicker));
+  observer.observe(shadowRoot, { childList: true, subtree: true });
+  shadowRoot.addEventListener('pointerdown', setDetails, { capture: true });
+  shadowRoot.addEventListener('dragstart', setDetails, { capture: true });
+  shadowRoot.addEventListener('dragend', clearDetails, { capture: true });
+  shadowRoot.addEventListener('drop', clearDetails, { capture: true });
+}
+
+async function setMediaPickerSorterDetails(mediaPicker: HTMLElement & { updateComplete?: Promise<unknown> }): Promise<void> {
+  await mediaPicker.updateComplete;
+  await new Promise(resolve => window.requestAnimationFrame(resolve));
+
+  mediaPicker.shadowRoot?.querySelectorAll<HTMLElement>('uui-card-media[data-mark]').forEach(card => {
+    const unique = card.dataset.mark?.split(':').pop() ?? '';
+
+    if (unique) {
+      card.setAttribute('detail', unique);
+    }
+  });
+}
+
+async function clearMediaPickerSorterDetails(mediaPicker: HTMLElement & { updateComplete?: Promise<unknown> }): Promise<void> {
+  await mediaPicker.updateComplete;
+  await new Promise(resolve => window.requestAnimationFrame(resolve));
+
+  mediaPicker.shadowRoot?.querySelectorAll<HTMLElement>('uui-card-media[detail]').forEach(card => {
+    card.removeAttribute('detail');
+  });
+}
+
+function normalizeMediaSelection(selection: unknown[]): string[] {
+  return selection
+    .map(item => {
+      if (typeof item === 'string') {
+        return normalizeMediaIdentifier(item);
+      }
+
+      if (item != null && typeof item === 'object') {
+        const record = item as Record<string, unknown>;
+        return normalizeMediaIdentifier(String(record.udi ?? record.key ?? record.unique ?? record.id ?? ''));
+      }
+
+      return '';
+    })
+    .filter(Boolean);
+}
+
+function isDraft(id: number): boolean {
+  return id <= 0;
+}
+
+function snapshotGroup(group: VariantGroup): string {
+  return stableStringify({
+    titleValues: group.titleValues,
+    images: group.images,
+    customFields: group.customFields,
+    sortOrder: group.sortOrder,
+  });
+}
+
+function snapshotVariant(variant: VariantItem): string {
+  return stableStringify({
+    titleValues: variant.titleValues,
+    sku: variant.sku,
+    images: variant.images,
+    priceValues: variant.priceValues,
+    stockValues: variant.stockValues,
+    customFields: variant.customFields,
+    sortOrder: variant.sortOrder,
+  });
+}
+
+function createCustomFields(fields: CustomFieldDefinition[] | undefined): CustomField[] {
+  return (fields ?? []).map(field => ({
+    ...field,
+    value: '',
+  }));
+}
+
+function normalizePriceValues(priceValues: Record<string, CurrencyPrice[]>, stores: VariantStore[]): Record<string, CurrencyPrice[]> {
+  const normalized: Record<string, CurrencyPrice[]> = {};
+
+  for (const store of stores) {
+    const storeAlias = store.alias ?? '';
+    const pricesByCurrency = new Map<string, CurrencyPrice>();
+
+    for (const [key, prices] of Object.entries(priceValues ?? {})) {
+      if (key.toLowerCase() !== storeAlias.toLowerCase()) {
+        continue;
+      }
+
+      for (const price of prices) {
+        const currency = getCurrency(price);
+
+        if (currency === '') {
+          continue;
+        }
+
+        pricesByCurrency.set(currency.toLowerCase(), {
+          Currency: currency,
+          Price: getPrice(price),
+        });
+      }
+    }
+
+    if (pricesByCurrency.size > 0) {
+      normalized[storeAlias] = [...pricesByCurrency.values()];
+    }
+  }
+
+  return normalized;
+}
+
+function reorderById<T extends { id: number }>(items: T[], sourceId: number, targetId: number): T[] {
+  const next = [...items];
+  const sourceIndex = next.findIndex(item => item.id === sourceId);
+  const targetIndex = next.findIndex(item => item.id === targetId);
+
+  if (sourceIndex < 0 || targetIndex < 0) {
+    return items;
+  }
+
+  const [item] = next.splice(sourceIndex, 1);
+  next.splice(targetIndex, 0, item);
+  return next;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  if (value != null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map(key => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+const styles = `
+  :host { display: block; padding: var(--uui-size-layout-1, 24px); background: #f4f3f5; color: #1b264f; font-family: Lato, Arial, sans-serif; }
+  .ekm-variant-editor { display: grid; gap: 16px; }
+  .top-bar, .selection-actions, .main-actions, .group-header, .group-header-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .top-bar { background: #f4f3f5; border-bottom: 1px solid #e2e1e6; box-shadow: 0 4px 10px rgba(27, 38, 79, .06); justify-content: space-between; margin: -24px -24px 0; padding: 16px 24px; position: sticky; top: 0; z-index: 10; }
+  .selection-actions { min-height: 32px; }
+  .main-actions { margin-left: auto; justify-content: flex-end; }
+  .group-list { display: grid; gap: 14px; }
+  .group-card { background: #fff; border: 1px solid #e2e1e6; border-radius: 6px; box-shadow: 0 1px 3px rgba(27, 38, 79, .06); overflow: hidden; }
+  .group-card.is-draft, .variant-row.is-draft { background: #f8fbf9; }
+  .group-header { padding: 12px 14px; }
+  .drag-handle { color: #8b8994; cursor: grab; font-weight: 900; letter-spacing: -2px; user-select: none; }
+  [draggable="true"]:active .drag-handle { cursor: grabbing; }
+  .group-toggle, .group-title, .thumb--button, .close-button, .mini-tab { border: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; }
+  .group-title { font-weight: 900; text-align: left; }
+  .thumb { display: inline-flex; width: 38px; height: 38px; align-items: center; justify-content: center; border: 1px solid #e2e1e6; border-radius: 4px; background: #f4f3f5; color: #686570; font-size: 11px; text-transform: uppercase; }
+  .thumb umb-imaging-thumbnail { width: 100%; height: 100%; }
+  .count, .hint { color: #686570; }
+  .badge { border-radius: 999px; padding: 2px 8px; background: #ecf7f1; color: #188a4f; font-size: 11px; font-weight: 700; text-transform: uppercase; }
+  .group-header-actions { margin-left: auto; }
+  .variant-table { border-top: 1px solid #e2e1e6; }
+  .variant-head, .variant-row { display: grid; grid-template-columns: 18px 24px 44px minmax(140px, 1.3fr) minmax(100px, .8fr) minmax(100px, .8fr) minmax(80px, .6fr) auto; gap: 12px; align-items: center; padding: 10px 14px; }
+  .variant-head { background: #f8f7fa; color: #8b8994; font-size: 11px; font-weight: 900; letter-spacing: .04em; text-transform: uppercase; }
+  .variant-row { border-top: 1px solid #e2e1e6; }
+  .variant-price-cell, .variant-stock-cell { text-align: center; }
+  input { box-sizing: border-box; width: 100%; border: 1px solid #c4c2cb; border-radius: 3px; padding: 8px; font: inherit; }
+  input:focus { border-color: #1b264f; outline: none; }
+  input[type="checkbox"] { width: 16px; height: 16px; accent-color: #188a4f; }
+  .status { padding: 12px; background: #fff; border-radius: 3px; }
+  .status--error { color: #d42054; }
+  .drawer-backdrop { position: fixed; inset: 0; background: rgba(27, 38, 79, .35); z-index: 1000; }
+  .drawer { position: fixed; top: 0; right: 0; bottom: 0; z-index: 1001; width: min(460px, 100vw); display: grid; grid-template-rows: auto 1fr auto; background: #fff; box-shadow: -6px 0 24px rgba(27, 38, 79, .18); animation: slide-in .18s ease-out; }
+  .drawer-header, .drawer-footer { display: flex; gap: 12px; align-items: center; justify-content: space-between; padding: 18px; border-bottom: 1px solid #e2e1e6; }
+  .drawer-footer { border-top: 1px solid #e2e1e6; border-bottom: 0; }
+  .drawer-title { min-width: 0; }
+  .drawer-header-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+  .drawer-footer-left, .drawer-footer-right { display: flex; gap: 12px; align-items: center; }
+  .drawer-footer-left { margin-right: auto; }
+  .danger-button { background: #d42054; border: 1px solid #d42054; border-radius: 3px; color: #fff; cursor: pointer; font: inherit; font-weight: 700; padding: 8px 14px; }
+  .danger-button:hover { background: #b51b46; border-color: #b51b46; }
+  .drawer-header h2 { margin: 0; font-size: 20px; }
+  .drawer-header p { margin: 4px 0 0; color: #686570; }
+  .edit-icon { display: inline-block; font-size: 15px; line-height: 1; transform: translateY(-1px); }
+  .drawer-body { display: grid; gap: 18px; align-content: start; overflow: auto; padding: 18px; }
+  label, .media-field { display: grid; gap: 8px; font-weight: 700; }
+  .field-label, h3 { font-weight: 900; margin: 0; }
+  .drawer-body section h3 { font-size: 13px; margin-bottom: 10px; }
+  .mini-tabs { display: inline-flex; gap: 4px; }
+  .mini-tab { padding: 4px 8px; border-bottom: 2px solid transparent; color: #686570; font-weight: 700; }
+  .mini-tab.active { border-bottom-color: #1b264f; color: #1b264f; }
+  table { width: 100%; border-collapse: collapse; }
+  th { background: #f8f7fa; color: #8b8994; font-size: 11px; letter-spacing: .04em; text-align: left; text-transform: uppercase; }
+  th, td { border-bottom: 1px solid #e2e1e6; padding: 8px; }
+  .numeric { text-align: right; }
+  @keyframes slide-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+`;
+
+customElements.define('ekom-variants-workspace-view', EkomVariantsWorkspaceViewElement);
+
+export default EkomVariantsWorkspaceViewElement;

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
         'property-editor.element': 'src/property-editors/property-editor.element.ts',
         'range-editor.element': 'src/property-editors/range-editor.element.ts',
         'stock-editor.element': 'src/property-editors/stock-editor.element.ts',
+        'variant-count-workspace-footer-app.element': 'src/variants/variant-count-workspace-footer-app.element.ts',
+        'variants-workspace-view.element': 'src/variants/variants-workspace-view.element.ts',
         'zone-picker.element': 'src/property-editors/zone-picker.element.ts',
       },
       formats: ['es'],

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -1,0 +1,822 @@
+angular.module('umbraco').controller('Ekom.Variants', function ($element, $http, $scope, editorService, editorState, notificationsService) {
+    var vm = this;
+
+    vm.loading = true;
+    vm.busy = false;
+    vm.error = '';
+    vm.status = '';
+    vm.product = null;
+    vm.activeLanguage = '';
+    vm.expandedGroupIds = {};
+    vm.selectedGroupIds = {};
+    vm.selectedVariantIds = {};
+    vm.deletedNodeIds = [];
+    vm.groupSnapshots = {};
+    vm.variantSnapshots = {};
+    vm.drawer = null;
+
+    var nextDraftId = -1;
+
+    vm.load = function () {
+        vm.loading = true;
+        vm.error = '';
+
+        $http.get('/ekom/backoffice/Variants/' + encodeURIComponent(editorState.current.id))
+            .then(function (response) {
+                vm.product = response.data;
+                vm.activeLanguage = (vm.product.languages[0] || {}).isoCode || '';
+                vm.expandedGroupIds = {};
+                vm.selectedGroupIds = {};
+                vm.selectedVariantIds = {};
+                vm.deletedNodeIds = [];
+                vm.drawer = null;
+                if (vm.product.groups.length === 1) {
+                    vm.expandedGroupIds[vm.product.groups[0].id] = true;
+                }
+                resetSnapshots();
+                setBadge();
+            })
+            .catch(function (error) {
+                vm.error = getErrorMessage(error, 'Could not load variants.');
+                notificationsService.error('Variants', vm.error);
+            })
+            .finally(function () {
+                vm.loading = false;
+            });
+    };
+
+    vm.createGroup = function () {
+        var id = nextDraftId--;
+        var group = {
+            id: id,
+            key: '00000000-0000-0000-0000-000000000000',
+            name: 'New variant group',
+            title: '',
+            titleValues: createEmptyTitleValues(),
+            color: '',
+            images: '',
+            sortOrder: vm.product.groups.length,
+            published: false,
+            customFields: createCustomFields(vm.product.variantGroupFields),
+            variants: []
+        };
+
+        vm.product.groups.push(group);
+        vm.expandedGroupIds[id] = true;
+        vm.drawer = { type: 'group', group: group, item: group };
+    };
+
+    vm.createVariant = function (group) {
+        var id = nextDraftId--;
+        var variant = {
+            id: id,
+            key: '00000000-0000-0000-0000-000000000000',
+            name: 'New variant',
+            title: '',
+            titleValues: createEmptyTitleValues(),
+            sku: '',
+            images: '',
+            priceValues: {},
+            stockValues: createEmptyStockValues(),
+            customFields: createCustomFields(vm.product.variantFields),
+            sortOrder: group.variants.length,
+            published: false
+        };
+
+        group.variants.push(variant);
+        vm.expandedGroupIds[group.id] = true;
+        vm.drawer = { type: 'variant', group: group, item: variant };
+    };
+
+    vm.saveAll = function () {
+        if (!validateAllCustomFields()) {
+            return;
+        }
+
+        if (!vm.hasChanges()) {
+            vm.status = 'No changes to save.';
+            notificationsService.info('Variants', 'No changes to save.');
+            return;
+        }
+
+        saveVariantChanges();
+    };
+
+    $scope.$on('formSubmitting', function () {
+        if (vm.product && vm.hasChanges()) {
+            saveVariantChanges({ silentNoChanges: true });
+        }
+    });
+
+    vm.deleteSelected = function () {
+        var count = selectedCount();
+
+        if (!count || !window.confirm('Delete ' + count + ' selected item' + (count === 1 ? '' : 's') + '?')) {
+            return;
+        }
+
+        (vm.product.groups || []).forEach(function (group) {
+            if (vm.selectedGroupIds[group.id] && !isDraft(group.id)) {
+                addDeletedNodeId(group.id);
+            }
+
+            group.variants.forEach(function (variant) {
+                if (vm.selectedVariantIds[variant.id] && !isDraft(variant.id)) {
+                    addDeletedNodeId(variant.id);
+                }
+            });
+        });
+
+        vm.product.groups = (vm.product.groups || []).filter(function (group) {
+            return !vm.selectedGroupIds[group.id];
+        }).map(function (group) {
+            group.variants = group.variants.filter(function (variant) {
+                return !vm.selectedVariantIds[variant.id];
+            });
+            return group;
+        });
+
+        vm.selectedGroupIds = {};
+        vm.selectedVariantIds = {};
+        vm.drawer = null;
+    };
+
+    vm.toggleGroup = function (group) {
+        vm.expandedGroupIds[group.id] = !vm.expandedGroupIds[group.id];
+    };
+
+    vm.editGroup = function (group) {
+        vm.drawer = { type: 'group', group: group, item: group };
+    };
+
+    vm.editVariant = function (group, variant) {
+        vm.drawer = { type: 'variant', group: group, item: variant };
+    };
+
+    vm.closeDrawer = function () {
+        vm.drawer = null;
+    };
+
+    vm.saveDrawer = function () {
+        if (!validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
+            return;
+        }
+
+        vm.drawer = null;
+    };
+
+    vm.deleteDrawerItem = function () {
+        if (!vm.drawer) {
+            return;
+        }
+
+        var isGroup = vm.drawer.type === 'group';
+        var label = isGroup ? 'variant group' : 'variant';
+
+        if (!window.confirm('Delete this ' + label + '?')) {
+            return;
+        }
+
+        if (isGroup) {
+            if (!isDraft(vm.drawer.item.id)) {
+                addDeletedNodeId(vm.drawer.item.id);
+            }
+
+            vm.product.groups = (vm.product.groups || []).filter(function (group) {
+                return group.id !== vm.drawer.item.id;
+            });
+        } else {
+            if (!isDraft(vm.drawer.item.id)) {
+                addDeletedNodeId(vm.drawer.item.id);
+            }
+
+            vm.drawer.group.variants = vm.drawer.group.variants.filter(function (variant) {
+                return variant.id !== vm.drawer.item.id;
+            });
+        }
+
+        vm.drawer = null;
+    };
+
+    vm.drawerTitle = function () {
+        if (!vm.drawer) {
+            return '';
+        }
+
+        return vm.getTitleValue(vm.drawer.item) || vm.drawer.item.name || (vm.drawer.type === 'group' ? 'New variant group' : 'New variant');
+    };
+
+    vm.drawerSubtitle = function () {
+        if (!vm.drawer) {
+            return '';
+        }
+
+        return vm.drawer.type === 'group' ? 'variant group' : (vm.getTitleValue(vm.drawer.group) || 'Group') + ' / variant';
+    };
+
+    vm.setLanguage = function (value) {
+        vm.activeLanguage = value;
+    };
+
+    vm.getTitleValue = function (item) {
+        ensureTitleValues(item);
+        return item.titleValues[vm.activeLanguage] || firstValue(item.titleValues) || item.title || '';
+    };
+
+    vm.setTitleValue = function (item, value) {
+        ensureTitleValues(item);
+        item.titleValues[vm.activeLanguage] = value;
+        item.title = firstValue(item.titleValues) || item.name;
+    };
+
+    vm.getPrice = getVariantPrice;
+
+    vm.setPrice = function (variant, storeAlias, currency, value) {
+        if (!variant.priceValues) {
+            variant.priceValues = {};
+        }
+
+        var prices = variant.priceValues[storeAlias] || [];
+        var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
+        var numericValue = Number(value) || 0;
+
+        if (price) {
+            price.Price = numericValue;
+            price.price = numericValue;
+        } else {
+            prices.push({ Currency: currency, Price: numericValue });
+        }
+
+        variant.priceValues[storeAlias] = prices;
+    };
+
+    vm.getStockValue = function (variant, storeAlias) {
+        var stock = (variant.stockValues || []).filter(function (item) { return item.storeAlias === storeAlias; })[0];
+        return stock ? stock.value || 0 : 0;
+    };
+
+    vm.setCustomField = function (item, field, value) {
+        ensureCustomFields(item);
+        var customField = item.customFields.filter(function (current) { return current.alias === field.alias; })[0];
+
+        if (customField) {
+            customField.value = value;
+        }
+    };
+
+    vm.setStockValue = function (variant, storeAlias, value) {
+        if (!variant.stockValues) {
+            variant.stockValues = [];
+        }
+
+        var stock = variant.stockValues.filter(function (item) { return item.storeAlias === storeAlias; })[0];
+        if (!stock) {
+            stock = { storeAlias: storeAlias, value: 0 };
+            variant.stockValues.push(stock);
+        }
+
+        stock.value = Number(value) || 0;
+    };
+
+    vm.priceRows = function () {
+        if (!vm.drawer || vm.drawer.type !== 'variant') {
+            return [];
+        }
+
+        var rows = [];
+        (vm.product.stores || []).forEach(function (store) {
+            (store.currencies || []).forEach(function (currency) {
+                rows.push({
+                    storeAlias: store.alias || '',
+                    storeTitle: store.title || store.alias || '',
+                    currencyValue: currency.currencyValue || '',
+                    currencyLabel: currency.isoCurrencySymbol || currency.currencyValue || '',
+                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
+                });
+            });
+        });
+
+        return rows;
+    };
+
+    vm.stockRows = function () {
+        if (!vm.drawer || vm.drawer.type !== 'variant') {
+            return [];
+        }
+
+        return (vm.product.stores || []).map(function (store) {
+            var storeAlias = store.alias || '';
+            return {
+                storeAlias: storeAlias,
+                storeTitle: store.title || storeAlias,
+                value: vm.getStockValue(vm.drawer.item, storeAlias)
+            };
+        });
+    };
+
+    vm.variantImageHint = function () {
+        if (!vm.drawer || vm.drawer.type !== 'variant') {
+            return '';
+        }
+
+        var ownImages = splitImages(vm.drawer.item.images).length;
+        var groupImages = splitImages(vm.drawer.group.images).length;
+        return ownImages ? 'Own images override the group images.' : 'No own images — inherits ' + groupImages + ' image(s) from ' + (vm.getTitleValue(vm.drawer.group) || 'group') + '.';
+    };
+
+    vm.isGroupChanged = isGroupChanged;
+    vm.isVariantChanged = isVariantChanged;
+    vm.hasChanges = function () {
+        return vm.deletedNodeIds.length > 0 || (vm.product && (vm.product.groups || []).some(function (group) {
+            return isGroupChanged(group) || group.variants.some(isVariantChanged);
+        }));
+    };
+    vm.selectedCount = selectedCount;
+    vm.isDraft = isDraft;
+    vm.imageCount = function (value) { return splitImages(value).length; };
+    vm.mediaImages = function (item) { return splitImages(item && item.images); };
+    vm.getThumbUrl = getThumbUrl;
+    vm.getLanguageLabel = getLanguageLabel;
+    vm.getFirstImageThumbUrl = getFirstImageThumbUrl;
+    vm.getGroupThumbUrl = function (group) {
+        var image = getFirstImage(group.images);
+
+        if (!image) {
+            for (var i = 0; i < group.variants.length; i++) {
+                image = getFirstImage(group.variants[i].images);
+
+                if (image) {
+                    break;
+                }
+            }
+        }
+
+        return getThumbUrl(image);
+    };
+    vm.getDefaultPrice = function (variant) {
+        var store = (vm.product.stores || [])[0];
+        var currency = store && (store.currencies || [])[0];
+
+        if (!store || !currency) {
+            return '—';
+        }
+
+        var value = getVariantPrice(variant, store.alias || '', currency.currencyValue || '');
+        var symbol = currency.currencySymbol || currency.isoCurrencySymbol || currency.currencyValue || '';
+        return (formatNumber(value) + ' ' + symbol).trim();
+    };
+    vm.getTotalStock = function (variant) {
+        return formatNumber((variant.stockValues || []).reduce(function (total, stock) {
+            return total + (Number(stock.value) || 0);
+        }, 0));
+    };
+    vm.openMediaPicker = function (item) {
+        editorService.mediaPicker({
+            multiPicker: true,
+            selection: splitImages(item.images),
+            submit: function (model) {
+                item.images = normalizeMediaSelection(model.selection).join(',');
+                editorService.close();
+            },
+            close: function () {
+                editorService.close();
+            }
+        });
+    };
+
+    bindDragAndDrop();
+
+    function saveVariantChanges(options) {
+        if (!validateAllCustomFields()) {
+            return Promise.resolve();
+        }
+
+        var groups = (vm.product.groups || []).map(getChangedGroupForSave).filter(Boolean);
+
+        return saveGroups(groups, options || {});
+    }
+
+    function saveGroups(groups, options) {
+        options = options || {};
+
+        if (!groups.length && !vm.deletedNodeIds.length) {
+            if (!options.silentNoChanges) {
+                vm.status = 'No changes to save.';
+                notificationsService.info('Variants', 'No changes to save.');
+            }
+
+            return Promise.resolve();
+        }
+
+        return runAction('Saving changes...', function () {
+            var deleteRequests = vm.deletedNodeIds.map(function (id) {
+                return $http.delete('/ekom/backoffice/Variants/' + encodeURIComponent(id));
+            });
+
+            return Promise.all(deleteRequests).then(function () {
+                if (!groups.length) {
+                    return vm.load();
+                }
+
+                return $http.post('/ekom/backoffice/Variants/Save', {
+                    productId: String(editorState.current.id),
+                    publish: true,
+                    groups: groups
+                }).then(function (response) {
+                    vm.product = response.data;
+                    vm.selectedGroupIds = {};
+                    vm.selectedVariantIds = {};
+                    vm.deletedNodeIds = [];
+                    vm.drawer = null;
+                    vm.expandedGroupIds = {};
+                    if (vm.product.groups.length === 1) {
+                        vm.expandedGroupIds[vm.product.groups[0].id] = true;
+                    }
+                    resetSnapshots();
+                    setBadge();
+                });
+            });
+        });
+    }
+
+    function getChangedGroupForSave(group) {
+        var variants = group.variants.filter(isVariantChanged).map(markChanged);
+
+        if (!isGroupChanged(group) && !variants.length) {
+            return null;
+        }
+
+        return angular.extend({}, group, { changed: isGroupChanged(group), variants: variants });
+    }
+
+    function markChanged(item) {
+        return angular.extend({}, item, { changed: true });
+    }
+
+    function runAction(status, action) {
+        vm.busy = true;
+        vm.status = status;
+        vm.error = '';
+
+        return action()
+            .then(function () {
+                vm.status = 'Done.';
+                notificationsService.success('Variants', 'Variant changes were saved.');
+            })
+            .catch(function (error) {
+                vm.error = getErrorMessage(error, 'Action failed.');
+                notificationsService.error('Variants', vm.error);
+            })
+            .finally(function () {
+                vm.busy = false;
+            });
+    }
+
+    function resetSnapshots() {
+        vm.groupSnapshots = {};
+        vm.variantSnapshots = {};
+        (vm.product.groups || []).forEach(function (group) {
+            vm.groupSnapshots[group.id] = snapshotGroup(group);
+            group.variants.forEach(function (variant) {
+                vm.variantSnapshots[variant.id] = snapshotVariant(variant);
+            });
+        });
+    }
+
+    function isGroupChanged(group) {
+        return isDraft(group.id) || vm.groupSnapshots[group.id] !== snapshotGroup(group);
+    }
+
+    function isVariantChanged(variant) {
+        return isDraft(variant.id) || vm.variantSnapshots[variant.id] !== snapshotVariant(variant);
+    }
+
+    function createEmptyTitleValues() {
+        var values = {};
+        (vm.product.languages || []).forEach(function (language) {
+            values[language.isoCode || ''] = '';
+        });
+        return values;
+    }
+
+    function createCustomFields(fields) {
+        return (fields || []).map(function (field) {
+            return angular.extend({}, field, { value: '' });
+        });
+    }
+
+    function ensureCustomFields(item) {
+        if (!item.customFields) {
+            item.customFields = [];
+        }
+    }
+
+    function validateAllCustomFields() {
+        var groups = vm.product ? vm.product.groups || [] : [];
+
+        for (var i = 0; i < groups.length; i++) {
+            if (!validateCustomFields(groups[i].customFields)) {
+                return false;
+            }
+
+            for (var j = 0; j < groups[i].variants.length; j++) {
+                if (!validateCustomFields(groups[i].variants[j].customFields)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    function validateCustomFields(fields) {
+        var missing = (fields || []).filter(function (field) {
+            return field.required && !String(field.value || '').trim();
+        })[0];
+
+        if (!missing) {
+            return true;
+        }
+
+        notificationsService.error('Variants', missing.label + ' is required.');
+        return false;
+    }
+
+    function createEmptyStockValues() {
+        return (vm.product.stores || []).map(function (store) {
+            return { storeAlias: store.alias || '', value: 0 };
+        });
+    }
+
+    function ensureTitleValues(item) {
+        if (!item.titleValues) {
+            item.titleValues = {};
+        }
+    }
+
+    function selectedCount() {
+        return Object.keys(vm.selectedGroupIds).filter(function (key) { return vm.selectedGroupIds[key]; }).length
+            + Object.keys(vm.selectedVariantIds).filter(function (key) { return vm.selectedVariantIds[key]; }).length;
+    }
+
+    function addDeletedNodeId(id) {
+        if (vm.deletedNodeIds.indexOf(id) === -1) {
+            vm.deletedNodeIds.push(id);
+        }
+    }
+
+    function bindDragAndDrop() {
+        var draggedGroupId = null;
+        var draggedVariant = null;
+        var draggedImageIndex = null;
+
+        $element[0].addEventListener('dragstart', function (event) {
+            var mediaCard = event.target.closest('[data-media-image-index]');
+            if (mediaCard) {
+                draggedImageIndex = Number(mediaCard.getAttribute('data-media-image-index'));
+                event.stopPropagation();
+                return;
+            }
+
+            var variantRow = event.target.closest('[data-drag-variant-id]');
+            if (variantRow) {
+                draggedVariant = {
+                    groupId: Number(variantRow.getAttribute('data-drag-group-id')),
+                    variantId: Number(variantRow.getAttribute('data-drag-variant-id'))
+                };
+                event.stopPropagation();
+                return;
+            }
+
+            var groupCard = event.target.closest('.ekm-variants-group[data-drag-group-id]');
+            if (groupCard) {
+                draggedGroupId = Number(groupCard.getAttribute('data-drag-group-id'));
+            }
+        });
+
+        $element[0].addEventListener('dragover', function (event) {
+            if (draggedImageIndex !== null && event.target.closest('[data-media-image-index]')) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+
+            var variantRow = event.target.closest('[data-drag-variant-id]');
+            if (variantRow && draggedVariant && draggedVariant.groupId === Number(variantRow.getAttribute('data-drag-group-id'))) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+
+            if (draggedGroupId !== null && event.target.closest('.ekm-variants-group[data-drag-group-id]')) {
+                event.preventDefault();
+            }
+        });
+
+        $element[0].addEventListener('drop', function (event) {
+            var mediaCard = event.target.closest('[data-media-image-index]');
+            if (mediaCard && draggedImageIndex !== null) {
+                event.preventDefault();
+                event.stopPropagation();
+                $scope.$apply(function () {
+                    reorderDrawerImage(draggedImageIndex, Number(mediaCard.getAttribute('data-media-image-index')));
+                });
+                draggedImageIndex = null;
+                return;
+            }
+
+            var variantRow = event.target.closest('[data-drag-variant-id]');
+            if (variantRow && draggedVariant) {
+                event.preventDefault();
+                event.stopPropagation();
+                $scope.$apply(function () {
+                    reorderVariant(draggedVariant, Number(variantRow.getAttribute('data-drag-group-id')), Number(variantRow.getAttribute('data-drag-variant-id')));
+                });
+                draggedVariant = null;
+                return;
+            }
+
+            var groupCard = event.target.closest('.ekm-variants-group[data-drag-group-id]');
+            if (groupCard && draggedGroupId !== null) {
+                event.preventDefault();
+                $scope.$apply(function () {
+                    reorderGroup(draggedGroupId, Number(groupCard.getAttribute('data-drag-group-id')));
+                });
+                draggedGroupId = null;
+            }
+        });
+
+        $element[0].addEventListener('dragend', function () {
+            draggedGroupId = null;
+            draggedVariant = null;
+            draggedImageIndex = null;
+        });
+    }
+
+    function reorderDrawerImage(sourceIndex, targetIndex) {
+        if (!vm.drawer || sourceIndex === targetIndex) {
+            return;
+        }
+
+        var images = splitImages(vm.drawer.item.images);
+
+        if (sourceIndex < 0 || targetIndex < 0 || sourceIndex >= images.length || targetIndex >= images.length) {
+            return;
+        }
+
+        var image = images.splice(sourceIndex, 1)[0];
+        images.splice(targetIndex, 0, image);
+        vm.drawer.item.images = images.join(',');
+    }
+
+    function reorderGroup(sourceId, targetId) {
+        if (sourceId === targetId) {
+            return;
+        }
+
+        vm.product.groups = reorderById(vm.product.groups, sourceId, targetId);
+        vm.product.groups.forEach(function (group, index) {
+            group.sortOrder = index;
+        });
+    }
+
+    function reorderVariant(source, targetGroupId, targetVariantId) {
+        if (!source || source.groupId !== targetGroupId || source.variantId === targetVariantId) {
+            return;
+        }
+
+        var group = (vm.product.groups || []).filter(function (item) { return item.id === source.groupId; })[0];
+        if (!group) {
+            return;
+        }
+
+        group.variants = reorderById(group.variants, source.variantId, targetVariantId);
+        group.variants.forEach(function (variant, index) {
+            variant.sortOrder = index;
+        });
+    }
+
+    function reorderById(items, sourceId, targetId) {
+        var next = items.slice();
+        var sourceIndex = next.findIndex(function (item) { return item.id === sourceId; });
+        var targetIndex = next.findIndex(function (item) { return item.id === targetId; });
+
+        if (sourceIndex < 0 || targetIndex < 0) {
+            return items;
+        }
+
+        var item = next.splice(sourceIndex, 1)[0];
+        next.splice(targetIndex, 0, item);
+        return next;
+    }
+
+    function setBadge() {
+        var count = vm.product ? vm.product.variantCount : 0;
+        $scope.model.badge = count > 0 ? { count: count, type: 'default' } : null;
+    }
+
+    function firstValue(values) {
+        for (var key in values) {
+            if (values[key]) {
+                return values[key];
+            }
+        }
+
+        return '';
+    }
+
+    function getLanguageLabel(language) {
+        return String(language.isoCode || language.cultureName || '').split('-')[0].toUpperCase();
+    }
+
+    function getVariantPrice(variant, storeAlias, currency) {
+        var prices = (variant.priceValues || {})[storeAlias] || [];
+        var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
+        return price ? getPrice(price) : 0;
+    }
+
+    function getCurrency(price) {
+        return price.Currency || price.currency || '';
+    }
+
+    function getPrice(price) {
+        return price.Price || price.price || 0;
+    }
+
+    function formatNumber(value) {
+        return new Intl.NumberFormat().format(value || 0);
+    }
+
+    function splitImages(value) {
+        var rawValue = String(value || '').trim();
+
+        if (!rawValue) {
+            return [];
+        }
+
+        if (rawValue.indexOf('[') === 0) {
+            try {
+                return JSON.parse(rawValue).map(function (item) {
+                    return String(item.mediaKey || item.key || '').trim();
+                }).filter(Boolean);
+            } catch (error) {
+                return [];
+            }
+        }
+
+        return rawValue.split(',').map(function (item) { return normalizeMediaIdentifier(item.trim()); }).filter(Boolean);
+    }
+
+    function normalizeMediaIdentifier(value) {
+        var match = value.match(/umb:\/\/media\/(.+)$/i);
+        return match ? match[1] : value;
+    }
+
+    function getFirstImageThumbUrl(value) {
+        return getThumbUrl(getFirstImage(value));
+    }
+
+    function getFirstImage(value) {
+        return splitImages(value)[0] || '';
+    }
+
+    function getThumbUrl(image) {
+        if (!image) {
+            return '';
+        }
+
+        return '/ekom/backoffice/Variants/Media/Thumbnail?mediaId=' + encodeURIComponent(image) + '&width=38&height=38';
+    }
+
+    function normalizeMediaSelection(selection) {
+        return (selection || []).map(function (item) {
+            if (typeof item === 'string') {
+                return item;
+            }
+
+            return item.udi || item.key || item.id || '';
+        }).filter(Boolean);
+    }
+
+    function isDraft(id) {
+        return id <= 0;
+    }
+
+    function snapshotGroup(group) {
+        return angular.toJson({ titleValues: group.titleValues, images: group.images, customFields: group.customFields, sortOrder: group.sortOrder });
+    }
+
+    function snapshotVariant(variant) {
+        return angular.toJson({ titleValues: variant.titleValues, sku: variant.sku, images: variant.images, priceValues: variant.priceValues, stockValues: variant.stockValues, customFields: variant.customFields, sortOrder: variant.sortOrder });
+    }
+
+    function getErrorMessage(error, fallback) {
+        if (error && error.data) {
+            return typeof error.data === 'string' ? error.data : error.data.message || fallback;
+        }
+
+        return fallback;
+    }
+
+    vm.load();
+});

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -1,0 +1,380 @@
+.ekm-variants-app {
+    color: #1b264f;
+}
+
+.ekm-variants-app .ekm-variants-toolbar,
+.ekm-variants-app .ekm-variants-selected,
+.ekm-variants-app .ekm-variants-toolbar__actions,
+.ekm-variants-app .ekm-variants-group__summary,
+.ekm-variants-app .ekm-variants-group__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.ekm-variants-app .ekm-variants-toolbar {
+    background: #fff;
+    border-bottom: 1px solid #e2e1e6;
+    box-shadow: 0 4px 10px rgba(27, 38, 79, .06);
+    justify-content: space-between;
+    margin: -20px -20px 16px;
+    padding: 16px 20px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.ekm-variants-app .ekm-variants-selected {
+    min-height: 32px;
+}
+
+.ekm-variants-app .ekm-variants-toolbar__actions,
+.ekm-variants-app .ekm-variants-group__actions {
+    justify-content: flex-end;
+    margin-left: auto;
+}
+
+.ekm-variants-app .ekm-variants-group-list {
+    display: grid;
+    gap: 14px;
+}
+
+.ekm-variants-app .ekm-variants-group {
+    background: #fff;
+    border: 1px solid #e2e1e6;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(27, 38, 79, .06);
+    overflow: hidden;
+}
+
+.ekm-variants-app .ekm-variants-group.is-draft,
+.ekm-variants-app .ekm-variants-row.is-draft {
+    background: #f8fbf9;
+}
+
+.ekm-variants-app .ekm-variants-group__summary {
+    padding: 12px 14px;
+}
+
+.ekm-variants-app .ekm-variants-drag-handle {
+    color: #8b8994;
+    cursor: grab;
+    font-weight: 900;
+    letter-spacing: -2px;
+    user-select: none;
+}
+
+.ekm-variants-app .ekm-variants-caret,
+.ekm-variants-app .ekm-variants-title-button,
+.ekm-variants-app .ekm-variants-thumb--button,
+.ekm-variants-app .ekm-variants-open-node,
+.ekm-variants-app .ekm-variants-close,
+.ekm-variants-app .ekm-variants-mini-tabs button {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+}
+
+.ekm-variants-app .ekm-variants-title-button {
+    font-weight: 900;
+    text-align: left;
+}
+
+.ekm-variants-app .ekm-variants-thumb {
+    align-items: center;
+    background: #f4f3f5;
+    border: 1px solid #e2e1e6;
+    border-radius: 4px;
+    color: #686570;
+    display: inline-flex;
+    font-size: 11px;
+    height: 38px;
+    justify-content: center;
+    text-transform: uppercase;
+    width: 38px;
+}
+
+.ekm-variants-app .ekm-variants-thumb img {
+    border-radius: 3px;
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+}
+
+.ekm-variants-app .ekm-variants-count,
+.ekm-variants-app .ekm-variants-hint,
+.ekm-variants-app small {
+    color: #686570;
+}
+
+.ekm-variants-app .ekm-variants-pill {
+    background: #ecf7f1;
+    border-radius: 999px;
+    color: #188a4f;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    text-transform: uppercase;
+}
+
+.ekm-variants-app .ekm-variants-table {
+    border-top: 1px solid #e2e1e6;
+}
+
+.ekm-variants-app .ekm-variants-table__head,
+.ekm-variants-app .ekm-variants-row {
+    align-items: center;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 18px 24px 44px minmax(140px, 1.3fr) minmax(100px, .8fr) minmax(100px, .8fr) minmax(80px, .6fr) auto;
+    padding: 10px 14px;
+}
+
+.ekm-variants-app .ekm-variants-table__head {
+    background: #f8f7fa;
+    color: #8b8994;
+    font-size: 11px;
+    font-weight: 900;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+
+.ekm-variants-app .ekm-variants-row {
+    border-top: 1px solid #e2e1e6;
+}
+
+.ekm-variants-app .ekm-variants-price-cell,
+.ekm-variants-app .ekm-variants-stock-cell {
+    text-align: center;
+}
+
+.ekm-variants-app label {
+    display: grid;
+    font-weight: 700;
+    gap: 8px;
+}
+
+.ekm-variants-app input {
+    border: 1px solid #c4c2cb;
+    border-radius: 3px;
+    box-sizing: border-box;
+    font: inherit;
+    padding: 8px;
+    width: 100%;
+}
+
+.ekm-variants-app input:focus {
+    border-color: #1b264f;
+    outline: none;
+}
+
+.ekm-variants-app input[type="checkbox"] {
+    accent-color: #188a4f;
+    height: 16px;
+    padding: 0;
+    width: 16px;
+}
+
+.ekm-variants-app .ekm-variants-number {
+    text-align: right;
+}
+
+.ekm-variants-app .ekm-variants-media-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.ekm-variants-app .ekm-variants-media-card {
+    align-items: center;
+    background: #f4f3f5;
+    border: 1px solid #e2e1e6;
+    border-radius: 4px;
+    cursor: grab;
+    display: grid;
+    gap: 4px;
+    grid-template-columns: 14px 54px;
+    padding: 4px;
+}
+
+.ekm-variants-app .ekm-variants-media-card img {
+    border-radius: 3px;
+    height: 54px;
+    object-fit: cover;
+    width: 54px;
+}
+
+.ekm-variants-app .ekm-variants-status {
+    background: #fff;
+    border-radius: 3px;
+    padding: 12px;
+}
+
+.ekm-variants-app .ekm-variants-status--error {
+    color: #d42054;
+}
+
+.ekm-variants-app .ekm-variants-empty,
+.ekm-variants-app .ekm-variants-empty-row {
+    border: 1px dashed #d8d7d9;
+    border-radius: 3px;
+    padding: 24px;
+}
+
+.ekm-variants-app .ekm-variants-empty-row {
+    border-width: 1px 0 0;
+    margin: 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer-backdrop {
+    background: rgba(27, 38, 79, .35);
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: 1000;
+}
+
+.ekm-variants-app .ekm-variants-drawer {
+    background: #fff;
+    bottom: 0;
+    box-shadow: -6px 0 24px rgba(27, 38, 79, .18);
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: min(460px, 100vw);
+    z-index: 1001;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header,
+.ekm-variants-app .ekm-variants-drawer__footer {
+    align-items: center;
+    border-bottom: 1px solid #e2e1e6;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    padding: 18px;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header > div:first-child {
+    min-width: 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header-actions {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+    gap: 8px;
+}
+
+.ekm-variants-app .ekm-variants-open-node {
+    align-items: center;
+    border: 1px solid #d8d7dc;
+    border-radius: 3px;
+    color: #1b264f;
+    display: inline-flex;
+    height: 32px;
+    justify-content: center;
+    text-decoration: none;
+    width: 32px;
+}
+
+.ekm-variants-app .ekm-variants-open-node:hover {
+    background: #f8f7fa;
+    color: #1b264f;
+    text-decoration: none;
+}
+
+.ekm-variants-app .ekm-variants-open-node span {
+    font-size: 15px;
+    line-height: 1;
+    transform: translateY(-1px);
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer {
+    border-bottom: 0;
+    border-top: 1px solid #e2e1e6;
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer-left,
+.ekm-variants-app .ekm-variants-drawer__footer-right {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer-left {
+    margin-right: auto;
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer-left .btn-danger {
+    background: #d42054;
+    border-color: #d42054;
+    color: #fff;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header h2 {
+    font-size: 20px;
+    margin: 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header p {
+    color: #686570;
+    margin: 4px 0 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer__body {
+    align-content: start;
+    display: grid;
+    gap: 18px;
+    overflow: auto;
+    padding: 18px;
+}
+
+.ekm-variants-app .ekm-variants-drawer__body section h3 {
+    font-size: 13px;
+    margin: 0 0 10px;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs {
+    display: inline-flex;
+    gap: 4px;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs button {
+    border-bottom: 2px solid transparent;
+    color: #686570;
+    font-weight: 700;
+    padding: 4px 8px;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs button.active {
+    border-bottom-color: #1b264f;
+    color: #1b264f;
+}
+
+.ekm-variants-app table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.ekm-variants-app th {
+    background: #f8f7fa;
+    color: #8b8994;
+    font-size: 11px;
+    letter-spacing: .04em;
+    text-align: left;
+    text-transform: uppercase;
+}
+
+.ekm-variants-app th,
+.ekm-variants-app td {
+    border-bottom: 1px solid #e2e1e6;
+    padding: 8px;
+}

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -1,0 +1,162 @@
+<div ng-controller="Ekom.Variants as vm" class="ekm-variants-app">
+    <umb-box>
+        <umb-box-content>
+            <div class="ekm-variants-toolbar">
+                <div class="ekm-variants-selected">
+                    <span ng-if="vm.selectedCount()">{{ vm.selectedCount() }} selected</span>
+                    <button type="button" class="btn umb-button__button btn-danger" ng-if="vm.selectedCount()" ng-click="vm.deleteSelected()" ng-disabled="vm.busy">Delete</button>
+                </div>
+                <div class="ekm-variants-toolbar__actions">
+                    <button type="button" class="btn umb-button__button btn-primary" ng-click="vm.createGroup()" ng-disabled="vm.busy || !vm.product">Add group</button>
+                    <button type="button" class="btn umb-button__button btn-success" ng-click="vm.saveAll()" ng-disabled="vm.busy || !vm.product || !vm.hasChanges()">Save variant changes</button>
+                </div>
+            </div>
+
+            <p ng-if="vm.loading">Loading variants...</p>
+            <p class="ekm-variants-status ekm-variants-status--error" ng-if="vm.error">{{ vm.error }}</p>
+            <p class="ekm-variants-status" ng-if="vm.status">{{ vm.status }}</p>
+
+            <div ng-if="!vm.loading && vm.product && !vm.product.groups.length" class="ekm-variants-empty">
+                <h3>No variants yet</h3>
+                <p>Create a variant group to start adding product variants.</p>
+                <button type="button" class="btn umb-button__button btn-primary" ng-click="vm.createGroup()">Create variant group</button>
+            </div>
+
+            <div class="ekm-variants-group-list" ng-if="!vm.loading && vm.product && vm.product.groups.length">
+                <article class="ekm-variants-group" ng-repeat="group in vm.product.groups" ng-class="{ 'is-draft': vm.isDraft(group.id) }" draggable="true" data-drag-group-id="{{ group.id }}">
+                    <div class="ekm-variants-group__summary">
+                        <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                        <input type="checkbox" ng-model="vm.selectedGroupIds[group.id]" aria-label="Select group" />
+                        <button type="button" class="ekm-variants-caret" ng-click="vm.toggleGroup(group)" aria-label="Toggle group">{{ vm.expandedGroupIds[group.id] ? '▾' : '▸' }}</button>
+                        <button type="button" class="ekm-variants-thumb ekm-variants-thumb--button" ng-click="vm.toggleGroup(group)">
+                            <img ng-if="vm.getGroupThumbUrl(group)" ng-src="{{ vm.getGroupThumbUrl(group) }}" alt="" />
+                            <span ng-if="!vm.getGroupThumbUrl(group)">-</span>
+                        </button>
+                        <button type="button" class="ekm-variants-title-button" ng-click="vm.toggleGroup(group)">{{ vm.getTitleValue(group) || group.name || 'New variant group' }}</button>
+                        <span class="ekm-variants-count">{{ group.variants.length }} variants</span>
+                        <span class="ekm-variants-pill" ng-if="vm.isDraft(group.id)">draft</span>
+                        <div class="ekm-variants-group__actions">
+                            <button type="button" class="btn umb-button__button" ng-click="vm.editGroup(group)">Edit group</button>
+                            <button type="button" class="btn umb-button__button" ng-click="vm.createVariant(group)">Add variant</button>
+                        </div>
+                    </div>
+
+                    <div class="ekm-variants-table" ng-if="vm.expandedGroupIds[group.id]">
+                        <div class="ekm-variants-table__head">
+                            <span></span><span></span><span></span><span>Title</span><span>SKU</span><span class="ekm-variants-price-cell">Price</span><span class="ekm-variants-stock-cell">Stock</span><span></span>
+                        </div>
+                        <div class="ekm-variants-row" ng-repeat="variant in group.variants" ng-class="{ 'is-draft': vm.isDraft(variant.id) }" draggable="true" data-drag-group-id="{{ group.id }}" data-drag-variant-id="{{ variant.id }}">
+                            <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                            <input type="checkbox" ng-model="vm.selectedVariantIds[variant.id]" aria-label="Select variant" />
+                            <span class="ekm-variants-thumb">
+                                <img ng-if="vm.getFirstImageThumbUrl(variant.images)" ng-src="{{ vm.getFirstImageThumbUrl(variant.images) }}" alt="" />
+                                <span ng-if="!vm.getFirstImageThumbUrl(variant.images)">-</span>
+                            </span>
+                            <strong>{{ vm.getTitleValue(variant) || variant.name || 'New variant' }} <span class="ekm-variants-pill" ng-if="vm.isDraft(variant.id)">draft</span></strong>
+                            <span>{{ variant.sku }}</span>
+                            <span class="ekm-variants-price-cell">{{ vm.getDefaultPrice(variant) }}</span>
+                            <span class="ekm-variants-stock-cell">{{ vm.getTotalStock(variant) }}</span>
+                            <button type="button" class="btn umb-button__button" ng-click="vm.editVariant(group, variant)">Edit</button>
+                        </div>
+                        <p class="ekm-variants-empty-row" ng-if="!group.variants.length">No variants in this group.</p>
+                    </div>
+                </article>
+            </div>
+        </umb-box-content>
+    </umb-box>
+
+    <div class="ekm-variants-drawer-backdrop" ng-if="vm.drawer" ng-click="vm.closeDrawer()"></div>
+    <aside class="ekm-variants-drawer" ng-if="vm.drawer">
+        <header class="ekm-variants-drawer__header">
+            <div>
+                <h2>{{ vm.drawerTitle() }}</h2>
+                <p>{{ vm.drawerSubtitle() }}</p>
+            </div>
+            <div class="ekm-variants-drawer__header-actions">
+                <a class="btn-reset ekm-variants-open-node" ng-if="vm.drawer.item.id > 0" ng-href="#/content/content/edit/{{ vm.drawer.item.id }}" target="_blank" rel="noopener" title="Open node in new tab" aria-label="Open node in new tab"><span aria-hidden="true">✎</span></a>
+                <button type="button" class="btn-reset ekm-variants-close" ng-click="vm.closeDrawer()" aria-label="Close">×</button>
+            </div>
+        </header>
+
+        <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'group'">
+            <label>Group title
+                <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                </div>
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+            </label>
+            <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
+                <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
+            </label>
+            <label>Images
+                <button type="button" class="btn umb-button__button" ng-click="vm.openMediaPicker(vm.drawer.item)">Select images</button>
+                <div class="ekm-variants-media-list" ng-if="vm.mediaImages(vm.drawer.item).length">
+                    <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
+                        <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                        <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                    </div>
+                </div>
+            </label>
+            <p class="ekm-variants-hint">Group images apply to all variants unless a variant has its own.</p>
+        </div>
+
+        <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'variant'">
+            <label>Title
+                <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                </div>
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+            </label>
+            <label>SKU
+                <input type="text" ng-model="vm.drawer.item.sku" />
+            </label>
+            <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
+                <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
+            </label>
+            <section>
+                <h3>Prices</h3>
+                <table>
+                    <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
+                    <tbody>
+                        <tr ng-repeat="priceRow in vm.priceRows()">
+                            <td>{{ priceRow.storeTitle }}</td>
+                            <td>{{ priceRow.currencyLabel }}</td>
+                            <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="priceRow.value" ng-change="vm.setPrice(vm.drawer.item, priceRow.storeAlias, priceRow.currencyValue, priceRow.value)" /></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+            <section>
+                <h3>Stock</h3>
+                <table>
+                    <thead><tr><th>Store</th><th>Stock</th></tr></thead>
+                    <tbody>
+                        <tr ng-repeat="stockRow in vm.stockRows()">
+                            <td>{{ stockRow.storeTitle }}</td>
+                            <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="stockRow.value" ng-change="vm.setStockValue(vm.drawer.item, stockRow.storeAlias, stockRow.value)" /></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+            <label>Images
+                <button type="button" class="btn umb-button__button" ng-click="vm.openMediaPicker(vm.drawer.item)">Select images</button>
+                <div class="ekm-variants-media-list" ng-if="vm.mediaImages(vm.drawer.item).length">
+                    <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
+                        <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                        <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                    </div>
+                </div>
+            </label>
+        </div>
+
+        <footer class="ekm-variants-drawer__footer">
+            <div class="ekm-variants-drawer__footer-left">
+                <button type="button" class="btn umb-button__button btn-danger" ng-click="vm.deleteDrawerItem()">Delete</button>
+            </div>
+            <div class="ekm-variants-drawer__footer-right">
+                <button type="button" class="btn umb-button__button" ng-click="vm.closeDrawer()">Close</button>
+                <button type="button" class="btn umb-button__button btn-success" ng-click="vm.saveDrawer()">Save</button>
+            </div>
+        </footer>
+    </aside>
+</div>

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/package.manifest
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/package.manifest
@@ -6,9 +6,23 @@
         "~/App_Plugins/Ekom/Shared/Chosen/chosen.jquery.min.js",
         "~/App_Plugins/Ekom/Shared/Chosen/angular-chosen.min.js",
         "~/App_Plugins/Ekom/Shared/ekmUtility.js",
-        "~/App_Plugins/Ekom/Shared/ekmResources.js"
+        "~/App_Plugins/Ekom/Shared/ekmResources.js",
+        "~/App_Plugins/Ekom/Variants/ekmVariants.controller.js"
     ],
     "css": [
-        "~/App_Plugins/Ekom/Shared/Chosen/chosen.css"
+        "~/App_Plugins/Ekom/Shared/Chosen/chosen.css",
+        "~/App_Plugins/Ekom/Variants/ekmVariants.css"
+    ],
+    "contentApps": [
+        {
+            "name": "Variants",
+            "alias": "ekomVariants",
+            "weight": 0,
+            "icon": "icon-layers-alt",
+            "view": "~/App_Plugins/Ekom/Variants/ekmVariants.html",
+            "show": [
+                "+content/ekmProduct"
+            ]
+        }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ All Ekom settings live under the `Ekom` section in `appsettings.json`.
       "store1": [ "group-a", "group-b" ]
     }
   },
+  "VariantApp": {
+    "VariantGroups": [ "color" ],
+    "Variants": [ "material" ]
+  },
   "Headless": {
     "ReValidateApis": [
       { "Store": "store1", "Url": "https://example.com/api/revalidate", "Secret": "secret" }
@@ -137,6 +141,8 @@ All Ekom settings live under the `Ekom` section in `appsettings.json`.
 - `CustomerData` (bool, default `false`): Store checkout customer data in `ekmCustomerData` table.
 - `Manager:SectionAccessGroup` (CSV string): Backoffice groups that can access the manager section.
 - `Manager:StoreGroupPermissions` (object): Store alias to allowed group list mapping.
+- `VariantApp:VariantGroups` (list): Textstring property aliases from `ekmProductVariantGroup` to show in the variant group drawer.
+- `VariantApp:Variants` (list): Textstring property aliases from `ekmProductVariant` to show in the variant drawer.
 - `SectionAccessRules` (CSV string, legacy): Backwards-compatible alias for `Manager:SectionAccessGroup`.
 - `Headless:ReValidateApis` (list): Items with `Store`, `Url`, `Secret` for headless revalidation.
 - `OrderDiscountCalculation:ApiKey` (string, required to enable): `POST /ekom/order-discounts/calculate` requires this value in the `X-Ekom-Api-Key` header. When missing or empty, the endpoint always returns unauthorized.
@@ -364,6 +370,19 @@ With this setup:
 - members of `StoreGroup` can access the manager and work only with `Store`
 - members of `Store2Group` can access the manager and work only with `Store2`
 - users without a matching group cannot access the related store
+
+### Variant App custom fields
+
+The backoffice Variant App can expose extra editable textstring properties in the variant group and variant drawers. Configure the property aliases under `Ekom:VariantApp`; labels and required validation come from the Umbraco document type property settings.
+
+```json
+"VariantApp": {
+  "VariantGroups": [ "color" ],
+  "Variants": [ "material", "size" ]
+}
+```
+
+Only Umbraco textstring properties are rendered. See [Variant App custom fields](docs/variant-app.md) for full setup notes.
 
 ## Plugins
 - https://github.com/Vettvangur/Ekom/tree/Ekom/Plugins/Ekom.Klaviyo

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -1,0 +1,822 @@
+angular.module('umbraco').controller('Ekom.Variants', function ($element, $http, $scope, editorService, editorState, notificationsService) {
+    var vm = this;
+
+    vm.loading = true;
+    vm.busy = false;
+    vm.error = '';
+    vm.status = '';
+    vm.product = null;
+    vm.activeLanguage = '';
+    vm.expandedGroupIds = {};
+    vm.selectedGroupIds = {};
+    vm.selectedVariantIds = {};
+    vm.deletedNodeIds = [];
+    vm.groupSnapshots = {};
+    vm.variantSnapshots = {};
+    vm.drawer = null;
+
+    var nextDraftId = -1;
+
+    vm.load = function () {
+        vm.loading = true;
+        vm.error = '';
+
+        $http.get('/ekom/backoffice/Variants/' + encodeURIComponent(editorState.current.id))
+            .then(function (response) {
+                vm.product = response.data;
+                vm.activeLanguage = (vm.product.languages[0] || {}).isoCode || '';
+                vm.expandedGroupIds = {};
+                vm.selectedGroupIds = {};
+                vm.selectedVariantIds = {};
+                vm.deletedNodeIds = [];
+                vm.drawer = null;
+                if (vm.product.groups.length === 1) {
+                    vm.expandedGroupIds[vm.product.groups[0].id] = true;
+                }
+                resetSnapshots();
+                setBadge();
+            })
+            .catch(function (error) {
+                vm.error = getErrorMessage(error, 'Could not load variants.');
+                notificationsService.error('Variants', vm.error);
+            })
+            .finally(function () {
+                vm.loading = false;
+            });
+    };
+
+    vm.createGroup = function () {
+        var id = nextDraftId--;
+        var group = {
+            id: id,
+            key: '00000000-0000-0000-0000-000000000000',
+            name: 'New variant group',
+            title: '',
+            titleValues: createEmptyTitleValues(),
+            color: '',
+            images: '',
+            sortOrder: vm.product.groups.length,
+            published: false,
+            customFields: createCustomFields(vm.product.variantGroupFields),
+            variants: []
+        };
+
+        vm.product.groups.push(group);
+        vm.expandedGroupIds[id] = true;
+        vm.drawer = { type: 'group', group: group, item: group };
+    };
+
+    vm.createVariant = function (group) {
+        var id = nextDraftId--;
+        var variant = {
+            id: id,
+            key: '00000000-0000-0000-0000-000000000000',
+            name: 'New variant',
+            title: '',
+            titleValues: createEmptyTitleValues(),
+            sku: '',
+            images: '',
+            priceValues: {},
+            stockValues: createEmptyStockValues(),
+            customFields: createCustomFields(vm.product.variantFields),
+            sortOrder: group.variants.length,
+            published: false
+        };
+
+        group.variants.push(variant);
+        vm.expandedGroupIds[group.id] = true;
+        vm.drawer = { type: 'variant', group: group, item: variant };
+    };
+
+    vm.saveAll = function () {
+        if (!validateAllCustomFields()) {
+            return;
+        }
+
+        if (!vm.hasChanges()) {
+            vm.status = 'No changes to save.';
+            notificationsService.info('Variants', 'No changes to save.');
+            return;
+        }
+
+        saveVariantChanges();
+    };
+
+    $scope.$on('formSubmitting', function () {
+        if (vm.product && vm.hasChanges()) {
+            saveVariantChanges({ silentNoChanges: true });
+        }
+    });
+
+    vm.deleteSelected = function () {
+        var count = selectedCount();
+
+        if (!count || !window.confirm('Delete ' + count + ' selected item' + (count === 1 ? '' : 's') + '?')) {
+            return;
+        }
+
+        (vm.product.groups || []).forEach(function (group) {
+            if (vm.selectedGroupIds[group.id] && !isDraft(group.id)) {
+                addDeletedNodeId(group.id);
+            }
+
+            group.variants.forEach(function (variant) {
+                if (vm.selectedVariantIds[variant.id] && !isDraft(variant.id)) {
+                    addDeletedNodeId(variant.id);
+                }
+            });
+        });
+
+        vm.product.groups = (vm.product.groups || []).filter(function (group) {
+            return !vm.selectedGroupIds[group.id];
+        }).map(function (group) {
+            group.variants = group.variants.filter(function (variant) {
+                return !vm.selectedVariantIds[variant.id];
+            });
+            return group;
+        });
+
+        vm.selectedGroupIds = {};
+        vm.selectedVariantIds = {};
+        vm.drawer = null;
+    };
+
+    vm.toggleGroup = function (group) {
+        vm.expandedGroupIds[group.id] = !vm.expandedGroupIds[group.id];
+    };
+
+    vm.editGroup = function (group) {
+        vm.drawer = { type: 'group', group: group, item: group };
+    };
+
+    vm.editVariant = function (group, variant) {
+        vm.drawer = { type: 'variant', group: group, item: variant };
+    };
+
+    vm.closeDrawer = function () {
+        vm.drawer = null;
+    };
+
+    vm.saveDrawer = function () {
+        if (!validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
+            return;
+        }
+
+        vm.drawer = null;
+    };
+
+    vm.deleteDrawerItem = function () {
+        if (!vm.drawer) {
+            return;
+        }
+
+        var isGroup = vm.drawer.type === 'group';
+        var label = isGroup ? 'variant group' : 'variant';
+
+        if (!window.confirm('Delete this ' + label + '?')) {
+            return;
+        }
+
+        if (isGroup) {
+            if (!isDraft(vm.drawer.item.id)) {
+                addDeletedNodeId(vm.drawer.item.id);
+            }
+
+            vm.product.groups = (vm.product.groups || []).filter(function (group) {
+                return group.id !== vm.drawer.item.id;
+            });
+        } else {
+            if (!isDraft(vm.drawer.item.id)) {
+                addDeletedNodeId(vm.drawer.item.id);
+            }
+
+            vm.drawer.group.variants = vm.drawer.group.variants.filter(function (variant) {
+                return variant.id !== vm.drawer.item.id;
+            });
+        }
+
+        vm.drawer = null;
+    };
+
+    vm.drawerTitle = function () {
+        if (!vm.drawer) {
+            return '';
+        }
+
+        return vm.getTitleValue(vm.drawer.item) || vm.drawer.item.name || (vm.drawer.type === 'group' ? 'New variant group' : 'New variant');
+    };
+
+    vm.drawerSubtitle = function () {
+        if (!vm.drawer) {
+            return '';
+        }
+
+        return vm.drawer.type === 'group' ? 'variant group' : (vm.getTitleValue(vm.drawer.group) || 'Group') + ' / variant';
+    };
+
+    vm.setLanguage = function (value) {
+        vm.activeLanguage = value;
+    };
+
+    vm.getTitleValue = function (item) {
+        ensureTitleValues(item);
+        return item.titleValues[vm.activeLanguage] || firstValue(item.titleValues) || item.title || '';
+    };
+
+    vm.setTitleValue = function (item, value) {
+        ensureTitleValues(item);
+        item.titleValues[vm.activeLanguage] = value;
+        item.title = firstValue(item.titleValues) || item.name;
+    };
+
+    vm.getPrice = getVariantPrice;
+
+    vm.setPrice = function (variant, storeAlias, currency, value) {
+        if (!variant.priceValues) {
+            variant.priceValues = {};
+        }
+
+        var prices = variant.priceValues[storeAlias] || [];
+        var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
+        var numericValue = Number(value) || 0;
+
+        if (price) {
+            price.Price = numericValue;
+            price.price = numericValue;
+        } else {
+            prices.push({ Currency: currency, Price: numericValue });
+        }
+
+        variant.priceValues[storeAlias] = prices;
+    };
+
+    vm.getStockValue = function (variant, storeAlias) {
+        var stock = (variant.stockValues || []).filter(function (item) { return item.storeAlias === storeAlias; })[0];
+        return stock ? stock.value || 0 : 0;
+    };
+
+    vm.setCustomField = function (item, field, value) {
+        ensureCustomFields(item);
+        var customField = item.customFields.filter(function (current) { return current.alias === field.alias; })[0];
+
+        if (customField) {
+            customField.value = value;
+        }
+    };
+
+    vm.setStockValue = function (variant, storeAlias, value) {
+        if (!variant.stockValues) {
+            variant.stockValues = [];
+        }
+
+        var stock = variant.stockValues.filter(function (item) { return item.storeAlias === storeAlias; })[0];
+        if (!stock) {
+            stock = { storeAlias: storeAlias, value: 0 };
+            variant.stockValues.push(stock);
+        }
+
+        stock.value = Number(value) || 0;
+    };
+
+    vm.priceRows = function () {
+        if (!vm.drawer || vm.drawer.type !== 'variant') {
+            return [];
+        }
+
+        var rows = [];
+        (vm.product.stores || []).forEach(function (store) {
+            (store.currencies || []).forEach(function (currency) {
+                rows.push({
+                    storeAlias: store.alias || '',
+                    storeTitle: store.title || store.alias || '',
+                    currencyValue: currency.currencyValue || '',
+                    currencyLabel: currency.isoCurrencySymbol || currency.currencyValue || '',
+                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
+                });
+            });
+        });
+
+        return rows;
+    };
+
+    vm.stockRows = function () {
+        if (!vm.drawer || vm.drawer.type !== 'variant') {
+            return [];
+        }
+
+        return (vm.product.stores || []).map(function (store) {
+            var storeAlias = store.alias || '';
+            return {
+                storeAlias: storeAlias,
+                storeTitle: store.title || storeAlias,
+                value: vm.getStockValue(vm.drawer.item, storeAlias)
+            };
+        });
+    };
+
+    vm.variantImageHint = function () {
+        if (!vm.drawer || vm.drawer.type !== 'variant') {
+            return '';
+        }
+
+        var ownImages = splitImages(vm.drawer.item.images).length;
+        var groupImages = splitImages(vm.drawer.group.images).length;
+        return ownImages ? 'Own images override the group images.' : 'No own images — inherits ' + groupImages + ' image(s) from ' + (vm.getTitleValue(vm.drawer.group) || 'group') + '.';
+    };
+
+    vm.isGroupChanged = isGroupChanged;
+    vm.isVariantChanged = isVariantChanged;
+    vm.hasChanges = function () {
+        return vm.deletedNodeIds.length > 0 || (vm.product && (vm.product.groups || []).some(function (group) {
+            return isGroupChanged(group) || group.variants.some(isVariantChanged);
+        }));
+    };
+    vm.selectedCount = selectedCount;
+    vm.isDraft = isDraft;
+    vm.imageCount = function (value) { return splitImages(value).length; };
+    vm.mediaImages = function (item) { return splitImages(item && item.images); };
+    vm.getThumbUrl = getThumbUrl;
+    vm.getLanguageLabel = getLanguageLabel;
+    vm.getFirstImageThumbUrl = getFirstImageThumbUrl;
+    vm.getGroupThumbUrl = function (group) {
+        var image = getFirstImage(group.images);
+
+        if (!image) {
+            for (var i = 0; i < group.variants.length; i++) {
+                image = getFirstImage(group.variants[i].images);
+
+                if (image) {
+                    break;
+                }
+            }
+        }
+
+        return getThumbUrl(image);
+    };
+    vm.getDefaultPrice = function (variant) {
+        var store = (vm.product.stores || [])[0];
+        var currency = store && (store.currencies || [])[0];
+
+        if (!store || !currency) {
+            return '—';
+        }
+
+        var value = getVariantPrice(variant, store.alias || '', currency.currencyValue || '');
+        var symbol = currency.currencySymbol || currency.isoCurrencySymbol || currency.currencyValue || '';
+        return (formatNumber(value) + ' ' + symbol).trim();
+    };
+    vm.getTotalStock = function (variant) {
+        return formatNumber((variant.stockValues || []).reduce(function (total, stock) {
+            return total + (Number(stock.value) || 0);
+        }, 0));
+    };
+    vm.openMediaPicker = function (item) {
+        editorService.mediaPicker({
+            multiPicker: true,
+            selection: splitImages(item.images),
+            submit: function (model) {
+                item.images = normalizeMediaSelection(model.selection).join(',');
+                editorService.close();
+            },
+            close: function () {
+                editorService.close();
+            }
+        });
+    };
+
+    bindDragAndDrop();
+
+    function saveVariantChanges(options) {
+        if (!validateAllCustomFields()) {
+            return Promise.resolve();
+        }
+
+        var groups = (vm.product.groups || []).map(getChangedGroupForSave).filter(Boolean);
+
+        return saveGroups(groups, options || {});
+    }
+
+    function saveGroups(groups, options) {
+        options = options || {};
+
+        if (!groups.length && !vm.deletedNodeIds.length) {
+            if (!options.silentNoChanges) {
+                vm.status = 'No changes to save.';
+                notificationsService.info('Variants', 'No changes to save.');
+            }
+
+            return Promise.resolve();
+        }
+
+        return runAction('Saving changes...', function () {
+            var deleteRequests = vm.deletedNodeIds.map(function (id) {
+                return $http.delete('/ekom/backoffice/Variants/' + encodeURIComponent(id));
+            });
+
+            return Promise.all(deleteRequests).then(function () {
+                if (!groups.length) {
+                    return vm.load();
+                }
+
+                return $http.post('/ekom/backoffice/Variants/Save', {
+                    productId: String(editorState.current.id),
+                    publish: true,
+                    groups: groups
+                }).then(function (response) {
+                    vm.product = response.data;
+                    vm.selectedGroupIds = {};
+                    vm.selectedVariantIds = {};
+                    vm.deletedNodeIds = [];
+                    vm.drawer = null;
+                    vm.expandedGroupIds = {};
+                    if (vm.product.groups.length === 1) {
+                        vm.expandedGroupIds[vm.product.groups[0].id] = true;
+                    }
+                    resetSnapshots();
+                    setBadge();
+                });
+            });
+        });
+    }
+
+    function getChangedGroupForSave(group) {
+        var variants = group.variants.filter(isVariantChanged).map(markChanged);
+
+        if (!isGroupChanged(group) && !variants.length) {
+            return null;
+        }
+
+        return angular.extend({}, group, { changed: isGroupChanged(group), variants: variants });
+    }
+
+    function markChanged(item) {
+        return angular.extend({}, item, { changed: true });
+    }
+
+    function runAction(status, action) {
+        vm.busy = true;
+        vm.status = status;
+        vm.error = '';
+
+        return action()
+            .then(function () {
+                vm.status = 'Done.';
+                notificationsService.success('Variants', 'Variant changes were saved.');
+            })
+            .catch(function (error) {
+                vm.error = getErrorMessage(error, 'Action failed.');
+                notificationsService.error('Variants', vm.error);
+            })
+            .finally(function () {
+                vm.busy = false;
+            });
+    }
+
+    function resetSnapshots() {
+        vm.groupSnapshots = {};
+        vm.variantSnapshots = {};
+        (vm.product.groups || []).forEach(function (group) {
+            vm.groupSnapshots[group.id] = snapshotGroup(group);
+            group.variants.forEach(function (variant) {
+                vm.variantSnapshots[variant.id] = snapshotVariant(variant);
+            });
+        });
+    }
+
+    function isGroupChanged(group) {
+        return isDraft(group.id) || vm.groupSnapshots[group.id] !== snapshotGroup(group);
+    }
+
+    function isVariantChanged(variant) {
+        return isDraft(variant.id) || vm.variantSnapshots[variant.id] !== snapshotVariant(variant);
+    }
+
+    function createEmptyTitleValues() {
+        var values = {};
+        (vm.product.languages || []).forEach(function (language) {
+            values[language.isoCode || ''] = '';
+        });
+        return values;
+    }
+
+    function createCustomFields(fields) {
+        return (fields || []).map(function (field) {
+            return angular.extend({}, field, { value: '' });
+        });
+    }
+
+    function ensureCustomFields(item) {
+        if (!item.customFields) {
+            item.customFields = [];
+        }
+    }
+
+    function validateAllCustomFields() {
+        var groups = vm.product ? vm.product.groups || [] : [];
+
+        for (var i = 0; i < groups.length; i++) {
+            if (!validateCustomFields(groups[i].customFields)) {
+                return false;
+            }
+
+            for (var j = 0; j < groups[i].variants.length; j++) {
+                if (!validateCustomFields(groups[i].variants[j].customFields)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    function validateCustomFields(fields) {
+        var missing = (fields || []).filter(function (field) {
+            return field.required && !String(field.value || '').trim();
+        })[0];
+
+        if (!missing) {
+            return true;
+        }
+
+        notificationsService.error('Variants', missing.label + ' is required.');
+        return false;
+    }
+
+    function createEmptyStockValues() {
+        return (vm.product.stores || []).map(function (store) {
+            return { storeAlias: store.alias || '', value: 0 };
+        });
+    }
+
+    function ensureTitleValues(item) {
+        if (!item.titleValues) {
+            item.titleValues = {};
+        }
+    }
+
+    function selectedCount() {
+        return Object.keys(vm.selectedGroupIds).filter(function (key) { return vm.selectedGroupIds[key]; }).length
+            + Object.keys(vm.selectedVariantIds).filter(function (key) { return vm.selectedVariantIds[key]; }).length;
+    }
+
+    function addDeletedNodeId(id) {
+        if (vm.deletedNodeIds.indexOf(id) === -1) {
+            vm.deletedNodeIds.push(id);
+        }
+    }
+
+    function bindDragAndDrop() {
+        var draggedGroupId = null;
+        var draggedVariant = null;
+        var draggedImageIndex = null;
+
+        $element[0].addEventListener('dragstart', function (event) {
+            var mediaCard = event.target.closest('[data-media-image-index]');
+            if (mediaCard) {
+                draggedImageIndex = Number(mediaCard.getAttribute('data-media-image-index'));
+                event.stopPropagation();
+                return;
+            }
+
+            var variantRow = event.target.closest('[data-drag-variant-id]');
+            if (variantRow) {
+                draggedVariant = {
+                    groupId: Number(variantRow.getAttribute('data-drag-group-id')),
+                    variantId: Number(variantRow.getAttribute('data-drag-variant-id'))
+                };
+                event.stopPropagation();
+                return;
+            }
+
+            var groupCard = event.target.closest('.ekm-variants-group[data-drag-group-id]');
+            if (groupCard) {
+                draggedGroupId = Number(groupCard.getAttribute('data-drag-group-id'));
+            }
+        });
+
+        $element[0].addEventListener('dragover', function (event) {
+            if (draggedImageIndex !== null && event.target.closest('[data-media-image-index]')) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+
+            var variantRow = event.target.closest('[data-drag-variant-id]');
+            if (variantRow && draggedVariant && draggedVariant.groupId === Number(variantRow.getAttribute('data-drag-group-id'))) {
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
+
+            if (draggedGroupId !== null && event.target.closest('.ekm-variants-group[data-drag-group-id]')) {
+                event.preventDefault();
+            }
+        });
+
+        $element[0].addEventListener('drop', function (event) {
+            var mediaCard = event.target.closest('[data-media-image-index]');
+            if (mediaCard && draggedImageIndex !== null) {
+                event.preventDefault();
+                event.stopPropagation();
+                $scope.$apply(function () {
+                    reorderDrawerImage(draggedImageIndex, Number(mediaCard.getAttribute('data-media-image-index')));
+                });
+                draggedImageIndex = null;
+                return;
+            }
+
+            var variantRow = event.target.closest('[data-drag-variant-id]');
+            if (variantRow && draggedVariant) {
+                event.preventDefault();
+                event.stopPropagation();
+                $scope.$apply(function () {
+                    reorderVariant(draggedVariant, Number(variantRow.getAttribute('data-drag-group-id')), Number(variantRow.getAttribute('data-drag-variant-id')));
+                });
+                draggedVariant = null;
+                return;
+            }
+
+            var groupCard = event.target.closest('.ekm-variants-group[data-drag-group-id]');
+            if (groupCard && draggedGroupId !== null) {
+                event.preventDefault();
+                $scope.$apply(function () {
+                    reorderGroup(draggedGroupId, Number(groupCard.getAttribute('data-drag-group-id')));
+                });
+                draggedGroupId = null;
+            }
+        });
+
+        $element[0].addEventListener('dragend', function () {
+            draggedGroupId = null;
+            draggedVariant = null;
+            draggedImageIndex = null;
+        });
+    }
+
+    function reorderDrawerImage(sourceIndex, targetIndex) {
+        if (!vm.drawer || sourceIndex === targetIndex) {
+            return;
+        }
+
+        var images = splitImages(vm.drawer.item.images);
+
+        if (sourceIndex < 0 || targetIndex < 0 || sourceIndex >= images.length || targetIndex >= images.length) {
+            return;
+        }
+
+        var image = images.splice(sourceIndex, 1)[0];
+        images.splice(targetIndex, 0, image);
+        vm.drawer.item.images = images.join(',');
+    }
+
+    function reorderGroup(sourceId, targetId) {
+        if (sourceId === targetId) {
+            return;
+        }
+
+        vm.product.groups = reorderById(vm.product.groups, sourceId, targetId);
+        vm.product.groups.forEach(function (group, index) {
+            group.sortOrder = index;
+        });
+    }
+
+    function reorderVariant(source, targetGroupId, targetVariantId) {
+        if (!source || source.groupId !== targetGroupId || source.variantId === targetVariantId) {
+            return;
+        }
+
+        var group = (vm.product.groups || []).filter(function (item) { return item.id === source.groupId; })[0];
+        if (!group) {
+            return;
+        }
+
+        group.variants = reorderById(group.variants, source.variantId, targetVariantId);
+        group.variants.forEach(function (variant, index) {
+            variant.sortOrder = index;
+        });
+    }
+
+    function reorderById(items, sourceId, targetId) {
+        var next = items.slice();
+        var sourceIndex = next.findIndex(function (item) { return item.id === sourceId; });
+        var targetIndex = next.findIndex(function (item) { return item.id === targetId; });
+
+        if (sourceIndex < 0 || targetIndex < 0) {
+            return items;
+        }
+
+        var item = next.splice(sourceIndex, 1)[0];
+        next.splice(targetIndex, 0, item);
+        return next;
+    }
+
+    function setBadge() {
+        var count = vm.product ? vm.product.variantCount : 0;
+        $scope.model.badge = count > 0 ? { count: count, type: 'default' } : null;
+    }
+
+    function firstValue(values) {
+        for (var key in values) {
+            if (values[key]) {
+                return values[key];
+            }
+        }
+
+        return '';
+    }
+
+    function getLanguageLabel(language) {
+        return String(language.isoCode || language.cultureName || '').split('-')[0].toUpperCase();
+    }
+
+    function getVariantPrice(variant, storeAlias, currency) {
+        var prices = (variant.priceValues || {})[storeAlias] || [];
+        var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
+        return price ? getPrice(price) : 0;
+    }
+
+    function getCurrency(price) {
+        return price.Currency || price.currency || '';
+    }
+
+    function getPrice(price) {
+        return price.Price || price.price || 0;
+    }
+
+    function formatNumber(value) {
+        return new Intl.NumberFormat().format(value || 0);
+    }
+
+    function splitImages(value) {
+        var rawValue = String(value || '').trim();
+
+        if (!rawValue) {
+            return [];
+        }
+
+        if (rawValue.indexOf('[') === 0) {
+            try {
+                return JSON.parse(rawValue).map(function (item) {
+                    return String(item.mediaKey || item.key || '').trim();
+                }).filter(Boolean);
+            } catch (error) {
+                return [];
+            }
+        }
+
+        return rawValue.split(',').map(function (item) { return normalizeMediaIdentifier(item.trim()); }).filter(Boolean);
+    }
+
+    function normalizeMediaIdentifier(value) {
+        var match = value.match(/umb:\/\/media\/(.+)$/i);
+        return match ? match[1] : value;
+    }
+
+    function getFirstImageThumbUrl(value) {
+        return getThumbUrl(getFirstImage(value));
+    }
+
+    function getFirstImage(value) {
+        return splitImages(value)[0] || '';
+    }
+
+    function getThumbUrl(image) {
+        if (!image) {
+            return '';
+        }
+
+        return '/ekom/backoffice/Variants/Media/Thumbnail?mediaId=' + encodeURIComponent(image) + '&width=38&height=38';
+    }
+
+    function normalizeMediaSelection(selection) {
+        return (selection || []).map(function (item) {
+            if (typeof item === 'string') {
+                return item;
+            }
+
+            return item.udi || item.key || item.id || '';
+        }).filter(Boolean);
+    }
+
+    function isDraft(id) {
+        return id <= 0;
+    }
+
+    function snapshotGroup(group) {
+        return angular.toJson({ titleValues: group.titleValues, images: group.images, customFields: group.customFields, sortOrder: group.sortOrder });
+    }
+
+    function snapshotVariant(variant) {
+        return angular.toJson({ titleValues: variant.titleValues, sku: variant.sku, images: variant.images, priceValues: variant.priceValues, stockValues: variant.stockValues, customFields: variant.customFields, sortOrder: variant.sortOrder });
+    }
+
+    function getErrorMessage(error, fallback) {
+        if (error && error.data) {
+            return typeof error.data === 'string' ? error.data : error.data.message || fallback;
+        }
+
+        return fallback;
+    }
+
+    vm.load();
+});

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -1,0 +1,380 @@
+.ekm-variants-app {
+    color: #1b264f;
+}
+
+.ekm-variants-app .ekm-variants-toolbar,
+.ekm-variants-app .ekm-variants-selected,
+.ekm-variants-app .ekm-variants-toolbar__actions,
+.ekm-variants-app .ekm-variants-group__summary,
+.ekm-variants-app .ekm-variants-group__actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.ekm-variants-app .ekm-variants-toolbar {
+    background: #fff;
+    border-bottom: 1px solid #e2e1e6;
+    box-shadow: 0 4px 10px rgba(27, 38, 79, .06);
+    justify-content: space-between;
+    margin: -20px -20px 16px;
+    padding: 16px 20px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.ekm-variants-app .ekm-variants-selected {
+    min-height: 32px;
+}
+
+.ekm-variants-app .ekm-variants-toolbar__actions,
+.ekm-variants-app .ekm-variants-group__actions {
+    justify-content: flex-end;
+    margin-left: auto;
+}
+
+.ekm-variants-app .ekm-variants-group-list {
+    display: grid;
+    gap: 14px;
+}
+
+.ekm-variants-app .ekm-variants-group {
+    background: #fff;
+    border: 1px solid #e2e1e6;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(27, 38, 79, .06);
+    overflow: hidden;
+}
+
+.ekm-variants-app .ekm-variants-group.is-draft,
+.ekm-variants-app .ekm-variants-row.is-draft {
+    background: #f8fbf9;
+}
+
+.ekm-variants-app .ekm-variants-group__summary {
+    padding: 12px 14px;
+}
+
+.ekm-variants-app .ekm-variants-drag-handle {
+    color: #8b8994;
+    cursor: grab;
+    font-weight: 900;
+    letter-spacing: -2px;
+    user-select: none;
+}
+
+.ekm-variants-app .ekm-variants-caret,
+.ekm-variants-app .ekm-variants-title-button,
+.ekm-variants-app .ekm-variants-thumb--button,
+.ekm-variants-app .ekm-variants-open-node,
+.ekm-variants-app .ekm-variants-close,
+.ekm-variants-app .ekm-variants-mini-tabs button {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+}
+
+.ekm-variants-app .ekm-variants-title-button {
+    font-weight: 900;
+    text-align: left;
+}
+
+.ekm-variants-app .ekm-variants-thumb {
+    align-items: center;
+    background: #f4f3f5;
+    border: 1px solid #e2e1e6;
+    border-radius: 4px;
+    color: #686570;
+    display: inline-flex;
+    font-size: 11px;
+    height: 38px;
+    justify-content: center;
+    text-transform: uppercase;
+    width: 38px;
+}
+
+.ekm-variants-app .ekm-variants-thumb img {
+    border-radius: 3px;
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+}
+
+.ekm-variants-app .ekm-variants-count,
+.ekm-variants-app .ekm-variants-hint,
+.ekm-variants-app small {
+    color: #686570;
+}
+
+.ekm-variants-app .ekm-variants-pill {
+    background: #ecf7f1;
+    border-radius: 999px;
+    color: #188a4f;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    text-transform: uppercase;
+}
+
+.ekm-variants-app .ekm-variants-table {
+    border-top: 1px solid #e2e1e6;
+}
+
+.ekm-variants-app .ekm-variants-table__head,
+.ekm-variants-app .ekm-variants-row {
+    align-items: center;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 18px 24px 44px minmax(140px, 1.3fr) minmax(100px, .8fr) minmax(100px, .8fr) minmax(80px, .6fr) auto;
+    padding: 10px 14px;
+}
+
+.ekm-variants-app .ekm-variants-table__head {
+    background: #f8f7fa;
+    color: #8b8994;
+    font-size: 11px;
+    font-weight: 900;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+
+.ekm-variants-app .ekm-variants-row {
+    border-top: 1px solid #e2e1e6;
+}
+
+.ekm-variants-app .ekm-variants-price-cell,
+.ekm-variants-app .ekm-variants-stock-cell {
+    text-align: center;
+}
+
+.ekm-variants-app label {
+    display: grid;
+    font-weight: 700;
+    gap: 8px;
+}
+
+.ekm-variants-app input {
+    border: 1px solid #c4c2cb;
+    border-radius: 3px;
+    box-sizing: border-box;
+    font: inherit;
+    padding: 8px;
+    width: 100%;
+}
+
+.ekm-variants-app input:focus {
+    border-color: #1b264f;
+    outline: none;
+}
+
+.ekm-variants-app input[type="checkbox"] {
+    accent-color: #188a4f;
+    height: 16px;
+    padding: 0;
+    width: 16px;
+}
+
+.ekm-variants-app .ekm-variants-number {
+    text-align: right;
+}
+
+.ekm-variants-app .ekm-variants-media-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.ekm-variants-app .ekm-variants-media-card {
+    align-items: center;
+    background: #f4f3f5;
+    border: 1px solid #e2e1e6;
+    border-radius: 4px;
+    cursor: grab;
+    display: grid;
+    gap: 4px;
+    grid-template-columns: 14px 54px;
+    padding: 4px;
+}
+
+.ekm-variants-app .ekm-variants-media-card img {
+    border-radius: 3px;
+    height: 54px;
+    object-fit: cover;
+    width: 54px;
+}
+
+.ekm-variants-app .ekm-variants-status {
+    background: #fff;
+    border-radius: 3px;
+    padding: 12px;
+}
+
+.ekm-variants-app .ekm-variants-status--error {
+    color: #d42054;
+}
+
+.ekm-variants-app .ekm-variants-empty,
+.ekm-variants-app .ekm-variants-empty-row {
+    border: 1px dashed #d8d7d9;
+    border-radius: 3px;
+    padding: 24px;
+}
+
+.ekm-variants-app .ekm-variants-empty-row {
+    border-width: 1px 0 0;
+    margin: 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer-backdrop {
+    background: rgba(27, 38, 79, .35);
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: 1000;
+}
+
+.ekm-variants-app .ekm-variants-drawer {
+    background: #fff;
+    bottom: 0;
+    box-shadow: -6px 0 24px rgba(27, 38, 79, .18);
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: min(460px, 100vw);
+    z-index: 1001;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header,
+.ekm-variants-app .ekm-variants-drawer__footer {
+    align-items: center;
+    border-bottom: 1px solid #e2e1e6;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    padding: 18px;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header > div:first-child {
+    min-width: 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header-actions {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+    gap: 8px;
+}
+
+.ekm-variants-app .ekm-variants-open-node {
+    align-items: center;
+    border: 1px solid #d8d7dc;
+    border-radius: 3px;
+    color: #1b264f;
+    display: inline-flex;
+    height: 32px;
+    justify-content: center;
+    text-decoration: none;
+    width: 32px;
+}
+
+.ekm-variants-app .ekm-variants-open-node:hover {
+    background: #f8f7fa;
+    color: #1b264f;
+    text-decoration: none;
+}
+
+.ekm-variants-app .ekm-variants-open-node span {
+    font-size: 15px;
+    line-height: 1;
+    transform: translateY(-1px);
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer {
+    border-bottom: 0;
+    border-top: 1px solid #e2e1e6;
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer-left,
+.ekm-variants-app .ekm-variants-drawer__footer-right {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer-left {
+    margin-right: auto;
+}
+
+.ekm-variants-app .ekm-variants-drawer__footer-left .btn-danger {
+    background: #d42054;
+    border-color: #d42054;
+    color: #fff;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header h2 {
+    font-size: 20px;
+    margin: 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer__header p {
+    color: #686570;
+    margin: 4px 0 0;
+}
+
+.ekm-variants-app .ekm-variants-drawer__body {
+    align-content: start;
+    display: grid;
+    gap: 18px;
+    overflow: auto;
+    padding: 18px;
+}
+
+.ekm-variants-app .ekm-variants-drawer__body section h3 {
+    font-size: 13px;
+    margin: 0 0 10px;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs {
+    display: inline-flex;
+    gap: 4px;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs button {
+    border-bottom: 2px solid transparent;
+    color: #686570;
+    font-weight: 700;
+    padding: 4px 8px;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs button.active {
+    border-bottom-color: #1b264f;
+    color: #1b264f;
+}
+
+.ekm-variants-app table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.ekm-variants-app th {
+    background: #f8f7fa;
+    color: #8b8994;
+    font-size: 11px;
+    letter-spacing: .04em;
+    text-align: left;
+    text-transform: uppercase;
+}
+
+.ekm-variants-app th,
+.ekm-variants-app td {
+    border-bottom: 1px solid #e2e1e6;
+    padding: 8px;
+}

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -1,0 +1,162 @@
+<div ng-controller="Ekom.Variants as vm" class="ekm-variants-app">
+    <umb-box>
+        <umb-box-content>
+            <div class="ekm-variants-toolbar">
+                <div class="ekm-variants-selected">
+                    <span ng-if="vm.selectedCount()">{{ vm.selectedCount() }} selected</span>
+                    <button type="button" class="btn umb-button__button btn-danger" ng-if="vm.selectedCount()" ng-click="vm.deleteSelected()" ng-disabled="vm.busy">Delete</button>
+                </div>
+                <div class="ekm-variants-toolbar__actions">
+                    <button type="button" class="btn umb-button__button btn-primary" ng-click="vm.createGroup()" ng-disabled="vm.busy || !vm.product">Add group</button>
+                    <button type="button" class="btn umb-button__button btn-success" ng-click="vm.saveAll()" ng-disabled="vm.busy || !vm.product || !vm.hasChanges()">Save variant changes</button>
+                </div>
+            </div>
+
+            <p ng-if="vm.loading">Loading variants...</p>
+            <p class="ekm-variants-status ekm-variants-status--error" ng-if="vm.error">{{ vm.error }}</p>
+            <p class="ekm-variants-status" ng-if="vm.status">{{ vm.status }}</p>
+
+            <div ng-if="!vm.loading && vm.product && !vm.product.groups.length" class="ekm-variants-empty">
+                <h3>No variants yet</h3>
+                <p>Create a variant group to start adding product variants.</p>
+                <button type="button" class="btn umb-button__button btn-primary" ng-click="vm.createGroup()">Create variant group</button>
+            </div>
+
+            <div class="ekm-variants-group-list" ng-if="!vm.loading && vm.product && vm.product.groups.length">
+                <article class="ekm-variants-group" ng-repeat="group in vm.product.groups" ng-class="{ 'is-draft': vm.isDraft(group.id) }" draggable="true" data-drag-group-id="{{ group.id }}">
+                    <div class="ekm-variants-group__summary">
+                        <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                        <input type="checkbox" ng-model="vm.selectedGroupIds[group.id]" aria-label="Select group" />
+                        <button type="button" class="ekm-variants-caret" ng-click="vm.toggleGroup(group)" aria-label="Toggle group">{{ vm.expandedGroupIds[group.id] ? '▾' : '▸' }}</button>
+                        <button type="button" class="ekm-variants-thumb ekm-variants-thumb--button" ng-click="vm.toggleGroup(group)">
+                            <img ng-if="vm.getGroupThumbUrl(group)" ng-src="{{ vm.getGroupThumbUrl(group) }}" alt="" />
+                            <span ng-if="!vm.getGroupThumbUrl(group)">-</span>
+                        </button>
+                        <button type="button" class="ekm-variants-title-button" ng-click="vm.toggleGroup(group)">{{ vm.getTitleValue(group) || group.name || 'New variant group' }}</button>
+                        <span class="ekm-variants-count">{{ group.variants.length }} variants</span>
+                        <span class="ekm-variants-pill" ng-if="vm.isDraft(group.id)">draft</span>
+                        <div class="ekm-variants-group__actions">
+                            <button type="button" class="btn umb-button__button" ng-click="vm.editGroup(group)">Edit group</button>
+                            <button type="button" class="btn umb-button__button" ng-click="vm.createVariant(group)">Add variant</button>
+                        </div>
+                    </div>
+
+                    <div class="ekm-variants-table" ng-if="vm.expandedGroupIds[group.id]">
+                        <div class="ekm-variants-table__head">
+                            <span></span><span></span><span></span><span>Title</span><span>SKU</span><span class="ekm-variants-price-cell">Price</span><span class="ekm-variants-stock-cell">Stock</span><span></span>
+                        </div>
+                        <div class="ekm-variants-row" ng-repeat="variant in group.variants" ng-class="{ 'is-draft': vm.isDraft(variant.id) }" draggable="true" data-drag-group-id="{{ group.id }}" data-drag-variant-id="{{ variant.id }}">
+                            <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                            <input type="checkbox" ng-model="vm.selectedVariantIds[variant.id]" aria-label="Select variant" />
+                            <span class="ekm-variants-thumb">
+                                <img ng-if="vm.getFirstImageThumbUrl(variant.images)" ng-src="{{ vm.getFirstImageThumbUrl(variant.images) }}" alt="" />
+                                <span ng-if="!vm.getFirstImageThumbUrl(variant.images)">-</span>
+                            </span>
+                            <strong>{{ vm.getTitleValue(variant) || variant.name || 'New variant' }} <span class="ekm-variants-pill" ng-if="vm.isDraft(variant.id)">draft</span></strong>
+                            <span>{{ variant.sku }}</span>
+                            <span class="ekm-variants-price-cell">{{ vm.getDefaultPrice(variant) }}</span>
+                            <span class="ekm-variants-stock-cell">{{ vm.getTotalStock(variant) }}</span>
+                            <button type="button" class="btn umb-button__button" ng-click="vm.editVariant(group, variant)">Edit</button>
+                        </div>
+                        <p class="ekm-variants-empty-row" ng-if="!group.variants.length">No variants in this group.</p>
+                    </div>
+                </article>
+            </div>
+        </umb-box-content>
+    </umb-box>
+
+    <div class="ekm-variants-drawer-backdrop" ng-if="vm.drawer" ng-click="vm.closeDrawer()"></div>
+    <aside class="ekm-variants-drawer" ng-if="vm.drawer">
+        <header class="ekm-variants-drawer__header">
+            <div>
+                <h2>{{ vm.drawerTitle() }}</h2>
+                <p>{{ vm.drawerSubtitle() }}</p>
+            </div>
+            <div class="ekm-variants-drawer__header-actions">
+                <a class="btn-reset ekm-variants-open-node" ng-if="vm.drawer.item.id > 0" ng-href="#/content/content/edit/{{ vm.drawer.item.id }}" target="_blank" rel="noopener" title="Open node in new tab" aria-label="Open node in new tab"><span aria-hidden="true">✎</span></a>
+                <button type="button" class="btn-reset ekm-variants-close" ng-click="vm.closeDrawer()" aria-label="Close">×</button>
+            </div>
+        </header>
+
+        <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'group'">
+            <label>Group title
+                <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                </div>
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+            </label>
+            <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
+                <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
+            </label>
+            <label>Images
+                <button type="button" class="btn umb-button__button" ng-click="vm.openMediaPicker(vm.drawer.item)">Select images</button>
+                <div class="ekm-variants-media-list" ng-if="vm.mediaImages(vm.drawer.item).length">
+                    <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
+                        <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                        <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                    </div>
+                </div>
+            </label>
+            <p class="ekm-variants-hint">Group images apply to all variants unless a variant has its own.</p>
+        </div>
+
+        <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'variant'">
+            <label>Title
+                <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                </div>
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+            </label>
+            <label>SKU
+                <input type="text" ng-model="vm.drawer.item.sku" />
+            </label>
+            <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
+                <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
+            </label>
+            <section>
+                <h3>Prices</h3>
+                <table>
+                    <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
+                    <tbody>
+                        <tr ng-repeat="priceRow in vm.priceRows()">
+                            <td>{{ priceRow.storeTitle }}</td>
+                            <td>{{ priceRow.currencyLabel }}</td>
+                            <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="priceRow.value" ng-change="vm.setPrice(vm.drawer.item, priceRow.storeAlias, priceRow.currencyValue, priceRow.value)" /></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+            <section>
+                <h3>Stock</h3>
+                <table>
+                    <thead><tr><th>Store</th><th>Stock</th></tr></thead>
+                    <tbody>
+                        <tr ng-repeat="stockRow in vm.stockRows()">
+                            <td>{{ stockRow.storeTitle }}</td>
+                            <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="stockRow.value" ng-change="vm.setStockValue(vm.drawer.item, stockRow.storeAlias, stockRow.value)" /></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+            <label>Images
+                <button type="button" class="btn umb-button__button" ng-click="vm.openMediaPicker(vm.drawer.item)">Select images</button>
+                <div class="ekm-variants-media-list" ng-if="vm.mediaImages(vm.drawer.item).length">
+                    <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
+                        <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
+                        <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                    </div>
+                </div>
+            </label>
+        </div>
+
+        <footer class="ekm-variants-drawer__footer">
+            <div class="ekm-variants-drawer__footer-left">
+                <button type="button" class="btn umb-button__button btn-danger" ng-click="vm.deleteDrawerItem()">Delete</button>
+            </div>
+            <div class="ekm-variants-drawer__footer-right">
+                <button type="button" class="btn umb-button__button" ng-click="vm.closeDrawer()">Close</button>
+                <button type="button" class="btn umb-button__button btn-success" ng-click="vm.saveDrawer()">Save</button>
+            </div>
+        </footer>
+    </aside>
+</div>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/package.manifest
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/package.manifest
@@ -6,9 +6,23 @@
         "~/App_Plugins/Ekom/Shared/Chosen/chosen.jquery.min.js",
         "~/App_Plugins/Ekom/Shared/Chosen/angular-chosen.min.js",
         "~/App_Plugins/Ekom/Shared/ekmUtility.js",
-        "~/App_Plugins/Ekom/Shared/ekmResources.js"
+        "~/App_Plugins/Ekom/Shared/ekmResources.js",
+        "~/App_Plugins/Ekom/Variants/ekmVariants.controller.js"
     ],
     "css": [
-        "~/App_Plugins/Ekom/Shared/Chosen/chosen.css"
+        "~/App_Plugins/Ekom/Shared/Chosen/chosen.css",
+        "~/App_Plugins/Ekom/Variants/ekmVariants.css"
+    ],
+    "contentApps": [
+        {
+            "name": "Variants",
+            "alias": "ekomVariants",
+            "weight": 0,
+            "icon": "icon-layers-alt",
+            "view": "~/App_Plugins/Ekom/Variants/ekmVariants.html",
+            "show": [
+                "+content/ekmProduct"
+            ]
+        }
     ]
 }

--- a/Samples/U10/Ekom.Site/Ekom.Site.csproj
+++ b/Samples/U10/Ekom.Site/Ekom.Site.csproj
@@ -33,6 +33,8 @@
       <Content Include="App_Plugins\Ekom\Shared\Chosen\chosen-sprite.png" />
       <Content Include="App_Plugins\Ekom\Shared\Chosen\chosen-sprite@2x.png" />
       <Content Include="App_Plugins\Ekom\Shared\Chosen\chosen.css" />
+      <Content Include="App_Plugins\Ekom\Variants\ekmVariants.css" />
+      <Content Include="App_Plugins\Ekom\Variants\ekmVariants.html" />
     </ItemGroup>
     <ItemGroup>
       <None Include="App_Plugins\Ekom\DataTypes\CacheEditor\ekmCache.controller.js" />
@@ -62,6 +64,7 @@
       <None Include="App_Plugins\Ekom\Shared\ekmUtility.js" />
       <None Include="App_Plugins\Ekom\package.manifest" />
       <None Include="App_Plugins\Ekom\Shared\ekmResources.js" />
+      <None Include="App_Plugins\Ekom\Variants\ekmVariants.controller.js" />
     </ItemGroup>
 
     <ItemGroup>

--- a/docs/variant-app.md
+++ b/docs/variant-app.md
@@ -1,0 +1,44 @@
+# Variant App custom fields
+
+The Ekom backoffice Variant App can show additional editable text fields in the variant group and variant drawers. This is useful when projects need a small number of extra textstring properties without opening each variant node separately.
+
+## Configuration
+
+Configure the aliases under the existing `Ekom` section in `appsettings.json`:
+
+```json
+{
+  "Ekom": {
+    "VariantApp": {
+      "VariantGroups": [ "color" ],
+      "Variants": [ "material", "size" ]
+    }
+  }
+}
+```
+
+- `VariantGroups` contains property aliases from the `ekmProductVariantGroup` document type.
+- `Variants` contains property aliases from the `ekmProductVariant` document type.
+
+## Supported properties
+
+Only Umbraco textstring properties are rendered by the Variant App custom field UI.
+
+Configured aliases are ignored when:
+
+- the alias does not exist on the target document type
+- the property is not a textstring property
+- the alias is empty or duplicated
+
+## Labels and required validation
+
+Field metadata comes from the Umbraco document type property itself:
+
+- the drawer label uses the property name
+- required validation uses the property's mandatory setting
+
+Required fields are validated before drawer Save and before saving all variant changes. The drawer Close action does not validate because it only dismisses the drawer.
+
+## Saving behavior
+
+Custom field changes are included in the Variant App change detection. Updating only a configured custom field is enough to mark the related variant group or variant as changed and save it through the normal Variant App save flow.


### PR DESCRIPTION
## Summary
- Add U17 and U10 backoffice Variant App APIs for managing product variant groups and variants.
- Add U17 workspace view and U10 content app UI for variant groups, variants, media, prices, stock, sorting, deletion, and batch saves.
- Add configurable Variant App custom textstring fields via `Ekom:VariantApp` appsettings, using Umbraco property labels and mandatory validation.
- Add variant count support and U17 workspace badge helper.
- Update README and add Variant App custom field documentation.

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `npm run typecheck` in `Ekom/Ekom.Web/Ekom.Web.U17/Client`
- `npm run build` in `Ekom/Ekom.Web/Ekom.Web.U17/Client`
- `node --check "Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js"`
- `node --check "Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js"`
- `git diff --cached --check`
