### PR TITLE
fix(variants): refine variant app behavior

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/VariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/VariantAppService.cs
@@ -773,7 +773,12 @@ internal sealed class VariantAppService : IVariantAppService
 
     private static string GetRequiredTitle(string? title, string fallback)
     {
-        return string.IsNullOrWhiteSpace(title) ? fallback : title.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        return title.Trim();
     }
 
     private IReadOnlyList<UmbracoLanguage> LoadLanguages()

--- a/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/VariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/VariantAppService.cs
@@ -774,7 +774,12 @@ internal sealed class VariantAppService : IVariantAppService
 
     private static string GetRequiredTitle(string? title, string fallback)
     {
-        return string.IsNullOrWhiteSpace(title) ? fallback : title.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        return title.Trim();
     }
 
     private IReadOnlyList<UmbracoLanguage> LoadLanguages()

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
@@ -1,12 +1,12 @@
-var T = Object.defineProperty;
-var F = (i, o, t) => o in i ? T(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
+var L = Object.defineProperty;
+var F = (i, o, t) => o in i ? L(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
 var l = (i, o, t) => F(i, typeof o != "symbol" ? o + "" : o, t);
 import { UmbElementMixin as M } from "@umbraco-cms/backoffice/element-api";
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT as O, UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT as B } from "@umbraco-cms/backoffice/document";
 import "@umbraco-cms/backoffice/imaging";
 import "@umbraco-cms/backoffice/media";
-import { UMB_NOTIFICATION_CONTEXT as W } from "@umbraco-cms/backoffice/notification";
-import { UMB_WORKSPACE_VIEW_CONTEXT as j } from "@umbraco-cms/backoffice/workspace";
+import { UMB_NOTIFICATION_CONTEXT as j } from "@umbraco-cms/backoffice/notification";
+import { UMB_WORKSPACE_VIEW_CONTEXT as W } from "@umbraco-cms/backoffice/workspace";
 const V = "00000000-0000-0000-0000-000000000000", m = "ekom-variant-count";
 class R extends M(HTMLElement) {
   constructor() {
@@ -40,9 +40,9 @@ class R extends M(HTMLElement) {
     });
   }
   connectedCallback() {
-    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(W, (t) => {
+    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(j, (t) => {
       this.notificationContext = t;
-    }), this.consumeContext(j, (t) => {
+    }), this.consumeContext(W, (t) => {
       this.workspaceViewContext = t, this.updateWorkspaceViewBadge();
     }), this.consumeContext(O, (t) => {
       if (t == null)
@@ -114,7 +114,7 @@ class R extends M(HTMLElement) {
       images: "",
       sortOrder: this.product.groups.length,
       published: !1,
-      customFields: q(this.product.variantGroupFields),
+      customFields: T(this.product.variantGroupFields),
       variants: []
     };
     this.product.groups = [...this.product.groups, e], this.expandedGroupIds.add(t), this.drawer = { type: "group", groupId: t }, this.render();
@@ -134,7 +134,7 @@ class R extends M(HTMLElement) {
       images: "",
       priceValues: {},
       stockValues: this.createEmptyStockValues(),
-      customFields: q(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
+      customFields: T(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
       sortOrder: e.variants.length,
       published: !1
     };
@@ -142,7 +142,7 @@ class R extends M(HTMLElement) {
   }
   async save() {
     var e;
-    if (this.syncMediaPickers(), !this.validateAllCustomFields())
+    if (this.syncMediaPickers(), !this.validateAllTitles() || !this.validateAllCustomFields())
       return;
     if (this.product == null || !this.hasChanges()) {
       this.showNotification("default", "Variants", "No changes to save.");
@@ -248,7 +248,7 @@ class R extends M(HTMLElement) {
       var s;
       return {
         ...a,
-        priceValues: H(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
+        priceValues: X(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
         changed: !0
       };
     });
@@ -312,7 +312,7 @@ class R extends M(HTMLElement) {
   }
   render() {
     this.innerHTML = `
-      <style>${X}</style>
+      <style>${Y}</style>
       <section class="ekm-variant-editor">
         ${this.renderTopBar()}
         ${this.error ? `<p class="status status--error">${u(this.error)}</p>` : ""}
@@ -470,9 +470,9 @@ class R extends M(HTMLElement) {
   }
   renderTitleField(t, e, a, s, r = 0) {
     return `
-      <label>${u(t)}
+      <label>${u(t)} *
         ${this.renderLanguageMiniTabs()}
-        <input ${a} data-group-id="${s}" data-variant-id="${r}" value="${u(e)}">
+        <input ${a} data-group-id="${s}" data-variant-id="${r}" value="${u(e)}" required>
       </label>
     `;
   }
@@ -545,7 +545,7 @@ class R extends M(HTMLElement) {
     this.querySelectorAll('[data-action="create-group"]').forEach((r) => {
       r.addEventListener("click", () => this.addGroup());
     }), (t = this.querySelector('[data-action="save"]')) == null || t.addEventListener("click", () => void this.save()), (e = this.querySelector('[data-action="delete-selected"]')) == null || e.addEventListener("click", () => this.deleteSelected()), (a = this.querySelector('[data-action="delete-drawer-item"]')) == null || a.addEventListener("click", () => this.deleteDrawerItem()), (s = this.querySelector('[data-action="save-drawer"]')) == null || s.addEventListener("click", () => {
-      this.syncMediaPickers(), this.validateDrawerCustomFields() && (this.drawer = void 0, this.render());
+      this.syncMediaPickers(), !(!this.validateDrawerTitle() || !this.validateDrawerCustomFields()) && (this.drawer = void 0, this.render());
     }), this.querySelectorAll('[data-action="close-drawer"]').forEach((r) => {
       r.addEventListener("click", () => {
         this.syncMediaPickers(), this.drawer = void 0, this.render();
@@ -632,18 +632,18 @@ class R extends M(HTMLElement) {
   }
   bindMediaPickers() {
     this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
-      const e = t, a = t.dataset.value ?? "", s = I(a);
+      const e = t, a = t.dataset.value ?? "", s = x(a);
       e.value = s.join(","), e.selection = s, _(e), t.addEventListener("change", async (r) => {
         const n = Number(t.dataset.groupId), d = Number(t.dataset.variantId);
         r.stopPropagation(), await Promise.resolve();
-        const c = P(e);
+        const c = A(e);
         await f(e), d !== 0 ? this.updateVariant(n, d, "images", c) : this.updateGroupImages(n, c);
       });
     });
   }
   syncMediaPickers() {
     this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
-      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = P(e);
+      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = A(e);
       if (s !== 0) {
         const d = this.getVariant(a, s);
         d != null && d.images !== r && (d.images = r);
@@ -668,6 +668,26 @@ class R extends M(HTMLElement) {
     const t = this.drawer.type === "group" ? this.getGroup(this.drawer.groupId) : this.getVariant(this.drawer.groupId, this.drawer.variantId);
     return this.validateCustomFields(t == null ? void 0 : t.customFields);
   }
+  validateDrawerTitle() {
+    if (this.drawer == null)
+      return !0;
+    const t = this.drawer.type === "group" ? this.getGroup(this.drawer.groupId) : this.getVariant(this.drawer.groupId, this.drawer.variantId);
+    return this.validateTitle(t);
+  }
+  validateAllTitles() {
+    var t;
+    for (const e of ((t = this.product) == null ? void 0 : t.groups) ?? []) {
+      if (!this.validateTitle(e))
+        return !1;
+      for (const a of e.variants)
+        if (!this.validateTitle(a))
+          return !1;
+    }
+    return !0;
+  }
+  validateTitle(t) {
+    return H(t == null ? void 0 : t.titleValues) ? !0 : (this.showError("Title is required."), !1);
+  }
   validateAllCustomFields() {
     var t;
     for (const e of ((t = this.product) == null ? void 0 : t.groups) ?? []) {
@@ -687,7 +707,7 @@ class R extends M(HTMLElement) {
     return a == null ? !0 : (this.showError(`${a.label} is required.`), e && this.render(), !1);
   }
   reorderGroup(t, e) {
-    this.product == null || t == null || t === e || (this.product.groups = L(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
+    this.product == null || t == null || t === e || (this.product.groups = q(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
       a.sortOrder = s;
     }), this.render());
   }
@@ -695,7 +715,7 @@ class R extends M(HTMLElement) {
     if (t == null || t.groupId !== e || t.variantId === a)
       return;
     const s = this.getGroup(t.groupId);
-    s != null && (s.variants = L(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
+    s != null && (s.variants = q(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
       r.sortOrder = n;
     }), this.render());
   }
@@ -793,7 +813,7 @@ function S(i) {
 function C(i) {
   return new Intl.NumberFormat().format(i);
 }
-function I(i) {
+function x(i) {
   const o = String(i ?? "").trim();
   if (o.length === 0)
     return [];
@@ -803,10 +823,10 @@ function I(i) {
     } catch {
       return [];
     }
-  return o.split(",").map((t) => x(t.trim())).filter(Boolean);
+  return o.split(",").map((t) => I(t.trim())).filter(Boolean);
 }
 function k(i) {
-  return I(i)[0] ?? "";
+  return x(i)[0] ?? "";
 }
 function U(i) {
   const o = k(i.images);
@@ -822,20 +842,20 @@ function U(i) {
 function E(i, o) {
   return i ? `<umb-imaging-thumbnail unique="${u(i)}" width="38" height="38" alt="${u(o)}"></umb-imaging-thumbnail>` : "-";
 }
-function x(i) {
+function I(i) {
   const o = i.match(/umb:\/\/media\/(.+)$/i);
   return (o == null ? void 0 : o[1]) ?? i;
 }
-function P(i) {
-  return Array.isArray(i.selection) ? K(i.selection).join(",") : I(i.value ?? "").join(",");
+function A(i) {
+  return Array.isArray(i.selection) ? K(i.selection).join(",") : x(i.value ?? "").join(",");
 }
-const A = /* @__PURE__ */ new WeakSet();
+const P = /* @__PURE__ */ new WeakSet();
 async function _(i) {
-  if (A.has(i)) {
+  if (P.has(i)) {
     await f(i);
     return;
   }
-  A.add(i), await f(i);
+  P.add(i), await f(i);
   const o = i.shadowRoot;
   if (o == null)
     return;
@@ -859,10 +879,10 @@ async function f(i) {
 function K(i) {
   return i.map((o) => {
     if (typeof o == "string")
-      return x(o);
+      return I(o);
     if (o != null && typeof o == "object") {
       const t = o;
-      return x(String(t.udi ?? t.key ?? t.unique ?? t.id ?? ""));
+      return I(String(t.udi ?? t.key ?? t.unique ?? t.id ?? ""));
     }
     return "";
   }).filter(Boolean);
@@ -889,13 +909,16 @@ function N(i) {
     sortOrder: i.sortOrder
   });
 }
-function q(i) {
+function T(i) {
   return (i ?? []).map((o) => ({
     ...o,
     value: ""
   }));
 }
-function H(i, o) {
+function H(i) {
+  return Object.values(i ?? {}).some((o) => o.trim().length > 0);
+}
+function X(i, o) {
   const t = {};
   for (const e of o) {
     const a = e.alias ?? "", s = /* @__PURE__ */ new Map();
@@ -912,7 +935,7 @@ function H(i, o) {
   }
   return t;
 }
-function L(i, o, t) {
+function q(i, o, t) {
   const e = [...i], a = e.findIndex((n) => n.id === o), s = e.findIndex((n) => n.id === t);
   if (a < 0 || s < 0)
     return i;
@@ -928,7 +951,7 @@ function b(i) {
   }
   return JSON.stringify(i);
 }
-const X = `
+const Y = `
   :host { display: block; padding: var(--uui-size-layout-1, 24px); background: #f4f3f5; color: #1b264f; font-family: Lato, Arial, sans-serif; }
   .ekm-variant-editor { display: grid; gap: 16px; }
   .top-bar, .selection-actions, .main-actions, .group-header, .group-header-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
@@ -1,14 +1,14 @@
-var M = Object.defineProperty;
-var O = (i, o, t) => o in i ? M(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
-var l = (i, o, t) => O(i, typeof o != "symbol" ? o + "" : o, t);
-import { UmbElementMixin as B } from "@umbraco-cms/backoffice/element-api";
-import { UMB_DOCUMENT_WORKSPACE_CONTEXT as j, UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT as W } from "@umbraco-cms/backoffice/document";
+var D = Object.defineProperty;
+var F = (i, o, t) => o in i ? D(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
+var l = (i, o, t) => F(i, typeof o != "symbol" ? o + "" : o, t);
+import { UmbElementMixin as M } from "@umbraco-cms/backoffice/element-api";
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT as O, UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT as B } from "@umbraco-cms/backoffice/document";
 import "@umbraco-cms/backoffice/imaging";
 import "@umbraco-cms/backoffice/media";
-import { UMB_NOTIFICATION_CONTEXT as R } from "@umbraco-cms/backoffice/notification";
-import { UMB_WORKSPACE_VIEW_CONTEXT as z } from "@umbraco-cms/backoffice/workspace";
-const C = "00000000-0000-0000-0000-000000000000", b = "ekom-variant-count";
-class U extends B(HTMLElement) {
+import { UMB_NOTIFICATION_CONTEXT as j } from "@umbraco-cms/backoffice/notification";
+import { UMB_WORKSPACE_VIEW_CONTEXT as W } from "@umbraco-cms/backoffice/workspace";
+const V = "00000000-0000-0000-0000-000000000000", m = "ekom-variant-count";
+class R extends M(HTMLElement) {
   constructor() {
     super(...arguments);
     l(this, "notificationContext");
@@ -40,18 +40,18 @@ class U extends B(HTMLElement) {
     });
   }
   connectedCallback() {
-    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(R, (t) => {
+    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(j, (t) => {
       this.notificationContext = t;
-    }), this.consumeContext(z, (t) => {
+    }), this.consumeContext(W, (t) => {
       this.workspaceViewContext = t, this.updateWorkspaceViewBadge();
-    }), this.consumeContext(j, (t) => {
+    }), this.consumeContext(O, (t) => {
       if (t == null)
         return;
       const e = t.getUnique();
       e != null && (this.productId = e), this.patchDocumentSave(t), this.observe(t.unique, (a) => {
         a == null || a === this.productId || (this.productId = a, this.load());
       }, "ekomVariantProductId");
-    }), this.consumeContext(W, (t) => {
+    }), this.consumeContext(B, (t) => {
       t != null && this.patchPublishingSave(t);
     }), this.productId = this.getProductIdFromUrl(), this.render(), this.productId && this.load();
   }
@@ -96,7 +96,7 @@ class U extends B(HTMLElement) {
     try {
       this.product = await this.fetchJson(`/ekom/backoffice/Variants/${encodeURIComponent(t)}`), this.activeLanguage = ((e = this.product.languages[0]) == null ? void 0 : e.isoCode) ?? "", this.drawer = void 0, this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.deletedNodeIds.clear(), this.expandedGroupIds.clear(), this.product.groups.length === 1 && this.expandedGroupIds.add(this.product.groups[0].id), this.resetSnapshots(), this.updateWorkspaceViewBadge();
     } catch (a) {
-      this.product = void 0, this.updateWorkspaceViewBadge(), this.error = E(a, "Could not load variants."), this.showError(this.error);
+      this.product = void 0, this.updateWorkspaceViewBadge(), this.error = $(a, "Could not load variants."), this.showError(this.error);
     } finally {
       this.loading = !1, this.render();
     }
@@ -106,7 +106,7 @@ class U extends B(HTMLElement) {
       return;
     const t = this.nextDraftId--, e = {
       id: t,
-      key: C,
+      key: V,
       name: "New group",
       title: "",
       titleValues: this.createEmptyTitleValues(),
@@ -114,7 +114,7 @@ class U extends B(HTMLElement) {
       images: "",
       sortOrder: this.product.groups.length,
       published: !1,
-      customFields: L(this.product.variantGroupFields),
+      customFields: T(this.product.variantGroupFields),
       variants: []
     };
     this.product.groups = [...this.product.groups, e], this.expandedGroupIds.add(t), this.drawer = { type: "group", groupId: t }, this.render();
@@ -126,7 +126,7 @@ class U extends B(HTMLElement) {
       return;
     const a = this.nextDraftId--, s = {
       id: a,
-      key: C,
+      key: V,
       name: "New variant",
       title: "",
       titleValues: this.createEmptyTitleValues(),
@@ -134,7 +134,7 @@ class U extends B(HTMLElement) {
       images: "",
       priceValues: {},
       stockValues: this.createEmptyStockValues(),
-      customFields: L(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
+      customFields: T(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
       sortOrder: e.variants.length,
       published: !1
     };
@@ -159,7 +159,7 @@ class U extends B(HTMLElement) {
         groups: t
       }) : await this.load(), this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.deletedNodeIds.clear(), this.drawer = void 0, this.expandedGroupIds.clear(), ((e = this.product) == null ? void 0 : e.groups.length) === 1 && this.expandedGroupIds.add(this.product.groups[0].id), this.resetSnapshots(), this.updateWorkspaceViewBadge(), this.showSuccess("Variant changes were saved.");
     } catch (a) {
-      this.error = E(a, "Action failed."), this.showError(this.error);
+      this.error = $(a, "Action failed."), this.showError(this.error);
     } finally {
       this.saving = !1, this.render();
     }
@@ -215,7 +215,7 @@ class U extends B(HTMLElement) {
     const n = this.getVariant(t, e);
     if (n == null)
       return;
-    const d = [...n.priceValues[a] ?? []], c = Number(r) || 0, p = d.find((f) => v(f) === s);
+    const d = [...n.priceValues[a] ?? []], c = Number(r) || 0, p = d.find((g) => v(g) === s);
     p != null ? (p.Price = c, p.price = c) : d.push({ Currency: s, Price: c }), n.priceValues = { ...n.priceValues, [a]: d }, this.updateSaveButtonState();
   }
   updateStock(t, e, a, s) {
@@ -235,10 +235,10 @@ class U extends B(HTMLElement) {
     var e;
     if (this.workspaceViewContext == null)
       return;
-    this.workspaceViewContext.hints.has(b) && this.workspaceViewContext.hints.removeOne(b);
+    this.workspaceViewContext.hints.has(m) && this.workspaceViewContext.hints.removeOne(m);
     const t = ((e = this.product) == null ? void 0 : e.variantCount) ?? 0;
     t > 0 && this.workspaceViewContext.hints.addOne({
-      unique: b,
+      unique: m,
       text: String(t),
       color: "default"
     });
@@ -248,7 +248,7 @@ class U extends B(HTMLElement) {
       var s;
       return {
         ...a,
-        priceValues: Q(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
+        priceValues: X(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
         changed: !0
       };
     });
@@ -259,10 +259,10 @@ class U extends B(HTMLElement) {
     };
   }
   isGroupChanged(t) {
-    return h(t.id) || this.groupSnapshots.get(t.id) !== T(t);
+    return h(t.id) || this.groupSnapshots.get(t.id) !== G(t);
   }
   isVariantChanged(t) {
-    return h(t.id) || this.variantSnapshots.get(t.id) !== q(t);
+    return h(t.id) || this.variantSnapshots.get(t.id) !== N(t);
   }
   getGroup(t) {
     var e;
@@ -276,9 +276,9 @@ class U extends B(HTMLElement) {
     var t;
     this.groupSnapshots.clear(), this.variantSnapshots.clear();
     for (const e of ((t = this.product) == null ? void 0 : t.groups) ?? []) {
-      this.groupSnapshots.set(e.id, T(e));
+      this.groupSnapshots.set(e.id, G(e));
       for (const a of e.variants)
-        this.variantSnapshots.set(a.id, q(a));
+        this.variantSnapshots.set(a.id, N(a));
     }
   }
   createEmptyTitleValues() {
@@ -312,7 +312,7 @@ class U extends B(HTMLElement) {
   }
   render() {
     this.innerHTML = `
-      <style>${Z}</style>
+      <style>${Y}</style>
       <section class="ekm-variant-editor">
         ${this.renderTopBar()}
         ${this.error ? `<p class="status status--error">${u(this.error)}</p>` : ""}
@@ -351,14 +351,14 @@ class U extends B(HTMLElement) {
     `;
   }
   renderGroup(t) {
-    const e = this.expandedGroupIds.has(t.id), a = this.getTitle(t, "New group"), s = J(t);
+    const e = this.expandedGroupIds.has(t.id), a = this.getTitle(t, "New group"), s = U(t);
     return `
       <article class="group-card ${h(t.id) ? "is-draft" : ""}" draggable="true" data-drag-group-id="${t.id}">
         <div class="group-header">
           <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
           <input type="checkbox" data-select-group data-group-id="${t.id}" ${this.selectedGroupIds.has(t.id) ? "checked" : ""} aria-label="Select group">
           <button type="button" class="group-toggle" data-action="toggle-group" data-group-id="${t.id}" aria-label="Toggle group">${e ? "▼" : "►"}</button>
-          <button type="button" class="thumb thumb--button" data-action="toggle-group" data-group-id="${t.id}">${P(s, a)}</button>
+          <button type="button" class="thumb thumb--button" data-action="toggle-group" data-group-id="${t.id}">${E(s, a)}</button>
           <button type="button" class="group-title" data-action="toggle-group" data-group-id="${t.id}">${u(a)}</button>
           <span class="count">${t.variants.length} variants</span>
           ${h(t.id) ? '<span class="badge">draft</span>' : ""}
@@ -386,7 +386,7 @@ class U extends B(HTMLElement) {
       <div class="variant-row ${h(e.id) ? "is-draft" : ""}" draggable="true" data-drag-group-id="${t.id}" data-drag-variant-id="${e.id}">
         <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
         <input type="checkbox" data-select-variant data-variant-id="${e.id}" ${this.selectedVariantIds.has(e.id) ? "checked" : ""} aria-label="Select variant">
-        <span class="thumb">${P(k(e.images), this.getTitle(e, "New variant"))}</span>
+        <span class="thumb">${E(k(e.images), this.getTitle(e, "New variant"))}</span>
         <strong>${u(this.getTitle(e, "New variant"))}${h(e.id) ? ' <span class="badge">draft</span>' : ""}</strong>
         <span>${u(e.sku)}</span>
         <span class="variant-price-cell">${u(this.getDefaultPrice(e))}</span>
@@ -484,7 +484,7 @@ class U extends B(HTMLElement) {
         ${e.map((s) => {
       var d, c;
       const r = s.isoCode ?? "", n = ["mini-tab"];
-      return r === this.activeLanguage && n.push("active"), (d = t[r]) != null && d.trim() || n.push("is-missing"), `<button type="button" data-action="set-language" data-tab-value="${u(r)}" class="${n.join(" ")}" title="${(c = t[r]) != null && c.trim() ? "" : "Missing title value"}">${u(_(s))}</button>`;
+      return r === this.activeLanguage && n.push("active"), (d = t[r]) != null && d.trim() || n.push("is-missing"), `<button type="button" data-action="set-language" data-tab-value="${u(r)}" class="${n.join(" ")}" title="${(c = t[r]) != null && c.trim() ? "" : "Missing title value"}">${u(z(s))}</button>`;
     }).join("")}
       </div>
     `;
@@ -505,9 +505,9 @@ class U extends B(HTMLElement) {
           <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
           <tbody>
             ${(((a = this.product) == null ? void 0 : a.stores) ?? []).flatMap((s) => (s.currencies ?? []).map((r) => {
-      var V, $;
-      const n = s.alias ?? "", d = r.currencyValue ?? "", c = ($ = (V = e.priceValues) == null ? void 0 : V[n]) == null ? void 0 : $.find((F) => v(F) === d), p = S(c);
-      return `<tr${c == null ? ' class="is-missing-value"' : ""}><td>${u(s.title ?? n)}</td><td>${u(r.isoCurrencySymbol ?? d)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${u(n)}" data-price-currency="${u(d)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(p)}"></td></tr>`;
+      var p, g;
+      const n = s.alias ?? "", d = r.currencyValue ?? "", c = S((g = (p = e.priceValues) == null ? void 0 : p[n]) == null ? void 0 : g.find((L) => v(L) === d));
+      return `<tr><td>${u(s.title ?? n)}</td><td>${u(r.isoCurrencySymbol ?? d)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${u(n)}" data-price-currency="${u(d)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(c)}"></td></tr>`;
     })).join("")}
           </tbody>
         </table>
@@ -594,8 +594,7 @@ class U extends B(HTMLElement) {
       });
     }), this.querySelectorAll("[data-price]").forEach((r) => {
       r.addEventListener("input", (n) => {
-        var d;
-        n.stopPropagation(), this.updatePrice(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.priceStore ?? "", r.dataset.priceCurrency ?? "", r.value), (d = r.closest("tr")) == null || d.classList.toggle("is-missing-value", r.value.trim().length === 0);
+        n.stopPropagation(), this.updatePrice(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.priceStore ?? "", r.dataset.priceCurrency ?? "", r.value);
       });
     }), this.querySelectorAll("[data-stock]").forEach((r) => {
       r.addEventListener("input", (n) => {
@@ -635,17 +634,17 @@ class U extends B(HTMLElement) {
   bindMediaPickers() {
     this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
       const e = t, a = t.dataset.value ?? "", s = I(a);
-      e.value = s.join(","), e.selection = s, K(e), t.addEventListener("change", async (r) => {
+      e.value = s.join(","), e.selection = s, _(e), t.addEventListener("change", async (r) => {
         const n = Number(t.dataset.groupId), d = Number(t.dataset.variantId);
         r.stopPropagation(), await Promise.resolve();
-        const c = G(e);
-        await g(e), d !== 0 ? this.updateVariant(n, d, "images", c) : this.updateGroupImages(n, c);
+        const c = A(e);
+        await f(e), d !== 0 ? this.updateVariant(n, d, "images", c) : this.updateGroupImages(n, c);
       });
     });
   }
   syncMediaPickers() {
     this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
-      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = G(e);
+      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = A(e);
       if (s !== 0) {
         const d = this.getVariant(a, s);
         d != null && d.images !== r && (d.images = r);
@@ -693,7 +692,7 @@ class U extends B(HTMLElement) {
     return !0;
   }
   validateTitle(t) {
-    return Y(t == null ? void 0 : t.titleValues) ? !0 : (this.showError("Title is required."), !1);
+    return H(t == null ? void 0 : t.titleValues) ? !0 : (this.showError("Title is required."), !1);
   }
   validateAllCustomFields() {
     var t;
@@ -714,7 +713,7 @@ class U extends B(HTMLElement) {
     return a == null ? !0 : (this.showError(`${a.label} is required.`), e && this.render(), !1);
   }
   reorderGroup(t, e) {
-    this.product == null || t == null || t === e || (this.product.groups = D(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
+    this.product == null || t == null || t === e || (this.product.groups = q(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
       a.sortOrder = s;
     }), this.render());
   }
@@ -722,7 +721,7 @@ class U extends B(HTMLElement) {
     if (t == null || t.groupId !== e || t.variantId === a)
       return;
     const s = this.getGroup(t.groupId);
-    s != null && (s.variants = D(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
+    s != null && (s.variants = q(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
       r.sortOrder = n;
     }), this.render());
   }
@@ -755,11 +754,11 @@ class U extends B(HTMLElement) {
     const e = (n = this.product) == null ? void 0 : n.stores[0], a = (d = e == null ? void 0 : e.currencies) == null ? void 0 : d[0];
     if (e == null || a == null)
       return "—";
-    const s = S((p = (c = t.priceValues) == null ? void 0 : c[e.alias ?? ""]) == null ? void 0 : p.find((f) => v(f) === (a.currencyValue ?? ""))), r = a.currencySymbol ?? a.isoCurrencySymbol ?? a.currencyValue ?? "";
-    return `${A(s)} ${r}`.trim();
+    const s = S((p = (c = t.priceValues) == null ? void 0 : c[e.alias ?? ""]) == null ? void 0 : p.find((g) => v(g) === (a.currencyValue ?? ""))), r = a.currencySymbol ?? a.isoCurrencySymbol ?? a.currencyValue ?? "";
+    return `${C(s)} ${r}`.trim();
   }
   getTotalStock(t) {
-    return t.stockValues.length === 0 ? "0" : A(t.stockValues.reduce((e, a) => e + (Number(a.value) || 0), 0));
+    return t.stockValues.length === 0 ? "0" : C(t.stockValues.reduce((e, a) => e + (Number(a.value) || 0), 0));
   }
   getStoreTitle(t) {
     var e, a;
@@ -799,7 +798,7 @@ async function w(i) {
   if (i.status !== 204)
     return i.json();
 }
-function E(i, o) {
+function $(i, o) {
   return i instanceof Error && i.message.length > 0 ? i.message : o;
 }
 function u(i) {
@@ -808,7 +807,7 @@ function u(i) {
 function y(i) {
   return Object.values(i ?? {}).find((o) => o != null && o.trim().length > 0) ?? "";
 }
-function _(i) {
+function z(i) {
   return (i.isoCode ?? i.cultureName ?? "").split("-")[0].toUpperCase();
 }
 function v(i) {
@@ -817,7 +816,7 @@ function v(i) {
 function S(i) {
   return (i == null ? void 0 : i.Price) ?? (i == null ? void 0 : i.price) ?? 0;
 }
-function A(i) {
+function C(i) {
   return new Intl.NumberFormat().format(i);
 }
 function I(i) {
@@ -835,7 +834,7 @@ function I(i) {
 function k(i) {
   return I(i)[0] ?? "";
 }
-function J(i) {
+function U(i) {
   const o = k(i.images);
   if (o)
     return o;
@@ -846,30 +845,30 @@ function J(i) {
   }
   return "";
 }
-function P(i, o) {
+function E(i, o) {
   return i ? `<umb-imaging-thumbnail unique="${u(i)}" width="38" height="38" alt="${u(o)}"></umb-imaging-thumbnail>` : "-";
 }
 function x(i) {
   const o = i.match(/umb:\/\/media\/(.+)$/i);
   return (o == null ? void 0 : o[1]) ?? i;
 }
-function G(i) {
-  return Array.isArray(i.selection) ? X(i.selection).join(",") : I(i.value ?? "").join(",");
+function A(i) {
+  return Array.isArray(i.selection) ? K(i.selection).join(",") : I(i.value ?? "").join(",");
 }
-const N = /* @__PURE__ */ new WeakSet();
-async function K(i) {
-  if (N.has(i)) {
-    await g(i);
+const P = /* @__PURE__ */ new WeakSet();
+async function _(i) {
+  if (P.has(i)) {
+    await f(i);
     return;
   }
-  N.add(i), await g(i);
+  P.add(i), await f(i);
   const o = i.shadowRoot;
   if (o == null)
     return;
-  const t = () => void H(i), e = () => window.setTimeout(() => void g(i));
-  new MutationObserver(() => void g(i)).observe(o, { childList: !0, subtree: !0 }), o.addEventListener("pointerdown", t, { capture: !0 }), o.addEventListener("dragstart", t, { capture: !0 }), o.addEventListener("dragend", e, { capture: !0 }), o.addEventListener("drop", e, { capture: !0 });
+  const t = () => void J(i), e = () => window.setTimeout(() => void f(i));
+  new MutationObserver(() => void f(i)).observe(o, { childList: !0, subtree: !0 }), o.addEventListener("pointerdown", t, { capture: !0 }), o.addEventListener("dragstart", t, { capture: !0 }), o.addEventListener("dragend", e, { capture: !0 }), o.addEventListener("drop", e, { capture: !0 });
 }
-async function H(i) {
+async function J(i) {
   var o;
   await i.updateComplete, await new Promise((t) => window.requestAnimationFrame(t)), (o = i.shadowRoot) == null || o.querySelectorAll("uui-card-media[data-mark]").forEach((t) => {
     var a;
@@ -877,13 +876,13 @@ async function H(i) {
     e && t.setAttribute("detail", e);
   });
 }
-async function g(i) {
+async function f(i) {
   var o;
   await i.updateComplete, await new Promise((t) => window.requestAnimationFrame(t)), (o = i.shadowRoot) == null || o.querySelectorAll("uui-card-media[detail]").forEach((t) => {
     t.removeAttribute("detail");
   });
 }
-function X(i) {
+function K(i) {
   return i.map((o) => {
     if (typeof o == "string")
       return x(o);
@@ -897,16 +896,16 @@ function X(i) {
 function h(i) {
   return i <= 0;
 }
-function T(i) {
-  return m({
+function G(i) {
+  return b({
     titleValues: i.titleValues,
     images: i.images,
     customFields: i.customFields,
     sortOrder: i.sortOrder
   });
 }
-function q(i) {
-  return m({
+function N(i) {
+  return b({
     titleValues: i.titleValues,
     sku: i.sku,
     images: i.images,
@@ -916,16 +915,16 @@ function q(i) {
     sortOrder: i.sortOrder
   });
 }
-function L(i) {
+function T(i) {
   return (i ?? []).map((o) => ({
     ...o,
     value: ""
   }));
 }
-function Y(i) {
+function H(i) {
   return Object.values(i ?? {}).some((o) => o.trim().length > 0);
 }
-function Q(i, o) {
+function X(i, o) {
   const t = {};
   for (const e of o) {
     const a = e.alias ?? "", s = /* @__PURE__ */ new Map();
@@ -942,23 +941,23 @@ function Q(i, o) {
   }
   return t;
 }
-function D(i, o, t) {
+function q(i, o, t) {
   const e = [...i], a = e.findIndex((n) => n.id === o), s = e.findIndex((n) => n.id === t);
   if (a < 0 || s < 0)
     return i;
   const [r] = e.splice(a, 1);
   return e.splice(s, 0, r), e;
 }
-function m(i) {
+function b(i) {
   if (Array.isArray(i))
-    return `[${i.map(m).join(",")}]`;
+    return `[${i.map(b).join(",")}]`;
   if (i != null && typeof i == "object") {
     const o = i;
-    return `{${Object.keys(o).sort().map((t) => `${JSON.stringify(t)}:${m(o[t])}`).join(",")}}`;
+    return `{${Object.keys(o).sort().map((t) => `${JSON.stringify(t)}:${b(o[t])}`).join(",")}}`;
   }
   return JSON.stringify(i);
 }
-const Z = `
+const Y = `
   :host { display: block; padding: var(--uui-size-layout-1, 24px); background: #f4f3f5; color: #1b264f; font-family: Lato, Arial, sans-serif; }
   .ekm-variant-editor { display: grid; gap: 16px; }
   .top-bar, .selection-actions, .main-actions, .group-header, .group-header-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
@@ -1013,11 +1012,10 @@ const Z = `
   table { width: 100%; border-collapse: collapse; }
   th { background: #f8f7fa; color: #8b8994; font-size: 11px; letter-spacing: .04em; text-align: left; text-transform: uppercase; }
   th, td { border-bottom: 1px solid #e2e1e6; padding: 8px; }
-  tr.is-missing-value td:first-child, tr.is-missing-value td:nth-child(2) { color: #d42054; font-weight: 700; }
   .numeric { text-align: right; }
   @keyframes slide-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
 `;
-customElements.define("ekom-variants-workspace-view", U);
+customElements.define("ekom-variants-workspace-view", R);
 export {
-  U as default
+  R as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/variants-workspace-view.element.js
@@ -1,14 +1,14 @@
-var L = Object.defineProperty;
-var F = (i, o, t) => o in i ? L(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
-var l = (i, o, t) => F(i, typeof o != "symbol" ? o + "" : o, t);
-import { UmbElementMixin as M } from "@umbraco-cms/backoffice/element-api";
-import { UMB_DOCUMENT_WORKSPACE_CONTEXT as O, UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT as B } from "@umbraco-cms/backoffice/document";
+var M = Object.defineProperty;
+var O = (i, o, t) => o in i ? M(i, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : i[o] = t;
+var l = (i, o, t) => O(i, typeof o != "symbol" ? o + "" : o, t);
+import { UmbElementMixin as B } from "@umbraco-cms/backoffice/element-api";
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT as j, UMB_DOCUMENT_PUBLISHING_WORKSPACE_CONTEXT as W } from "@umbraco-cms/backoffice/document";
 import "@umbraco-cms/backoffice/imaging";
 import "@umbraco-cms/backoffice/media";
-import { UMB_NOTIFICATION_CONTEXT as j } from "@umbraco-cms/backoffice/notification";
-import { UMB_WORKSPACE_VIEW_CONTEXT as W } from "@umbraco-cms/backoffice/workspace";
-const V = "00000000-0000-0000-0000-000000000000", m = "ekom-variant-count";
-class R extends M(HTMLElement) {
+import { UMB_NOTIFICATION_CONTEXT as R } from "@umbraco-cms/backoffice/notification";
+import { UMB_WORKSPACE_VIEW_CONTEXT as z } from "@umbraco-cms/backoffice/workspace";
+const C = "00000000-0000-0000-0000-000000000000", b = "ekom-variant-count";
+class U extends B(HTMLElement) {
   constructor() {
     super(...arguments);
     l(this, "notificationContext");
@@ -40,18 +40,18 @@ class R extends M(HTMLElement) {
     });
   }
   connectedCallback() {
-    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(j, (t) => {
+    super.connectedCallback(), window.addEventListener("keydown", this.onKeydown), this.consumeContext(R, (t) => {
       this.notificationContext = t;
-    }), this.consumeContext(W, (t) => {
+    }), this.consumeContext(z, (t) => {
       this.workspaceViewContext = t, this.updateWorkspaceViewBadge();
-    }), this.consumeContext(O, (t) => {
+    }), this.consumeContext(j, (t) => {
       if (t == null)
         return;
       const e = t.getUnique();
       e != null && (this.productId = e), this.patchDocumentSave(t), this.observe(t.unique, (a) => {
         a == null || a === this.productId || (this.productId = a, this.load());
       }, "ekomVariantProductId");
-    }), this.consumeContext(B, (t) => {
+    }), this.consumeContext(W, (t) => {
       t != null && this.patchPublishingSave(t);
     }), this.productId = this.getProductIdFromUrl(), this.render(), this.productId && this.load();
   }
@@ -96,7 +96,7 @@ class R extends M(HTMLElement) {
     try {
       this.product = await this.fetchJson(`/ekom/backoffice/Variants/${encodeURIComponent(t)}`), this.activeLanguage = ((e = this.product.languages[0]) == null ? void 0 : e.isoCode) ?? "", this.drawer = void 0, this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.deletedNodeIds.clear(), this.expandedGroupIds.clear(), this.product.groups.length === 1 && this.expandedGroupIds.add(this.product.groups[0].id), this.resetSnapshots(), this.updateWorkspaceViewBadge();
     } catch (a) {
-      this.product = void 0, this.updateWorkspaceViewBadge(), this.error = $(a, "Could not load variants."), this.showError(this.error);
+      this.product = void 0, this.updateWorkspaceViewBadge(), this.error = E(a, "Could not load variants."), this.showError(this.error);
     } finally {
       this.loading = !1, this.render();
     }
@@ -106,7 +106,7 @@ class R extends M(HTMLElement) {
       return;
     const t = this.nextDraftId--, e = {
       id: t,
-      key: V,
+      key: C,
       name: "New group",
       title: "",
       titleValues: this.createEmptyTitleValues(),
@@ -114,7 +114,7 @@ class R extends M(HTMLElement) {
       images: "",
       sortOrder: this.product.groups.length,
       published: !1,
-      customFields: T(this.product.variantGroupFields),
+      customFields: L(this.product.variantGroupFields),
       variants: []
     };
     this.product.groups = [...this.product.groups, e], this.expandedGroupIds.add(t), this.drawer = { type: "group", groupId: t }, this.render();
@@ -126,7 +126,7 @@ class R extends M(HTMLElement) {
       return;
     const a = this.nextDraftId--, s = {
       id: a,
-      key: V,
+      key: C,
       name: "New variant",
       title: "",
       titleValues: this.createEmptyTitleValues(),
@@ -134,7 +134,7 @@ class R extends M(HTMLElement) {
       images: "",
       priceValues: {},
       stockValues: this.createEmptyStockValues(),
-      customFields: T(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
+      customFields: L(((r = this.product) == null ? void 0 : r.variantFields) ?? []),
       sortOrder: e.variants.length,
       published: !1
     };
@@ -159,7 +159,7 @@ class R extends M(HTMLElement) {
         groups: t
       }) : await this.load(), this.selectedGroupIds.clear(), this.selectedVariantIds.clear(), this.deletedNodeIds.clear(), this.drawer = void 0, this.expandedGroupIds.clear(), ((e = this.product) == null ? void 0 : e.groups.length) === 1 && this.expandedGroupIds.add(this.product.groups[0].id), this.resetSnapshots(), this.updateWorkspaceViewBadge(), this.showSuccess("Variant changes were saved.");
     } catch (a) {
-      this.error = $(a, "Action failed."), this.showError(this.error);
+      this.error = E(a, "Action failed."), this.showError(this.error);
     } finally {
       this.saving = !1, this.render();
     }
@@ -197,7 +197,7 @@ class R extends M(HTMLElement) {
   }
   updateGroupTitle(t, e) {
     const a = this.getGroup(t);
-    a != null && (a.titleValues = { ...a.titleValues, [this.activeLanguage]: e }, a.title = y(a.titleValues) || a.name, this.updateSaveButtonState());
+    a != null && (a.titleValues = { ...a.titleValues, [this.activeLanguage]: e }, a.title = y(a.titleValues) || a.name, this.updateActiveLanguageTabMissingState(a.titleValues), this.updateSaveButtonState());
   }
   updateGroupImages(t, e) {
     const a = this.getGroup(t);
@@ -205,7 +205,7 @@ class R extends M(HTMLElement) {
   }
   updateVariantTitle(t, e, a) {
     const s = this.getVariant(t, e);
-    s != null && (s.titleValues = { ...s.titleValues, [this.activeLanguage]: a }, s.title = y(s.titleValues) || s.name, this.updateSaveButtonState());
+    s != null && (s.titleValues = { ...s.titleValues, [this.activeLanguage]: a }, s.title = y(s.titleValues) || s.name, this.updateActiveLanguageTabMissingState(s.titleValues), this.updateSaveButtonState());
   }
   updateVariant(t, e, a, s) {
     const r = this.getVariant(t, e);
@@ -215,7 +215,7 @@ class R extends M(HTMLElement) {
     const n = this.getVariant(t, e);
     if (n == null)
       return;
-    const d = [...n.priceValues[a] ?? []], c = Number(r) || 0, p = d.find((g) => v(g) === s);
+    const d = [...n.priceValues[a] ?? []], c = Number(r) || 0, p = d.find((f) => v(f) === s);
     p != null ? (p.Price = c, p.price = c) : d.push({ Currency: s, Price: c }), n.priceValues = { ...n.priceValues, [a]: d }, this.updateSaveButtonState();
   }
   updateStock(t, e, a, s) {
@@ -235,10 +235,10 @@ class R extends M(HTMLElement) {
     var e;
     if (this.workspaceViewContext == null)
       return;
-    this.workspaceViewContext.hints.has(m) && this.workspaceViewContext.hints.removeOne(m);
+    this.workspaceViewContext.hints.has(b) && this.workspaceViewContext.hints.removeOne(b);
     const t = ((e = this.product) == null ? void 0 : e.variantCount) ?? 0;
     t > 0 && this.workspaceViewContext.hints.addOne({
-      unique: m,
+      unique: b,
       text: String(t),
       color: "default"
     });
@@ -248,7 +248,7 @@ class R extends M(HTMLElement) {
       var s;
       return {
         ...a,
-        priceValues: X(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
+        priceValues: Q(a.priceValues, ((s = this.product) == null ? void 0 : s.stores) ?? []),
         changed: !0
       };
     });
@@ -259,10 +259,10 @@ class R extends M(HTMLElement) {
     };
   }
   isGroupChanged(t) {
-    return h(t.id) || this.groupSnapshots.get(t.id) !== G(t);
+    return h(t.id) || this.groupSnapshots.get(t.id) !== T(t);
   }
   isVariantChanged(t) {
-    return h(t.id) || this.variantSnapshots.get(t.id) !== N(t);
+    return h(t.id) || this.variantSnapshots.get(t.id) !== q(t);
   }
   getGroup(t) {
     var e;
@@ -276,9 +276,9 @@ class R extends M(HTMLElement) {
     var t;
     this.groupSnapshots.clear(), this.variantSnapshots.clear();
     for (const e of ((t = this.product) == null ? void 0 : t.groups) ?? []) {
-      this.groupSnapshots.set(e.id, G(e));
+      this.groupSnapshots.set(e.id, T(e));
       for (const a of e.variants)
-        this.variantSnapshots.set(a.id, N(a));
+        this.variantSnapshots.set(a.id, q(a));
     }
   }
   createEmptyTitleValues() {
@@ -312,7 +312,7 @@ class R extends M(HTMLElement) {
   }
   render() {
     this.innerHTML = `
-      <style>${Y}</style>
+      <style>${Z}</style>
       <section class="ekm-variant-editor">
         ${this.renderTopBar()}
         ${this.error ? `<p class="status status--error">${u(this.error)}</p>` : ""}
@@ -351,14 +351,14 @@ class R extends M(HTMLElement) {
     `;
   }
   renderGroup(t) {
-    const e = this.expandedGroupIds.has(t.id), a = this.getTitle(t, "New group"), s = U(t);
+    const e = this.expandedGroupIds.has(t.id), a = this.getTitle(t, "New group"), s = J(t);
     return `
       <article class="group-card ${h(t.id) ? "is-draft" : ""}" draggable="true" data-drag-group-id="${t.id}">
         <div class="group-header">
           <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
           <input type="checkbox" data-select-group data-group-id="${t.id}" ${this.selectedGroupIds.has(t.id) ? "checked" : ""} aria-label="Select group">
           <button type="button" class="group-toggle" data-action="toggle-group" data-group-id="${t.id}" aria-label="Toggle group">${e ? "▼" : "►"}</button>
-          <button type="button" class="thumb thumb--button" data-action="toggle-group" data-group-id="${t.id}">${E(s, a)}</button>
+          <button type="button" class="thumb thumb--button" data-action="toggle-group" data-group-id="${t.id}">${P(s, a)}</button>
           <button type="button" class="group-title" data-action="toggle-group" data-group-id="${t.id}">${u(a)}</button>
           <span class="count">${t.variants.length} variants</span>
           ${h(t.id) ? '<span class="badge">draft</span>' : ""}
@@ -386,7 +386,7 @@ class R extends M(HTMLElement) {
       <div class="variant-row ${h(e.id) ? "is-draft" : ""}" draggable="true" data-drag-group-id="${t.id}" data-drag-variant-id="${e.id}">
         <span class="drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
         <input type="checkbox" data-select-variant data-variant-id="${e.id}" ${this.selectedVariantIds.has(e.id) ? "checked" : ""} aria-label="Select variant">
-        <span class="thumb">${E(k(e.images), this.getTitle(e, "New variant"))}</span>
+        <span class="thumb">${P(k(e.images), this.getTitle(e, "New variant"))}</span>
         <strong>${u(this.getTitle(e, "New variant"))}${h(e.id) ? ' <span class="badge">draft</span>' : ""}</strong>
         <span>${u(e.sku)}</span>
         <span class="variant-price-cell">${u(this.getDefaultPrice(e))}</span>
@@ -413,7 +413,7 @@ class R extends M(HTMLElement) {
       <aside class="drawer">
         ${this.renderDrawerHeader(this.getTitle(t, "New group"), "variant group", t)}
         <div class="drawer-body">
-          ${this.renderTitleField("Group title", ((e = t.titleValues) == null ? void 0 : e[this.activeLanguage]) ?? "", "data-group-title", t.id)}
+          ${this.renderTitleField("Group title", ((e = t.titleValues) == null ? void 0 : e[this.activeLanguage]) ?? "", "data-group-title", t.id, 0, t.titleValues)}
           ${this.renderCustomFields(t.customFields, t.id)}
           ${this.renderMediaPicker("Images", t.images, "data-group-images", t.id)}
           <p class="hint">Group images apply to all variants unless a variant has its own.</p>
@@ -429,7 +429,7 @@ class R extends M(HTMLElement) {
       <aside class="drawer">
         ${this.renderDrawerHeader(this.getTitle(e, "New variant"), `${this.getTitle(t, "Group")} / variant`, e)}
         <div class="drawer-body">
-          ${this.renderTitleField("Title", ((a = e.titleValues) == null ? void 0 : a[this.activeLanguage]) ?? "", "data-variant-title", t.id, e.id)}
+          ${this.renderTitleField("Title", ((a = e.titleValues) == null ? void 0 : a[this.activeLanguage]) ?? "", "data-variant-title", t.id, e.id, e.titleValues)}
           <label>SKU<input data-variant-field="sku" data-group-id="${t.id}" data-variant-id="${e.id}" value="${u(e.sku)}"></label>
           ${this.renderCustomFields(e.customFields, t.id, e.id)}
           ${this.renderPriceTable(t.id, e)}
@@ -468,22 +468,23 @@ class R extends M(HTMLElement) {
       </footer>
     `;
   }
-  renderTitleField(t, e, a, s, r = 0) {
+  renderTitleField(t, e, a, s, r = 0, n = {}) {
     return `
       <label>${u(t)} *
-        ${this.renderLanguageMiniTabs()}
+        ${this.renderLanguageMiniTabs(n)}
         <input ${a} data-group-id="${s}" data-variant-id="${r}" value="${u(e)}" required>
       </label>
     `;
   }
-  renderLanguageMiniTabs() {
-    var e;
-    const t = ((e = this.product) == null ? void 0 : e.languages) ?? [];
-    return t.length <= 1 ? "" : `
+  renderLanguageMiniTabs(t) {
+    var a;
+    const e = ((a = this.product) == null ? void 0 : a.languages) ?? [];
+    return e.length <= 1 ? "" : `
       <div class="mini-tabs">
-        ${t.map((a) => {
-      const s = a.isoCode ?? "";
-      return `<button type="button" data-action="set-language" data-tab-value="${u(s)}" class="mini-tab ${s === this.activeLanguage ? "active" : ""}">${u(z(a))}</button>`;
+        ${e.map((s) => {
+      var d, c;
+      const r = s.isoCode ?? "", n = ["mini-tab"];
+      return r === this.activeLanguage && n.push("active"), (d = t[r]) != null && d.trim() || n.push("is-missing"), `<button type="button" data-action="set-language" data-tab-value="${u(r)}" class="${n.join(" ")}" title="${(c = t[r]) != null && c.trim() ? "" : "Missing title value"}">${u(_(s))}</button>`;
     }).join("")}
       </div>
     `;
@@ -504,9 +505,9 @@ class R extends M(HTMLElement) {
           <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
           <tbody>
             ${(((a = this.product) == null ? void 0 : a.stores) ?? []).flatMap((s) => (s.currencies ?? []).map((r) => {
-      var p, g;
-      const n = s.alias ?? "", d = r.currencyValue ?? "", c = S((g = (p = e.priceValues) == null ? void 0 : p[n]) == null ? void 0 : g.find((D) => v(D) === d));
-      return `<tr><td>${u(s.title ?? n)}</td><td>${u(r.isoCurrencySymbol ?? d)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${u(n)}" data-price-currency="${u(d)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(c)}"></td></tr>`;
+      var V, $;
+      const n = s.alias ?? "", d = r.currencyValue ?? "", c = ($ = (V = e.priceValues) == null ? void 0 : V[n]) == null ? void 0 : $.find((F) => v(F) === d), p = S(c);
+      return `<tr${c == null ? ' class="is-missing-value"' : ""}><td>${u(s.title ?? n)}</td><td>${u(r.isoCurrencySymbol ?? d)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${u(n)}" data-price-currency="${u(d)}" data-group-id="${t}" data-variant-id="${e.id}" value="${u(p)}"></td></tr>`;
     })).join("")}
           </tbody>
         </table>
@@ -593,7 +594,8 @@ class R extends M(HTMLElement) {
       });
     }), this.querySelectorAll("[data-price]").forEach((r) => {
       r.addEventListener("input", (n) => {
-        n.stopPropagation(), this.updatePrice(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.priceStore ?? "", r.dataset.priceCurrency ?? "", r.value);
+        var d;
+        n.stopPropagation(), this.updatePrice(Number(r.dataset.groupId), Number(r.dataset.variantId), r.dataset.priceStore ?? "", r.dataset.priceCurrency ?? "", r.value), (d = r.closest("tr")) == null || d.classList.toggle("is-missing-value", r.value.trim().length === 0);
       });
     }), this.querySelectorAll("[data-stock]").forEach((r) => {
       r.addEventListener("input", (n) => {
@@ -632,18 +634,18 @@ class R extends M(HTMLElement) {
   }
   bindMediaPickers() {
     this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
-      const e = t, a = t.dataset.value ?? "", s = x(a);
-      e.value = s.join(","), e.selection = s, _(e), t.addEventListener("change", async (r) => {
+      const e = t, a = t.dataset.value ?? "", s = I(a);
+      e.value = s.join(","), e.selection = s, K(e), t.addEventListener("change", async (r) => {
         const n = Number(t.dataset.groupId), d = Number(t.dataset.variantId);
         r.stopPropagation(), await Promise.resolve();
-        const c = A(e);
-        await f(e), d !== 0 ? this.updateVariant(n, d, "images", c) : this.updateGroupImages(n, c);
+        const c = G(e);
+        await g(e), d !== 0 ? this.updateVariant(n, d, "images", c) : this.updateGroupImages(n, c);
       });
     });
   }
   syncMediaPickers() {
     this.querySelectorAll("[data-group-images], [data-variant-images]").forEach((t) => {
-      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = A(e);
+      const e = t, a = Number(t.dataset.groupId), s = Number(t.dataset.variantId), r = G(e);
       if (s !== 0) {
         const d = this.getVariant(a, s);
         d != null && d.images !== r && (d.images = r);
@@ -656,6 +658,11 @@ class R extends M(HTMLElement) {
   updateSaveButtonState() {
     const t = this.querySelector('[data-action="save"]');
     t != null && t.toggleAttribute("disabled", this.saving || !this.hasChanges());
+  }
+  updateActiveLanguageTabMissingState(t) {
+    var a;
+    const e = Array.from(this.querySelectorAll('[data-action="set-language"]')).find((s) => s.dataset.tabValue === this.activeLanguage);
+    e == null || e.classList.toggle("is-missing", !((a = t[this.activeLanguage]) != null && a.trim()));
   }
   updateCustomField(t, e, a, s) {
     var d;
@@ -686,7 +693,7 @@ class R extends M(HTMLElement) {
     return !0;
   }
   validateTitle(t) {
-    return H(t == null ? void 0 : t.titleValues) ? !0 : (this.showError("Title is required."), !1);
+    return Y(t == null ? void 0 : t.titleValues) ? !0 : (this.showError("Title is required."), !1);
   }
   validateAllCustomFields() {
     var t;
@@ -707,7 +714,7 @@ class R extends M(HTMLElement) {
     return a == null ? !0 : (this.showError(`${a.label} is required.`), e && this.render(), !1);
   }
   reorderGroup(t, e) {
-    this.product == null || t == null || t === e || (this.product.groups = q(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
+    this.product == null || t == null || t === e || (this.product.groups = D(this.product.groups, t, e), this.product.groups.forEach((a, s) => {
       a.sortOrder = s;
     }), this.render());
   }
@@ -715,7 +722,7 @@ class R extends M(HTMLElement) {
     if (t == null || t.groupId !== e || t.variantId === a)
       return;
     const s = this.getGroup(t.groupId);
-    s != null && (s.variants = q(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
+    s != null && (s.variants = D(s.variants, t.variantId, a), s.variants.forEach((r, n) => {
       r.sortOrder = n;
     }), this.render());
   }
@@ -748,11 +755,11 @@ class R extends M(HTMLElement) {
     const e = (n = this.product) == null ? void 0 : n.stores[0], a = (d = e == null ? void 0 : e.currencies) == null ? void 0 : d[0];
     if (e == null || a == null)
       return "—";
-    const s = S((p = (c = t.priceValues) == null ? void 0 : c[e.alias ?? ""]) == null ? void 0 : p.find((g) => v(g) === (a.currencyValue ?? ""))), r = a.currencySymbol ?? a.isoCurrencySymbol ?? a.currencyValue ?? "";
-    return `${C(s)} ${r}`.trim();
+    const s = S((p = (c = t.priceValues) == null ? void 0 : c[e.alias ?? ""]) == null ? void 0 : p.find((f) => v(f) === (a.currencyValue ?? ""))), r = a.currencySymbol ?? a.isoCurrencySymbol ?? a.currencyValue ?? "";
+    return `${A(s)} ${r}`.trim();
   }
   getTotalStock(t) {
-    return t.stockValues.length === 0 ? "0" : C(t.stockValues.reduce((e, a) => e + (Number(a.value) || 0), 0));
+    return t.stockValues.length === 0 ? "0" : A(t.stockValues.reduce((e, a) => e + (Number(a.value) || 0), 0));
   }
   getStoreTitle(t) {
     var e, a;
@@ -792,7 +799,7 @@ async function w(i) {
   if (i.status !== 204)
     return i.json();
 }
-function $(i, o) {
+function E(i, o) {
   return i instanceof Error && i.message.length > 0 ? i.message : o;
 }
 function u(i) {
@@ -801,7 +808,7 @@ function u(i) {
 function y(i) {
   return Object.values(i ?? {}).find((o) => o != null && o.trim().length > 0) ?? "";
 }
-function z(i) {
+function _(i) {
   return (i.isoCode ?? i.cultureName ?? "").split("-")[0].toUpperCase();
 }
 function v(i) {
@@ -810,10 +817,10 @@ function v(i) {
 function S(i) {
   return (i == null ? void 0 : i.Price) ?? (i == null ? void 0 : i.price) ?? 0;
 }
-function C(i) {
+function A(i) {
   return new Intl.NumberFormat().format(i);
 }
-function x(i) {
+function I(i) {
   const o = String(i ?? "").trim();
   if (o.length === 0)
     return [];
@@ -823,12 +830,12 @@ function x(i) {
     } catch {
       return [];
     }
-  return o.split(",").map((t) => I(t.trim())).filter(Boolean);
+  return o.split(",").map((t) => x(t.trim())).filter(Boolean);
 }
 function k(i) {
-  return x(i)[0] ?? "";
+  return I(i)[0] ?? "";
 }
-function U(i) {
+function J(i) {
   const o = k(i.images);
   if (o)
     return o;
@@ -839,30 +846,30 @@ function U(i) {
   }
   return "";
 }
-function E(i, o) {
+function P(i, o) {
   return i ? `<umb-imaging-thumbnail unique="${u(i)}" width="38" height="38" alt="${u(o)}"></umb-imaging-thumbnail>` : "-";
 }
-function I(i) {
+function x(i) {
   const o = i.match(/umb:\/\/media\/(.+)$/i);
   return (o == null ? void 0 : o[1]) ?? i;
 }
-function A(i) {
-  return Array.isArray(i.selection) ? K(i.selection).join(",") : x(i.value ?? "").join(",");
+function G(i) {
+  return Array.isArray(i.selection) ? X(i.selection).join(",") : I(i.value ?? "").join(",");
 }
-const P = /* @__PURE__ */ new WeakSet();
-async function _(i) {
-  if (P.has(i)) {
-    await f(i);
+const N = /* @__PURE__ */ new WeakSet();
+async function K(i) {
+  if (N.has(i)) {
+    await g(i);
     return;
   }
-  P.add(i), await f(i);
+  N.add(i), await g(i);
   const o = i.shadowRoot;
   if (o == null)
     return;
-  const t = () => void J(i), e = () => window.setTimeout(() => void f(i));
-  new MutationObserver(() => void f(i)).observe(o, { childList: !0, subtree: !0 }), o.addEventListener("pointerdown", t, { capture: !0 }), o.addEventListener("dragstart", t, { capture: !0 }), o.addEventListener("dragend", e, { capture: !0 }), o.addEventListener("drop", e, { capture: !0 });
+  const t = () => void H(i), e = () => window.setTimeout(() => void g(i));
+  new MutationObserver(() => void g(i)).observe(o, { childList: !0, subtree: !0 }), o.addEventListener("pointerdown", t, { capture: !0 }), o.addEventListener("dragstart", t, { capture: !0 }), o.addEventListener("dragend", e, { capture: !0 }), o.addEventListener("drop", e, { capture: !0 });
 }
-async function J(i) {
+async function H(i) {
   var o;
   await i.updateComplete, await new Promise((t) => window.requestAnimationFrame(t)), (o = i.shadowRoot) == null || o.querySelectorAll("uui-card-media[data-mark]").forEach((t) => {
     var a;
@@ -870,19 +877,19 @@ async function J(i) {
     e && t.setAttribute("detail", e);
   });
 }
-async function f(i) {
+async function g(i) {
   var o;
   await i.updateComplete, await new Promise((t) => window.requestAnimationFrame(t)), (o = i.shadowRoot) == null || o.querySelectorAll("uui-card-media[detail]").forEach((t) => {
     t.removeAttribute("detail");
   });
 }
-function K(i) {
+function X(i) {
   return i.map((o) => {
     if (typeof o == "string")
-      return I(o);
+      return x(o);
     if (o != null && typeof o == "object") {
       const t = o;
-      return I(String(t.udi ?? t.key ?? t.unique ?? t.id ?? ""));
+      return x(String(t.udi ?? t.key ?? t.unique ?? t.id ?? ""));
     }
     return "";
   }).filter(Boolean);
@@ -890,16 +897,16 @@ function K(i) {
 function h(i) {
   return i <= 0;
 }
-function G(i) {
-  return b({
+function T(i) {
+  return m({
     titleValues: i.titleValues,
     images: i.images,
     customFields: i.customFields,
     sortOrder: i.sortOrder
   });
 }
-function N(i) {
-  return b({
+function q(i) {
+  return m({
     titleValues: i.titleValues,
     sku: i.sku,
     images: i.images,
@@ -909,16 +916,16 @@ function N(i) {
     sortOrder: i.sortOrder
   });
 }
-function T(i) {
+function L(i) {
   return (i ?? []).map((o) => ({
     ...o,
     value: ""
   }));
 }
-function H(i) {
+function Y(i) {
   return Object.values(i ?? {}).some((o) => o.trim().length > 0);
 }
-function X(i, o) {
+function Q(i, o) {
   const t = {};
   for (const e of o) {
     const a = e.alias ?? "", s = /* @__PURE__ */ new Map();
@@ -935,23 +942,23 @@ function X(i, o) {
   }
   return t;
 }
-function q(i, o, t) {
+function D(i, o, t) {
   const e = [...i], a = e.findIndex((n) => n.id === o), s = e.findIndex((n) => n.id === t);
   if (a < 0 || s < 0)
     return i;
   const [r] = e.splice(a, 1);
   return e.splice(s, 0, r), e;
 }
-function b(i) {
+function m(i) {
   if (Array.isArray(i))
-    return `[${i.map(b).join(",")}]`;
+    return `[${i.map(m).join(",")}]`;
   if (i != null && typeof i == "object") {
     const o = i;
-    return `{${Object.keys(o).sort().map((t) => `${JSON.stringify(t)}:${b(o[t])}`).join(",")}}`;
+    return `{${Object.keys(o).sort().map((t) => `${JSON.stringify(t)}:${m(o[t])}`).join(",")}}`;
   }
   return JSON.stringify(i);
 }
-const Y = `
+const Z = `
   :host { display: block; padding: var(--uui-size-layout-1, 24px); background: #f4f3f5; color: #1b264f; font-family: Lato, Arial, sans-serif; }
   .ekm-variant-editor { display: grid; gap: 16px; }
   .top-bar, .selection-actions, .main-actions, .group-header, .group-header-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
@@ -1001,13 +1008,16 @@ const Y = `
   .mini-tabs { display: inline-flex; gap: 4px; }
   .mini-tab { padding: 4px 8px; border-bottom: 2px solid transparent; color: #686570; font-weight: 700; }
   .mini-tab.active { border-bottom-color: #1b264f; color: #1b264f; }
+  .mini-tab.is-missing { color: #d42054; }
+  .mini-tab.is-missing::after { content: ''; display: inline-block; width: 6px; height: 6px; margin-left: 5px; border-radius: 999px; background: #d42054; vertical-align: middle; }
   table { width: 100%; border-collapse: collapse; }
   th { background: #f8f7fa; color: #8b8994; font-size: 11px; letter-spacing: .04em; text-align: left; text-transform: uppercase; }
   th, td { border-bottom: 1px solid #e2e1e6; padding: 8px; }
+  tr.is-missing-value td:first-child, tr.is-missing-value td:nth-child(2) { color: #d42054; font-weight: 700; }
   .numeric { text-align: right; }
   @keyframes slide-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
 `;
-customElements.define("ekom-variants-workspace-view", R);
+customElements.define("ekom-variants-workspace-view", U);
 export {
-  R as default
+  U as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
@@ -960,10 +960,8 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
             ${(this.product?.stores ?? []).flatMap(store => (store.currencies ?? []).map(currency => {
               const storeAlias = store.alias ?? '';
               const currencyValue = currency.currencyValue ?? '';
-              const priceItem = variant.priceValues?.[storeAlias]?.find(item => getCurrency(item) === currencyValue);
-              const price = getPrice(priceItem);
-              const missingClass = priceItem == null ? ' class="is-missing-value"' : '';
-              return `<tr${missingClass}><td>${escapeHtml(store.title ?? storeAlias)}</td><td>${escapeHtml(currency.isoCurrencySymbol ?? currencyValue)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${escapeHtml(storeAlias)}" data-price-currency="${escapeHtml(currencyValue)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(price)}"></td></tr>`;
+              const price = getPrice(variant.priceValues?.[storeAlias]?.find(item => getCurrency(item) === currencyValue));
+              return `<tr><td>${escapeHtml(store.title ?? storeAlias)}</td><td>${escapeHtml(currency.isoCurrencySymbol ?? currencyValue)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${escapeHtml(storeAlias)}" data-price-currency="${escapeHtml(currencyValue)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(price)}"></td></tr>`;
             })).join('')}
           </tbody>
         </table>
@@ -1107,7 +1105,6 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
       field.addEventListener('input', event => {
         event.stopPropagation();
         this.updatePrice(Number(field.dataset.groupId), Number(field.dataset.variantId), field.dataset.priceStore ?? '', field.dataset.priceCurrency ?? '', field.value);
-        field.closest('tr')?.classList.toggle('is-missing-value', field.value.trim().length === 0);
       });
     });
 
@@ -1815,7 +1812,6 @@ const styles = `
   table { width: 100%; border-collapse: collapse; }
   th { background: #f8f7fa; color: #8b8994; font-size: 11px; letter-spacing: .04em; text-align: left; text-transform: uppercase; }
   th, td { border-bottom: 1px solid #e2e1e6; padding: 8px; }
-  tr.is-missing-value td:first-child, tr.is-missing-value td:nth-child(2) { color: #d42054; font-weight: 700; }
   .numeric { text-align: right; }
   @keyframes slide-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
 `;

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
@@ -521,6 +521,7 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
     if (group != null) {
       group.titleValues = { ...group.titleValues, [this.activeLanguage]: value };
       group.title = getFirstValue(group.titleValues) || group.name;
+      this.updateActiveLanguageTabMissingState(group.titleValues);
       this.updateSaveButtonState();
     }
   }
@@ -540,6 +541,7 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
     if (variant != null) {
       variant.titleValues = { ...variant.titleValues, [this.activeLanguage]: value };
       variant.title = getFirstValue(variant.titleValues) || variant.name;
+      this.updateActiveLanguageTabMissingState(variant.titleValues);
       this.updateSaveButtonState();
     }
   }
@@ -842,7 +844,7 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
       <aside class="drawer">
         ${this.renderDrawerHeader(this.getTitle(group, 'New group'), 'variant group', group)}
         <div class="drawer-body">
-          ${this.renderTitleField('Group title', group.titleValues?.[this.activeLanguage] ?? '', 'data-group-title', group.id)}
+          ${this.renderTitleField('Group title', group.titleValues?.[this.activeLanguage] ?? '', 'data-group-title', group.id, 0, group.titleValues)}
           ${this.renderCustomFields(group.customFields, group.id)}
           ${this.renderMediaPicker('Images', group.images, 'data-group-images', group.id)}
           <p class="hint">Group images apply to all variants unless a variant has its own.</p>
@@ -858,7 +860,7 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
       <aside class="drawer">
         ${this.renderDrawerHeader(this.getTitle(variant, 'New variant'), `${this.getTitle(group, 'Group')} / variant`, variant)}
         <div class="drawer-body">
-          ${this.renderTitleField('Title', variant.titleValues?.[this.activeLanguage] ?? '', 'data-variant-title', group.id, variant.id)}
+          ${this.renderTitleField('Title', variant.titleValues?.[this.activeLanguage] ?? '', 'data-variant-title', group.id, variant.id, variant.titleValues)}
           <label>SKU<input data-variant-field="sku" data-group-id="${group.id}" data-variant-id="${variant.id}" value="${escapeHtml(variant.sku)}"></label>
           ${this.renderCustomFields(variant.customFields, group.id, variant.id)}
           ${this.renderPriceTable(group.id, variant)}
@@ -901,16 +903,16 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
     `;
   }
 
-  private renderTitleField(label: string, value: string, attribute: string, groupId: number, variantId = 0): string {
+  private renderTitleField(label: string, value: string, attribute: string, groupId: number, variantId = 0, titleValues: Record<string, string> = {}): string {
     return `
       <label>${escapeHtml(label)} *
-        ${this.renderLanguageMiniTabs()}
+        ${this.renderLanguageMiniTabs(titleValues)}
         <input ${attribute} data-group-id="${groupId}" data-variant-id="${variantId}" value="${escapeHtml(value)}" required>
       </label>
     `;
   }
 
-  private renderLanguageMiniTabs(): string {
+  private renderLanguageMiniTabs(titleValues: Record<string, string>): string {
     const languages = this.product?.languages ?? [];
 
     if (languages.length <= 1) {
@@ -921,7 +923,16 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
       <div class="mini-tabs">
         ${languages.map(language => {
           const value = language.isoCode ?? '';
-          return `<button type="button" data-action="set-language" data-tab-value="${escapeHtml(value)}" class="mini-tab ${value === this.activeLanguage ? 'active' : ''}">${escapeHtml(getLanguageLabel(language))}</button>`;
+          const classes = ['mini-tab'];
+          if (value === this.activeLanguage) {
+            classes.push('active');
+          }
+
+          if (!titleValues[value]?.trim()) {
+            classes.push('is-missing');
+          }
+
+          return `<button type="button" data-action="set-language" data-tab-value="${escapeHtml(value)}" class="${classes.join(' ')}" title="${!titleValues[value]?.trim() ? 'Missing title value' : ''}">${escapeHtml(getLanguageLabel(language))}</button>`;
         }).join('')}
       </div>
     `;
@@ -949,8 +960,10 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
             ${(this.product?.stores ?? []).flatMap(store => (store.currencies ?? []).map(currency => {
               const storeAlias = store.alias ?? '';
               const currencyValue = currency.currencyValue ?? '';
-              const price = getPrice(variant.priceValues?.[storeAlias]?.find(item => getCurrency(item) === currencyValue));
-              return `<tr><td>${escapeHtml(store.title ?? storeAlias)}</td><td>${escapeHtml(currency.isoCurrencySymbol ?? currencyValue)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${escapeHtml(storeAlias)}" data-price-currency="${escapeHtml(currencyValue)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(price)}"></td></tr>`;
+              const priceItem = variant.priceValues?.[storeAlias]?.find(item => getCurrency(item) === currencyValue);
+              const price = getPrice(priceItem);
+              const missingClass = priceItem == null ? ' class="is-missing-value"' : '';
+              return `<tr${missingClass}><td>${escapeHtml(store.title ?? storeAlias)}</td><td>${escapeHtml(currency.isoCurrencySymbol ?? currencyValue)}</td><td><input class="numeric" type="number" min="0" step="any" data-price data-price-store="${escapeHtml(storeAlias)}" data-price-currency="${escapeHtml(currencyValue)}" data-group-id="${groupId}" data-variant-id="${variant.id}" value="${escapeHtml(price)}"></td></tr>`;
             })).join('')}
           </tbody>
         </table>
@@ -1094,6 +1107,7 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
       field.addEventListener('input', event => {
         event.stopPropagation();
         this.updatePrice(Number(field.dataset.groupId), Number(field.dataset.variantId), field.dataset.priceStore ?? '', field.dataset.priceCurrency ?? '', field.value);
+        field.closest('tr')?.classList.toggle('is-missing-value', field.value.trim().length === 0);
       });
     });
 
@@ -1224,6 +1238,12 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
     if (saveButton != null) {
       saveButton.toggleAttribute('disabled', this.saving || !this.hasChanges());
     }
+  }
+
+  private updateActiveLanguageTabMissingState(titleValues: Record<string, string>): void {
+    const activeTab = Array.from(this.querySelectorAll<HTMLElement>('[data-action="set-language"]'))
+      .find(tab => tab.dataset.tabValue === this.activeLanguage);
+    activeTab?.classList.toggle('is-missing', !titleValues[this.activeLanguage]?.trim());
   }
 
   private updateCustomField(groupId: number, variantId: number, alias: string, value: string): void {
@@ -1790,9 +1810,12 @@ const styles = `
   .mini-tabs { display: inline-flex; gap: 4px; }
   .mini-tab { padding: 4px 8px; border-bottom: 2px solid transparent; color: #686570; font-weight: 700; }
   .mini-tab.active { border-bottom-color: #1b264f; color: #1b264f; }
+  .mini-tab.is-missing { color: #d42054; }
+  .mini-tab.is-missing::after { content: ''; display: inline-block; width: 6px; height: 6px; margin-left: 5px; border-radius: 999px; background: #d42054; vertical-align: middle; }
   table { width: 100%; border-collapse: collapse; }
   th { background: #f8f7fa; color: #8b8994; font-size: 11px; letter-spacing: .04em; text-align: left; text-transform: uppercase; }
   th, td { border-bottom: 1px solid #e2e1e6; padding: 8px; }
+  tr.is-missing-value td:first-child, tr.is-missing-value td:nth-child(2) { color: #d42054; font-weight: 700; }
   .numeric { text-align: right; }
   @keyframes slide-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
 `;

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/variants/variants-workspace-view.element.ts
@@ -385,6 +385,10 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
   private async save(): Promise<void> {
     this.syncMediaPickers();
 
+    if (!this.validateAllTitles()) {
+      return;
+    }
+
     if (!this.validateAllCustomFields()) {
       return;
     }
@@ -899,9 +903,9 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
 
   private renderTitleField(label: string, value: string, attribute: string, groupId: number, variantId = 0): string {
     return `
-      <label>${escapeHtml(label)}
+      <label>${escapeHtml(label)} *
         ${this.renderLanguageMiniTabs()}
-        <input ${attribute} data-group-id="${groupId}" data-variant-id="${variantId}" value="${escapeHtml(value)}">
+        <input ${attribute} data-group-id="${groupId}" data-variant-id="${variantId}" value="${escapeHtml(value)}" required>
       </label>
     `;
   }
@@ -997,7 +1001,7 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
     this.querySelector('[data-action="save-drawer"]')?.addEventListener('click', () => {
       this.syncMediaPickers();
 
-      if (!this.validateDrawerCustomFields()) {
+      if (!this.validateDrawerTitle() || !this.validateDrawerCustomFields()) {
         return;
       }
 
@@ -1245,6 +1249,43 @@ class EkomVariantsWorkspaceViewElement extends UmbElementMixin(HTMLElement) {
       : this.getVariant(this.drawer.groupId, this.drawer.variantId);
 
     return this.validateCustomFields(item?.customFields);
+  }
+
+  private validateDrawerTitle(): boolean {
+    if (this.drawer == null) {
+      return true;
+    }
+
+    const item = this.drawer.type === 'group'
+      ? this.getGroup(this.drawer.groupId)
+      : this.getVariant(this.drawer.groupId, this.drawer.variantId);
+
+    return this.validateTitle(item);
+  }
+
+  private validateAllTitles(): boolean {
+    for (const group of this.product?.groups ?? []) {
+      if (!this.validateTitle(group)) {
+        return false;
+      }
+
+      for (const variant of group.variants) {
+        if (!this.validateTitle(variant)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  private validateTitle(item: { titleValues?: Record<string, string> } | undefined): boolean {
+    if (hasAnyTitleValue(item?.titleValues)) {
+      return true;
+    }
+
+    this.showError('Title is required.');
+    return false;
   }
 
   private validateAllCustomFields(): boolean {
@@ -1632,6 +1673,10 @@ function createCustomFields(fields: CustomFieldDefinition[] | undefined): Custom
     ...field,
     value: '',
   }));
+}
+
+function hasAnyTitleValue(values: Record<string, string> | undefined): boolean {
+  return Object.values(values ?? {}).some(value => value.trim().length > 0);
 }
 
 function normalizePriceValues(priceValues: Record<string, CurrencyPrice[]>, stores: VariantStore[]): Record<string, CurrencyPrice[]> {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -161,6 +161,16 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         vm.drawer = null;
     };
 
+    function onKeyDown(event) {
+        if (event.key !== 'Escape' || !vm.drawer) {
+            return;
+        }
+
+        $scope.$apply(function () {
+            vm.closeDrawer();
+        });
+    }
+
     vm.saveDrawer = function () {
         if (!validateTitle(vm.drawer && vm.drawer.item) || !validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
             return;
@@ -407,6 +417,11 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         images.splice(index, 1);
         vm.drawer.item.images = images.join(',');
     };
+
+    document.addEventListener('keydown', onKeyDown);
+    $scope.$on('$destroy', function () {
+        document.removeEventListener('keydown', onKeyDown);
+    });
 
     bindDragAndDrop();
 

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -300,8 +300,7 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
                     storeTitle: store.title || store.alias || '',
                     currencyValue: currency.currencyValue || '',
                     currencyLabel: currency.isoCurrencySymbol || currency.currencyValue || '',
-                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || ''),
-                    missing: !hasVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
+                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
                 });
             });
         });
@@ -795,11 +794,6 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         var prices = (variant.priceValues || {})[storeAlias] || [];
         var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
         return price ? getPrice(price) : 0;
-    }
-
-    function hasVariantPrice(variant, storeAlias, currency) {
-        var prices = (variant.priceValues || {})[storeAlias] || [];
-        return prices.some(function (item) { return getCurrency(item) === currency; });
     }
 
     function getCurrency(price) {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -222,6 +222,11 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         vm.activeLanguage = value;
     };
 
+    vm.isLanguageTitleMissing = function (item, language) {
+        ensureTitleValues(item);
+        return !String(item.titleValues[language.isoCode || ''] || '').trim();
+    };
+
     vm.getTitleValue = function (item) {
         ensureTitleValues(item);
         return item.titleValues[vm.activeLanguage] || firstValue(item.titleValues) || item.title || '';
@@ -295,7 +300,8 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
                     storeTitle: store.title || store.alias || '',
                     currencyValue: currency.currencyValue || '',
                     currencyLabel: currency.isoCurrencySymbol || currency.currencyValue || '',
-                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
+                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || ''),
+                    missing: !hasVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
                 });
             });
         });
@@ -774,6 +780,11 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         var prices = (variant.priceValues || {})[storeAlias] || [];
         var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
         return price ? getPrice(price) : 0;
+    }
+
+    function hasVariantPrice(variant, storeAlias, currency) {
+        var prices = (variant.priceValues || {})[storeAlias] || [];
+        return prices.some(function (item) { return getCurrency(item) === currency; });
     }
 
     function getCurrency(price) {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -89,6 +89,10 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     };
 
     vm.saveAll = function () {
+        if (!validateAllTitles()) {
+            return;
+        }
+
         if (!validateAllCustomFields()) {
             return;
         }
@@ -158,7 +162,7 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     };
 
     vm.saveDrawer = function () {
-        if (!validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
+        if (!validateTitle(vm.drawer && vm.drawer.item) || !validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
             return;
         }
 
@@ -387,6 +391,10 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     bindDragAndDrop();
 
     function saveVariantChanges(options) {
+        if (!validateAllTitles()) {
+            return Promise.resolve();
+        }
+
         if (!validateAllCustomFields()) {
             return Promise.resolve();
         }
@@ -527,6 +535,39 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         }
 
         return true;
+    }
+
+    function validateAllTitles() {
+        var groups = vm.product ? vm.product.groups || [] : [];
+
+        for (var i = 0; i < groups.length; i++) {
+            if (!validateTitle(groups[i])) {
+                return false;
+            }
+
+            for (var j = 0; j < groups[i].variants.length; j++) {
+                if (!validateTitle(groups[i].variants[j])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    function validateTitle(item) {
+        if (hasAnyTitleValue(item && item.titleValues)) {
+            return true;
+        }
+
+        notificationsService.error('Variants', 'Title is required.');
+        return false;
+    }
+
+    function hasAnyTitleValue(values) {
+        return Object.keys(values || {}).some(function (key) {
+            return String(values[key] || '').trim();
+        });
     }
 
     function validateCustomFields(fields) {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -385,13 +385,28 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
             multiPicker: true,
             selection: splitImages(item.images),
             submit: function (model) {
-                item.images = normalizeMediaSelection(model.selection).join(',');
+                item.images = appendUniqueImages(splitImages(item.images), normalizeMediaSelection(model.selection)).join(',');
                 editorService.close();
             },
             close: function () {
                 editorService.close();
             }
         });
+    };
+
+    vm.removeDrawerImage = function (index) {
+        if (!vm.drawer) {
+            return;
+        }
+
+        var images = splitImages(vm.drawer.item.images);
+
+        if (index < 0 || index >= images.length) {
+            return;
+        }
+
+        images.splice(index, 1);
+        vm.drawer.item.images = images.join(',');
     };
 
     bindDragAndDrop();
@@ -843,11 +858,23 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     function normalizeMediaSelection(selection) {
         return (selection || []).map(function (item) {
             if (typeof item === 'string') {
-                return item;
+                return normalizeMediaIdentifier(item);
             }
 
-            return item.udi || item.key || item.id || '';
+            return normalizeMediaIdentifier(item.udi || item.key || item.id || '');
         }).filter(Boolean);
+    }
+
+    function appendUniqueImages(currentImages, selectedImages) {
+        var images = currentImages.slice();
+
+        selectedImages.forEach(function (image) {
+            if (images.indexOf(image) === -1) {
+                images.push(image);
+            }
+        });
+
+        return images;
     }
 
     function isDraft(id) {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -182,6 +182,27 @@
     text-align: right;
 }
 
+.ekm-variants-app .ekm-variants-mini-tabs button.is-missing {
+    color: #d42054;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs button.is-missing::after {
+    background: #d42054;
+    border-radius: 999px;
+    content: '';
+    display: inline-block;
+    height: 6px;
+    margin-left: 5px;
+    vertical-align: middle;
+    width: 6px;
+}
+
+.ekm-variants-app tr.is-missing-value td:first-child,
+.ekm-variants-app tr.is-missing-value td:nth-child(2) {
+    color: #d42054;
+    font-weight: 700;
+}
+
 .ekm-variants-app .ekm-variants-media-list {
     display: flex;
     flex-wrap: wrap;

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -151,10 +151,15 @@
     text-align: center;
 }
 
-.ekm-variants-app label {
+.ekm-variants-app label,
+.ekm-variants-app .ekm-variants-field-group {
     display: grid;
     font-weight: 700;
     gap: 8px;
+}
+
+.ekm-variants-app .ekm-variants-field-group table {
+    font-weight: 400;
 }
 
 .ekm-variants-app input {
@@ -195,12 +200,6 @@
     margin-left: 5px;
     vertical-align: middle;
     width: 6px;
-}
-
-.ekm-variants-app tr.is-missing-value td:first-child,
-.ekm-variants-app tr.is-missing-value td:nth-child(2) {
-    color: #d42054;
-    font-weight: 700;
 }
 
 .ekm-variants-app .ekm-variants-media-list {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -219,6 +219,7 @@
     gap: 4px;
     grid-template-columns: 14px 54px;
     padding: 4px;
+    position: relative;
 }
 
 .ekm-variants-app .ekm-variants-media-card img {
@@ -226,6 +227,31 @@
     height: 54px;
     object-fit: cover;
     width: 54px;
+}
+
+.ekm-variants-app .ekm-variants-media-remove {
+    align-items: center;
+    background: #d42054;
+    border: 1px solid #d42054;
+    border-radius: 999px;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 14px;
+    font-weight: 900;
+    height: 22px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    position: absolute;
+    right: -7px;
+    top: -7px;
+    width: 22px;
+}
+
+.ekm-variants-app .ekm-variants-media-remove:hover {
+    background: #b51b46;
+    border-color: #b51b46;
 }
 
 .ekm-variants-app .ekm-variants-status {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -114,12 +114,12 @@
             <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
                 <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
             </label>
-            <section>
-                <h3>Prices</h3>
+            <section class="ekm-variants-field-group">
+                <div class="ekm-variants-field-label">Prices</div>
                 <table>
                     <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
                     <tbody>
-                        <tr ng-repeat="priceRow in vm.priceRows()" ng-class="{ 'is-missing-value': priceRow.missing }">
+                        <tr ng-repeat="priceRow in vm.priceRows()">
                             <td>{{ priceRow.storeTitle }}</td>
                             <td>{{ priceRow.currencyLabel }}</td>
                             <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="priceRow.value" ng-change="vm.setPrice(vm.drawer.item, priceRow.storeAlias, priceRow.currencyValue, priceRow.value)" /></td>
@@ -127,8 +127,8 @@
                     </tbody>
                 </table>
             </section>
-            <section>
-                <h3>Stock</h3>
+            <section class="ekm-variants-field-group">
+                <div class="ekm-variants-field-label">Stock</div>
                 <table>
                     <thead><tr><th>Store</th><th>Stock</th></tr></thead>
                     <tbody>

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -81,7 +81,7 @@
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'group'">
             <label>Group title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
-                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage, 'is-missing': vm.isLanguageTitleMissing(vm.drawer.item, language) }" ng-click="vm.setLanguage(language.isoCode)" title="{{ vm.isLanguageTitleMissing(vm.drawer.item, language) ? 'Missing title value' : '' }}">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
                 <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
@@ -103,7 +103,7 @@
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'variant'">
             <label>Title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
-                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage, 'is-missing': vm.isLanguageTitleMissing(vm.drawer.item, language) }" ng-click="vm.setLanguage(language.isoCode)" title="{{ vm.isLanguageTitleMissing(vm.drawer.item, language) ? 'Missing title value' : '' }}">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
                 <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
@@ -118,7 +118,7 @@
                 <table>
                     <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
                     <tbody>
-                        <tr ng-repeat="priceRow in vm.priceRows()">
+                        <tr ng-repeat="priceRow in vm.priceRows()" ng-class="{ 'is-missing-value': priceRow.missing }">
                             <td>{{ priceRow.storeTitle }}</td>
                             <td>{{ priceRow.currencyLabel }}</td>
                             <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="priceRow.value" ng-change="vm.setPrice(vm.drawer.item, priceRow.storeAlias, priceRow.currencyValue, priceRow.value)" /></td>

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -79,11 +79,11 @@
         </header>
 
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'group'">
-            <label>Group title
+            <label>Group title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
                     <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
-                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
             <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
                 <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
@@ -101,11 +101,11 @@
         </div>
 
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'variant'">
-            <label>Title
+            <label>Title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
                     <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
-                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
             <label>SKU
                 <input type="text" ng-model="vm.drawer.item.sku" />

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -94,6 +94,7 @@
                     <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
                         <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
                         <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                        <button type="button" class="ekm-variants-media-remove" ng-click="vm.removeDrawerImage($index)" title="Remove image" aria-label="Remove image">×</button>
                     </div>
                 </div>
             </label>
@@ -144,6 +145,7 @@
                     <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
                         <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
                         <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                        <button type="button" class="ekm-variants-media-remove" ng-click="vm.removeDrawerImage($index)" title="Remove image" aria-label="Remove image">×</button>
                     </div>
                 </div>
             </label>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -161,6 +161,16 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         vm.drawer = null;
     };
 
+    function onKeyDown(event) {
+        if (event.key !== 'Escape' || !vm.drawer) {
+            return;
+        }
+
+        $scope.$apply(function () {
+            vm.closeDrawer();
+        });
+    }
+
     vm.saveDrawer = function () {
         if (!validateTitle(vm.drawer && vm.drawer.item) || !validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
             return;
@@ -407,6 +417,11 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         images.splice(index, 1);
         vm.drawer.item.images = images.join(',');
     };
+
+    document.addEventListener('keydown', onKeyDown);
+    $scope.$on('$destroy', function () {
+        document.removeEventListener('keydown', onKeyDown);
+    });
 
     bindDragAndDrop();
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -300,8 +300,7 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
                     storeTitle: store.title || store.alias || '',
                     currencyValue: currency.currencyValue || '',
                     currencyLabel: currency.isoCurrencySymbol || currency.currencyValue || '',
-                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || ''),
-                    missing: !hasVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
+                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
                 });
             });
         });
@@ -795,11 +794,6 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         var prices = (variant.priceValues || {})[storeAlias] || [];
         var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
         return price ? getPrice(price) : 0;
-    }
-
-    function hasVariantPrice(variant, storeAlias, currency) {
-        var prices = (variant.priceValues || {})[storeAlias] || [];
-        return prices.some(function (item) { return getCurrency(item) === currency; });
     }
 
     function getCurrency(price) {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -222,6 +222,11 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         vm.activeLanguage = value;
     };
 
+    vm.isLanguageTitleMissing = function (item, language) {
+        ensureTitleValues(item);
+        return !String(item.titleValues[language.isoCode || ''] || '').trim();
+    };
+
     vm.getTitleValue = function (item) {
         ensureTitleValues(item);
         return item.titleValues[vm.activeLanguage] || firstValue(item.titleValues) || item.title || '';
@@ -295,7 +300,8 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
                     storeTitle: store.title || store.alias || '',
                     currencyValue: currency.currencyValue || '',
                     currencyLabel: currency.isoCurrencySymbol || currency.currencyValue || '',
-                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
+                    value: getVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || ''),
+                    missing: !hasVariantPrice(vm.drawer.item, store.alias || '', currency.currencyValue || '')
                 });
             });
         });
@@ -774,6 +780,11 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         var prices = (variant.priceValues || {})[storeAlias] || [];
         var price = prices.filter(function (item) { return getCurrency(item) === currency; })[0];
         return price ? getPrice(price) : 0;
+    }
+
+    function hasVariantPrice(variant, storeAlias, currency) {
+        var prices = (variant.priceValues || {})[storeAlias] || [];
+        return prices.some(function (item) { return getCurrency(item) === currency; });
     }
 
     function getCurrency(price) {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -89,6 +89,10 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     };
 
     vm.saveAll = function () {
+        if (!validateAllTitles()) {
+            return;
+        }
+
         if (!validateAllCustomFields()) {
             return;
         }
@@ -158,7 +162,7 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     };
 
     vm.saveDrawer = function () {
-        if (!validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
+        if (!validateTitle(vm.drawer && vm.drawer.item) || !validateCustomFields(vm.drawer && vm.drawer.item && vm.drawer.item.customFields)) {
             return;
         }
 
@@ -387,6 +391,10 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     bindDragAndDrop();
 
     function saveVariantChanges(options) {
+        if (!validateAllTitles()) {
+            return Promise.resolve();
+        }
+
         if (!validateAllCustomFields()) {
             return Promise.resolve();
         }
@@ -527,6 +535,39 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
         }
 
         return true;
+    }
+
+    function validateAllTitles() {
+        var groups = vm.product ? vm.product.groups || [] : [];
+
+        for (var i = 0; i < groups.length; i++) {
+            if (!validateTitle(groups[i])) {
+                return false;
+            }
+
+            for (var j = 0; j < groups[i].variants.length; j++) {
+                if (!validateTitle(groups[i].variants[j])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    function validateTitle(item) {
+        if (hasAnyTitleValue(item && item.titleValues)) {
+            return true;
+        }
+
+        notificationsService.error('Variants', 'Title is required.');
+        return false;
+    }
+
+    function hasAnyTitleValue(values) {
+        return Object.keys(values || {}).some(function (key) {
+            return String(values[key] || '').trim();
+        });
     }
 
     function validateCustomFields(fields) {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.controller.js
@@ -385,13 +385,28 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
             multiPicker: true,
             selection: splitImages(item.images),
             submit: function (model) {
-                item.images = normalizeMediaSelection(model.selection).join(',');
+                item.images = appendUniqueImages(splitImages(item.images), normalizeMediaSelection(model.selection)).join(',');
                 editorService.close();
             },
             close: function () {
                 editorService.close();
             }
         });
+    };
+
+    vm.removeDrawerImage = function (index) {
+        if (!vm.drawer) {
+            return;
+        }
+
+        var images = splitImages(vm.drawer.item.images);
+
+        if (index < 0 || index >= images.length) {
+            return;
+        }
+
+        images.splice(index, 1);
+        vm.drawer.item.images = images.join(',');
     };
 
     bindDragAndDrop();
@@ -843,11 +858,23 @@ angular.module('umbraco').controller('Ekom.Variants', function ($element, $http,
     function normalizeMediaSelection(selection) {
         return (selection || []).map(function (item) {
             if (typeof item === 'string') {
-                return item;
+                return normalizeMediaIdentifier(item);
             }
 
-            return item.udi || item.key || item.id || '';
+            return normalizeMediaIdentifier(item.udi || item.key || item.id || '');
         }).filter(Boolean);
+    }
+
+    function appendUniqueImages(currentImages, selectedImages) {
+        var images = currentImages.slice();
+
+        selectedImages.forEach(function (image) {
+            if (images.indexOf(image) === -1) {
+                images.push(image);
+            }
+        });
+
+        return images;
     }
 
     function isDraft(id) {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -182,6 +182,27 @@
     text-align: right;
 }
 
+.ekm-variants-app .ekm-variants-mini-tabs button.is-missing {
+    color: #d42054;
+}
+
+.ekm-variants-app .ekm-variants-mini-tabs button.is-missing::after {
+    background: #d42054;
+    border-radius: 999px;
+    content: '';
+    display: inline-block;
+    height: 6px;
+    margin-left: 5px;
+    vertical-align: middle;
+    width: 6px;
+}
+
+.ekm-variants-app tr.is-missing-value td:first-child,
+.ekm-variants-app tr.is-missing-value td:nth-child(2) {
+    color: #d42054;
+    font-weight: 700;
+}
+
 .ekm-variants-app .ekm-variants-media-list {
     display: flex;
     flex-wrap: wrap;

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -151,10 +151,15 @@
     text-align: center;
 }
 
-.ekm-variants-app label {
+.ekm-variants-app label,
+.ekm-variants-app .ekm-variants-field-group {
     display: grid;
     font-weight: 700;
     gap: 8px;
+}
+
+.ekm-variants-app .ekm-variants-field-group table {
+    font-weight: 400;
 }
 
 .ekm-variants-app input {
@@ -195,12 +200,6 @@
     margin-left: 5px;
     vertical-align: middle;
     width: 6px;
-}
-
-.ekm-variants-app tr.is-missing-value td:first-child,
-.ekm-variants-app tr.is-missing-value td:nth-child(2) {
-    color: #d42054;
-    font-weight: 700;
 }
 
 .ekm-variants-app .ekm-variants-media-list {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.css
@@ -219,6 +219,7 @@
     gap: 4px;
     grid-template-columns: 14px 54px;
     padding: 4px;
+    position: relative;
 }
 
 .ekm-variants-app .ekm-variants-media-card img {
@@ -226,6 +227,31 @@
     height: 54px;
     object-fit: cover;
     width: 54px;
+}
+
+.ekm-variants-app .ekm-variants-media-remove {
+    align-items: center;
+    background: #d42054;
+    border: 1px solid #d42054;
+    border-radius: 999px;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 14px;
+    font-weight: 900;
+    height: 22px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    position: absolute;
+    right: -7px;
+    top: -7px;
+    width: 22px;
+}
+
+.ekm-variants-app .ekm-variants-media-remove:hover {
+    background: #b51b46;
+    border-color: #b51b46;
 }
 
 .ekm-variants-app .ekm-variants-status {

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -114,12 +114,12 @@
             <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
                 <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
             </label>
-            <section>
-                <h3>Prices</h3>
+            <section class="ekm-variants-field-group">
+                <div class="ekm-variants-field-label">Prices</div>
                 <table>
                     <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
                     <tbody>
-                        <tr ng-repeat="priceRow in vm.priceRows()" ng-class="{ 'is-missing-value': priceRow.missing }">
+                        <tr ng-repeat="priceRow in vm.priceRows()">
                             <td>{{ priceRow.storeTitle }}</td>
                             <td>{{ priceRow.currencyLabel }}</td>
                             <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="priceRow.value" ng-change="vm.setPrice(vm.drawer.item, priceRow.storeAlias, priceRow.currencyValue, priceRow.value)" /></td>
@@ -127,8 +127,8 @@
                     </tbody>
                 </table>
             </section>
-            <section>
-                <h3>Stock</h3>
+            <section class="ekm-variants-field-group">
+                <div class="ekm-variants-field-label">Stock</div>
                 <table>
                     <thead><tr><th>Store</th><th>Stock</th></tr></thead>
                     <tbody>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -81,7 +81,7 @@
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'group'">
             <label>Group title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
-                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage, 'is-missing': vm.isLanguageTitleMissing(vm.drawer.item, language) }" ng-click="vm.setLanguage(language.isoCode)" title="{{ vm.isLanguageTitleMissing(vm.drawer.item, language) ? 'Missing title value' : '' }}">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
                 <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
@@ -103,7 +103,7 @@
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'variant'">
             <label>Title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
-                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
+                    <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage, 'is-missing': vm.isLanguageTitleMissing(vm.drawer.item, language) }" ng-click="vm.setLanguage(language.isoCode)" title="{{ vm.isLanguageTitleMissing(vm.drawer.item, language) ? 'Missing title value' : '' }}">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
                 <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
@@ -118,7 +118,7 @@
                 <table>
                     <thead><tr><th>Store</th><th>Currency</th><th>Price</th></tr></thead>
                     <tbody>
-                        <tr ng-repeat="priceRow in vm.priceRows()">
+                        <tr ng-repeat="priceRow in vm.priceRows()" ng-class="{ 'is-missing-value': priceRow.missing }">
                             <td>{{ priceRow.storeTitle }}</td>
                             <td>{{ priceRow.currencyLabel }}</td>
                             <td><input class="ekm-variants-number" type="number" min="0" step="any" ng-model="priceRow.value" ng-change="vm.setPrice(vm.drawer.item, priceRow.storeAlias, priceRow.currencyValue, priceRow.value)" /></td>

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -79,11 +79,11 @@
         </header>
 
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'group'">
-            <label>Group title
+            <label>Group title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
                     <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
-                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
             <label ng-repeat="field in vm.drawer.item.customFields track by field.alias">{{ field.label }}<span ng-if="field.required"> *</span>
                 <input type="text" ng-model="field.value" ng-required="field.required" ng-change="vm.setCustomField(vm.drawer.item, field, field.value)" />
@@ -101,11 +101,11 @@
         </div>
 
         <div class="ekm-variants-drawer__body" ng-if="vm.drawer.type == 'variant'">
-            <label>Title
+            <label>Title *
                 <div class="ekm-variants-mini-tabs" ng-if="vm.product.languages.length > 1">
                     <button type="button" class="btn-reset" ng-repeat="language in vm.product.languages" ng-class="{ active: language.isoCode == vm.activeLanguage }" ng-click="vm.setLanguage(language.isoCode)">{{ vm.getLanguageLabel(language) }}</button>
                 </div>
-                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
+                <input type="text" ng-model="vm.drawer.item.titleValues[vm.activeLanguage]" ng-required="true" ng-change="vm.setTitleValue(vm.drawer.item, vm.drawer.item.titleValues[vm.activeLanguage])" />
             </label>
             <label>SKU
                 <input type="text" ng-model="vm.drawer.item.sku" />

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/Variants/ekmVariants.html
@@ -94,6 +94,7 @@
                     <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
                         <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
                         <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                        <button type="button" class="ekm-variants-media-remove" ng-click="vm.removeDrawerImage($index)" title="Remove image" aria-label="Remove image">×</button>
                     </div>
                 </div>
             </label>
@@ -144,6 +145,7 @@
                     <div class="ekm-variants-media-card" ng-repeat="image in vm.mediaImages(vm.drawer.item) track by $index" draggable="true" data-media-image-index="{{ $index }}">
                         <span class="ekm-variants-drag-handle" title="Drag to reorder">⋮⋮</span>
                         <img ng-src="{{ vm.getThumbUrl(image) }}" alt="" />
+                        <button type="button" class="ekm-variants-media-remove" ng-click="vm.removeDrawerImage($index)" title="Remove image" aria-label="Remove image">×</button>
                     </div>
                 </div>
             </label>


### PR DESCRIPTION
## Summary
- Require variant/group titles before saving drafts and highlight missing drawer values.
- Improve U10 image handling by appending selected images, supporting removals, and aligning drawer labels.
- Remove U17 price row warning styling so store/currency labels no longer appear red.
- Close the U10 variant drawer with Escape.

## Test Plan
- Verify U10 and U17 variant drawers block saving when titles are missing.
- Verify missing title/custom field indicators render in the drawer.
- Verify U10 image picker appends images, avoids duplicates, and supports removal.
- Verify U17 price rows no longer show red store/currency labels.
- Verify pressing Escape closes the U10 variant drawer.