### PR TITLE
chore: bump Ekom release to 0.2.196

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "Ekom": "0.2.195",
+  "Ekom": "0.2.196",
   "Plugins/Ekom.Klaviyo": "0.2.99",
   "Plugins/Ekom.Algolia": "0.2.35"
 }

--- a/Ekom/Directory.Build.props
+++ b/Ekom/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <UseProjectReferences>true</UseProjectReferences>
-    <Version>0.2.195</Version>
+    <Version>0.2.196</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump Ekom release metadata from `0.2.195` to `0.2.196`.
- Avoid retrying the existing `Ekom-v0.2.195` tag, which already exists on GitHub.

## Test Plan
- `git diff --check`
- Verified `Ekom-v0.2.195` already exists as a GitHub release.
