### PR TITLE
feat(catalog): add custom collection view

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Ekom.AspNetCore;
 using Ekom.Services;
 using Ekom.Tracking;
+using Ekom.Umb.CatalogCollection.Services;
 using Ekom.Umb.Services;
 using Ekom.Umb.VariantApp.Services;
 using EkomCore.Services;
@@ -30,6 +31,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<NodeService>();
         services.AddTransient<IMetafieldService, MetafieldService>();
         services.AddTransient<IUmbracoService, UmbracoService>();
+        services.AddTransient<ICatalogCollectionService, CatalogCollectionService>();
         services.AddTransient<IVariantAppService, VariantAppService>();
         services.AddTransient<IUrlService, UrlService>();
         services.AddScoped<BackofficeUserAccessor>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Controllers/CatalogCollectionController.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Controllers/CatalogCollectionController.cs
@@ -1,0 +1,26 @@
+using Ekom.ActionFilters;
+using Ekom.Authorization;
+using Ekom.Umb.CatalogCollection.Models;
+using Ekom.Umb.CatalogCollection.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ekom.Umb.CatalogCollection.Controllers;
+
+[Route("ekom/backoffice/CatalogCollection")]
+[CamelCaseJson]
+public sealed class CatalogCollectionController : ControllerBase
+{
+    private readonly ICatalogCollectionService _catalogCollectionService;
+
+    public CatalogCollectionController(ICatalogCollectionService catalogCollectionService)
+    {
+        _catalogCollectionService = catalogCollectionService;
+    }
+
+    [HttpGet]
+    [Route("{nodeId}")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public CatalogCollectionResponse GetCollection([FromRoute] string nodeId, [FromQuery] CatalogCollectionRequest request)
+        => _catalogCollectionService.GetCollection(nodeId, request);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Models/CatalogCollectionModels.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Models/CatalogCollectionModels.cs
@@ -1,0 +1,50 @@
+namespace Ekom.Umb.CatalogCollection.Models;
+
+public sealed class CatalogCollectionRequest
+{
+    public string Query { get; set; } = string.Empty;
+    public string Sort { get; set; } = "sortOrderAsc";
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 80;
+}
+
+public sealed class CatalogCollectionResponse
+{
+    public CatalogCollectionNode Current { get; set; } = new();
+    public CatalogCollectionNode? Parent { get; set; }
+    public IReadOnlyList<CatalogCollectionNode> Breadcrumbs { get; set; } = Array.Empty<CatalogCollectionNode>();
+    public IReadOnlyList<CatalogCollectionNode> Subcategories { get; set; } = Array.Empty<CatalogCollectionNode>();
+    public IReadOnlyList<CatalogCollectionProduct> Products { get; set; } = Array.Empty<CatalogCollectionProduct>();
+    public int ProductCount { get; set; }
+    public int SubcategoryCount { get; set; }
+    public int FilteredProductCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int TotalPages { get; set; }
+}
+
+public class CatalogCollectionNode
+{
+    public int Id { get; set; }
+    public Guid Key { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string ContentTypeAlias { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+    public int ProductCount { get; set; }
+    public int SubcategoryCount { get; set; }
+}
+
+public sealed class CatalogCollectionProduct : CatalogCollectionNode
+{
+    public string Sku { get; set; } = string.Empty;
+    public string Price { get; set; } = string.Empty;
+    public decimal? PriceValue { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime UpdatedDate { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public bool Published { get; set; }
+    public bool PendingChanges { get; set; }
+    public bool Available { get; set; }
+    public string Image { get; set; } = string.Empty;
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/CatalogCollectionService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/CatalogCollectionService.cs
@@ -1,0 +1,486 @@
+using Ekom.Models;
+using Ekom.Models.Umbraco;
+using Ekom.Umb.CatalogCollection.Models;
+using Newtonsoft.Json;
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Extensions;
+
+namespace Ekom.Umb.CatalogCollection.Services;
+
+internal sealed class CatalogCollectionService : ICatalogCollectionService
+{
+    private const int MaxPageSize = 200;
+    private static readonly HashSet<string> CatalogAliases = new(StringComparer.OrdinalIgnoreCase) { "ekmCategory", "ekmProduct" };
+
+    private readonly IContentService _contentService;
+    private readonly IScopeProvider _scopeProvider;
+
+    public CatalogCollectionService(IContentService contentService, IScopeProvider scopeProvider)
+    {
+        _contentService = contentService;
+        _scopeProvider = scopeProvider;
+    }
+
+    public CatalogCollectionResponse GetCollection(string nodeId, CatalogCollectionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var current = GetContent(nodeId);
+        if (current.Trashed)
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.NotFound);
+        }
+
+        if (!CatalogAliases.Contains(current.ContentType.Alias))
+        {
+            throw new Exceptions.HttpResponseException(HttpStatusCode.BadRequest);
+        }
+
+        var pageSize = Math.Clamp(request.PageSize <= 0 ? 80 : request.PageSize, 1, MaxPageSize);
+        var page = Math.Max(request.Page, 1);
+        var children = GetCatalogChildren(current.Id);
+        var subcategoryContent = children
+            .Where(x => x.ContentType.Alias.Equals("ekmCategory", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(x => x.SortOrder)
+            .ThenBy(x => x.Name)
+            .ToList();
+        var subcategoryCounts = GetChildCounts(subcategoryContent.Select(x => x.Id).ToList());
+        var subcategories = subcategoryContent
+            .Select(category => MapNode(category, subcategoryCounts.GetValueOrDefault(category.Id)))
+            .ToList();
+        var products = children
+            .Where(x => x.ContentType.Alias.Equals("ekmProduct", StringComparison.OrdinalIgnoreCase))
+            .Select(MapProduct)
+            .ToList();
+
+        var filteredProducts = FilterProducts(products, request.Query);
+        filteredProducts = SortProducts(filteredProducts, request.Sort);
+
+        var totalPages = Math.Max(1, (int)Math.Ceiling(filteredProducts.Count / (double)pageSize));
+        page = Math.Min(page, totalPages);
+        var pagedProducts = filteredProducts
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return new CatalogCollectionResponse
+        {
+            Current = MapNode(current),
+            Parent = GetParent(current),
+            Breadcrumbs = GetBreadcrumbs(current),
+            Subcategories = subcategories,
+            Products = pagedProducts,
+            ProductCount = products.Count,
+            SubcategoryCount = subcategories.Count,
+            FilteredProductCount = filteredProducts.Count,
+            Page = page,
+            PageSize = pageSize,
+            TotalPages = totalPages,
+        };
+    }
+
+    private IContent GetContent(string id)
+    {
+        IContent? content = null;
+
+        if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
+        {
+            content = _contentService.GetById(intId);
+        }
+        else if (Guid.TryParse(id, out var key))
+        {
+            content = _contentService.GetById(key);
+        }
+
+        return content ?? throw new Exceptions.HttpResponseException(HttpStatusCode.NotFound);
+    }
+
+    private IReadOnlyList<IContent> GetCatalogChildren(int parentId)
+    {
+        return _contentService.GetPagedChildren(parentId, 0, int.MaxValue, out _)
+            .Where(x => !x.Trashed && CatalogAliases.Contains(x.ContentType.Alias))
+            .ToList();
+    }
+
+    private CatalogCollectionNode? GetParent(IContent content)
+    {
+        if (content.ParentId <= 0)
+        {
+            return null;
+        }
+
+        var parent = _contentService.GetById(content.ParentId);
+        return parent == null || !CatalogAliases.Contains(parent.ContentType.Alias) ? null : MapNode(parent);
+    }
+
+    private IReadOnlyList<CatalogCollectionNode> GetBreadcrumbs(IContent content)
+    {
+        var breadcrumbs = new List<CatalogCollectionNode>();
+        var current = content;
+
+        while (current.ParentId > 0)
+        {
+            var parent = _contentService.GetById(current.ParentId);
+            if (parent == null)
+            {
+                break;
+            }
+
+            if (CatalogAliases.Contains(parent.ContentType.Alias))
+            {
+                breadcrumbs.Add(MapNode(parent));
+            }
+
+            current = parent;
+        }
+
+        breadcrumbs.Reverse();
+        breadcrumbs.Add(MapNode(content));
+        return breadcrumbs;
+    }
+
+    private static List<CatalogCollectionProduct> FilterProducts(List<CatalogCollectionProduct> products, string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return products;
+        }
+
+        return products
+            .Where(x => x.Title.Contains(query, StringComparison.OrdinalIgnoreCase)
+                || x.Name.Contains(query, StringComparison.OrdinalIgnoreCase)
+                || x.Sku.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private static List<CatalogCollectionProduct> SortProducts(List<CatalogCollectionProduct> products, string? sort)
+    {
+        return (sort ?? string.Empty).ToUpperInvariant() switch
+        {
+            "SORTORDERDESC" => products.OrderByDescending(x => x.SortOrder).ThenBy(x => x.Title).ToList(),
+            "NAMEDESC" => products.OrderByDescending(x => x.Title).ThenBy(x => x.Sku).ToList(),
+            "PRICEASC" => products.OrderBy(x => x.PriceValue ?? decimal.MaxValue).ThenBy(x => x.Title).ToList(),
+            "PRICEDESC" => products.OrderByDescending(x => x.PriceValue ?? decimal.MinValue).ThenBy(x => x.Title).ToList(),
+            "SKUASC" => products.OrderBy(x => x.Sku).ThenBy(x => x.Title).ToList(),
+            "SKUDESC" => products.OrderByDescending(x => x.Sku).ThenBy(x => x.Title).ToList(),
+            "CREATEDASC" => products.OrderBy(x => x.CreatedDate).ThenBy(x => x.Title).ToList(),
+            "CREATEDDESC" => products.OrderByDescending(x => x.CreatedDate).ThenBy(x => x.Title).ToList(),
+            "UPDATEDASC" => products.OrderBy(x => x.UpdatedDate).ThenBy(x => x.Title).ToList(),
+            "UPDATEDDESC" => products.OrderByDescending(x => x.UpdatedDate).ThenBy(x => x.Title).ToList(),
+            "NAMEASC" => products.OrderBy(x => x.Title).ThenBy(x => x.Sku).ToList(),
+            _ => products.OrderBy(x => x.SortOrder).ThenBy(x => x.Title).ToList(),
+        };
+    }
+
+    private IReadOnlyDictionary<int, CatalogCollectionCounts> GetChildCounts(IReadOnlyList<int> parentIds)
+    {
+        if (parentIds.Count == 0)
+        {
+            return new Dictionary<int, CatalogCollectionCounts>();
+        }
+
+        using var scope = _scopeProvider.CreateScope(autoComplete: true);
+        var rows = scope.Database.Fetch<CatalogCollectionCountRow>(
+            @"SELECT n.parentId AS ParentId, ct.alias AS ContentTypeAlias, COUNT(*) AS Count
+FROM umbracoNode n
+INNER JOIN umbracoContent c ON c.nodeId = n.id
+INNER JOIN cmsContentType ct ON ct.nodeId = c.contentTypeId
+WHERE n.parentId IN (@0)
+  AND n.trashed = 0
+  AND ct.alias IN ('ekmCategory', 'ekmProduct')
+GROUP BY n.parentId, ct.alias",
+            parentIds);
+
+        var counts = new Dictionary<int, CatalogCollectionCounts>();
+        foreach (var row in rows)
+        {
+            if (!counts.TryGetValue(row.ParentId, out var count))
+            {
+                count = new CatalogCollectionCounts();
+                counts[row.ParentId] = count;
+            }
+
+            if (row.ContentTypeAlias.Equals("ekmProduct", StringComparison.OrdinalIgnoreCase))
+            {
+                count.ProductCount = row.Count;
+            }
+            else if (row.ContentTypeAlias.Equals("ekmCategory", StringComparison.OrdinalIgnoreCase))
+            {
+                count.SubcategoryCount = row.Count;
+            }
+        }
+
+        return counts;
+    }
+
+    private static CatalogCollectionNode MapNode(IContent content, CatalogCollectionCounts? counts = null)
+    {
+        return new CatalogCollectionNode
+        {
+            Id = content.Id,
+            Key = content.Key,
+            Name = content.Name ?? string.Empty,
+            Title = GetTitle(content),
+            ContentTypeAlias = content.ContentType.Alias,
+            SortOrder = content.SortOrder,
+            ProductCount = counts?.ProductCount ?? 0,
+            SubcategoryCount = counts?.SubcategoryCount ?? 0,
+        };
+    }
+
+    private static CatalogCollectionProduct MapProduct(IContent content)
+    {
+        var price = GetPrice(content);
+        var pendingChanges = content.Published && content.Edited;
+
+        return new CatalogCollectionProduct
+        {
+            Id = content.Id,
+            Key = content.Key,
+            Name = content.Name ?? string.Empty,
+            Title = GetTitle(content),
+            ContentTypeAlias = content.ContentType.Alias,
+            SortOrder = content.SortOrder,
+            Sku = GetStringValue(content, "sku"),
+            PriceValue = price.Value,
+            Price = FormatPrice(price),
+            CreatedDate = content.CreateDate,
+            UpdatedDate = content.UpdateDate,
+            Published = content.Published,
+            PendingChanges = pendingChanges,
+            Status = content.Published ? pendingChanges ? "Pending changes" : "Published" : "Unpublished",
+            Available = IsAvailable(content),
+            Image = GetFirstImage(GetStringValue(content, "images")),
+        };
+    }
+
+    private static string GetFirstImage(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var trimmedValue = value.Trim();
+        if (trimmedValue.StartsWith("[", StringComparison.Ordinal))
+        {
+            return GetFirstImageFromJson(trimmedValue);
+        }
+
+        return NormalizeMediaIdentifier(trimmedValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault() ?? string.Empty);
+    }
+
+    private static string GetFirstImageFromJson(string value)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return string.Empty;
+            }
+
+            foreach (var item in document.RootElement.EnumerateArray())
+            {
+                if (TryGetJsonString(item, "mediaKey", out var mediaKey) || TryGetJsonString(item, "key", out mediaKey))
+                {
+                    return NormalizeMediaIdentifier(mediaKey);
+                }
+            }
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private static bool TryGetJsonString(JsonElement item, string propertyName, out string value)
+    {
+        value = string.Empty;
+        if (item.ValueKind != JsonValueKind.Object || !item.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = property.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static string NormalizeMediaIdentifier(string value)
+    {
+        const string mediaUdiPrefix = "umb://media/";
+        var trimmedValue = value.Trim();
+        return trimmedValue.StartsWith(mediaUdiPrefix, StringComparison.OrdinalIgnoreCase)
+            ? trimmedValue[mediaUdiPrefix.Length..]
+            : trimmedValue;
+    }
+
+    private static string GetTitle(IContent content)
+    {
+        var title = GetStringValue(content, "title");
+        return string.IsNullOrWhiteSpace(title) ? content.Name ?? string.Empty : title;
+    }
+
+    private static string GetStringValue(IContent content, string alias)
+    {
+        if (!content.HasProperty(alias))
+        {
+            return string.Empty;
+        }
+
+        var value = content.GetValue<string>(alias) ?? string.Empty;
+        var property = ParsePropertyValue(value);
+        if (property?.Values == null)
+        {
+            return value;
+        }
+
+        return property.Values.Values.Select(x => x?.ToString()).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x)) ?? string.Empty;
+    }
+
+    private static PropertyValue? ParsePropertyValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        try
+        {
+            var propertyValue = value.InvariantContains("values") ? value : "{\"values\":" + value + "}";
+            return JsonConvert.DeserializeObject<PropertyValue>(propertyValue);
+        }
+        catch (Newtonsoft.Json.JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static CatalogProductPrice GetPrice(IContent content)
+    {
+        if (!content.HasProperty("price"))
+        {
+            return CatalogProductPrice.Empty;
+        }
+
+        var value = content.GetValue<string>("price");
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return CatalogProductPrice.Empty;
+        }
+
+        try
+        {
+            var prices = JsonConvert.DeserializeObject<CurrencyPriceRoot>(value);
+            return GetDefaultCurrencyPrice(prices);
+        }
+        catch (Newtonsoft.Json.JsonException)
+        {
+            return CatalogProductPrice.Empty;
+        }
+    }
+
+    private static CatalogProductPrice GetDefaultCurrencyPrice(CurrencyPriceRoot? prices)
+    {
+        var store = API.Store.Instance.GetStore() ?? API.Store.Instance.GetAllStores().FirstOrDefault();
+        var currency = store?.Currency;
+        var storePrices = GetStorePrices(prices, store?.Alias);
+
+        var price = GetCurrencyPrice(storePrices, currency?.CurrencyValue, currency?.ISOCurrencySymbol)
+            ?? GetCurrencyPrice(prices?.SelectMany(x => x.Value), currency?.CurrencyValue, currency?.ISOCurrencySymbol)
+            ?? storePrices?.FirstOrDefault(x => x.Price.HasValue)
+            ?? prices?.SelectMany(x => x.Value).FirstOrDefault(x => x.Price.HasValue);
+
+        return new CatalogProductPrice(price?.Price, currency);
+    }
+
+    private static IReadOnlyList<CurrencyPrice>? GetStorePrices(CurrencyPriceRoot? prices, string? storeAlias)
+    {
+        if (prices == null || string.IsNullOrWhiteSpace(storeAlias))
+        {
+            return null;
+        }
+
+        return prices.FirstOrDefault(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)).Value;
+    }
+
+    private static CurrencyPrice? GetCurrencyPrice(IEnumerable<CurrencyPrice>? prices, string? currencyValue, string? isoCurrencySymbol)
+    {
+        if (prices == null)
+        {
+            return null;
+        }
+
+        return prices.FirstOrDefault(x => x.Price.HasValue
+            && (string.Equals(x.Currency, currencyValue, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x.Currency, isoCurrencySymbol, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static string FormatPrice(CatalogProductPrice price)
+    {
+        if (price.Value == null)
+        {
+            return string.Empty;
+        }
+
+        if (price.Currency == null)
+        {
+            return price.Value.Value.ToString("N0", CultureInfo.InvariantCulture);
+        }
+
+        try
+        {
+            return price.Value.Value.ToString(price.Currency.CurrencyFormat, CultureInfo.GetCultureInfo(price.Currency.CurrencyValue));
+        }
+        catch (ArgumentException)
+        {
+            return price.Value.Value.ToString("N0", CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static bool IsAvailable(IContent content)
+    {
+        try
+        {
+            return API.Stock.Instance.GetStock(content.Key) > 0;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private sealed class CatalogCollectionCounts
+    {
+        public int ProductCount { get; set; }
+        public int SubcategoryCount { get; set; }
+    }
+
+    private sealed class CatalogCollectionCountRow
+    {
+        public int ParentId { get; set; }
+        public string ContentTypeAlias { get; set; } = string.Empty;
+        public int Count { get; set; }
+    }
+
+    private sealed class CatalogProductPrice
+    {
+        public static readonly CatalogProductPrice Empty = new(null, null);
+
+        public CatalogProductPrice(decimal? value, CurrencyModel? currency)
+        {
+            Value = value;
+            Currency = currency;
+        }
+
+        public decimal? Value { get; }
+        public CurrencyModel? Currency { get; }
+    }
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/ICatalogCollectionService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/ICatalogCollectionService.cs
@@ -1,0 +1,8 @@
+using Ekom.Umb.CatalogCollection.Models;
+
+namespace Ekom.Umb.CatalogCollection.Services;
+
+public interface ICatalogCollectionService
+{
+    CatalogCollectionResponse GetCollection(string nodeId, CatalogCollectionRequest request);
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
@@ -1,0 +1,438 @@
+var S = Object.defineProperty;
+var P = (s, d, e) => d in s ? S(s, d, { enumerable: !0, configurable: !0, writable: !0, value: e }) : s[d] = e;
+var n = (s, d, e) => P(s, typeof d != "symbol" ? d + "" : d, e);
+import { UMB_COLLECTION_CONTEXT as C } from "@umbraco-cms/backoffice/collection";
+import { UmbElementMixin as E } from "@umbraco-cms/backoffice/element-api";
+import "@umbraco-cms/backoffice/imaging";
+const T = 16, h = "sortOrderAsc", g = "ekomCatalogNode", b = 14, z = 220, I = 4, q = "ekomCatalogParent:", x = "ekomCatalogSort";
+class O extends E(HTMLElement) {
+  constructor() {
+    super(...arguments);
+    n(this, "nodeId", "");
+    n(this, "query", "");
+    n(this, "sort", m());
+    n(this, "page", 1);
+    n(this, "pageSize", T);
+    n(this, "loading", !0);
+    n(this, "error", "");
+    n(this, "data");
+    n(this, "revealTimer");
+    n(this, "resizeTimer");
+    n(this, "selectedProductKeys", /* @__PURE__ */ new Set());
+    n(this, "onPopState", () => this.restoreNodeFromHistory());
+    n(this, "onResize", () => {
+      this.resizeTimer != null && window.clearTimeout(this.resizeTimer), this.resizeTimer = window.setTimeout(() => {
+        this.updatePageSizeForViewport() && this.nodeId && this.data != null && !this.loading && this.load(!1);
+      }, 150);
+    });
+    n(this, "onWindowFocus", () => {
+      document.visibilityState !== "hidden" && this.nodeId && !this.loading && this.load(!1);
+    });
+  }
+  connectedCallback() {
+    super.connectedCallback(), this.style.setProperty("display", "block", "important"), this.style.setProperty("visibility", "visible", "important"), window.addEventListener("popstate", this.onPopState), window.addEventListener("resize", this.onResize), window.addEventListener("focus", this.onWindowFocus), document.addEventListener("visibilitychange", this.onWindowFocus), this.revealCollectionHost(), this.revealTimer = window.setTimeout(() => this.revealCollectionHost(), 250), this.nodeId = this.getNodeIdFromUrl(), this.sort = m(), this.consumeContext(C, (e) => {
+      var r;
+      const t = (r = e == null ? void 0 : e.getConfig()) == null ? void 0 : r.unique;
+      this.getCatalogNodeFromUrl() == null && t != null && t !== this.nodeId && (this.nodeId = t, this.load()), this.observe(e == null ? void 0 : e.filter, (i) => this.setQueryFromCollectionFilter(i), "ekomCatalogCollectionFilter");
+    }), this.render(), this.nodeId && this.load();
+  }
+  disconnectedCallback() {
+    window.removeEventListener("popstate", this.onPopState), window.removeEventListener("resize", this.onResize), window.removeEventListener("focus", this.onWindowFocus), document.removeEventListener("visibilitychange", this.onWindowFocus), this.revealTimer != null && window.clearTimeout(this.revealTimer), this.resizeTimer != null && window.clearTimeout(this.resizeTimer), super.disconnectedCallback();
+  }
+  async load(e = !0) {
+    if (!this.nodeId) {
+      this.loading = !1, this.error = "Unable to determine the current catalog node.", this.render();
+      return;
+    }
+    this.loading = e, this.error = "", this.updatePageSizeForViewport(), e && this.render();
+    try {
+      const t = new URLSearchParams({
+        query: this.query,
+        sort: this.sort,
+        page: String(this.page),
+        pageSize: String(this.pageSize)
+      });
+      this.data = await this.fetchJson(`/ekom/backoffice/CatalogCollection/${encodeURIComponent(this.nodeId)}?${t}`), this.page = this.data.page, this.pageSize = this.data.pageSize, this.storeParentNode(this.data);
+    } catch (t) {
+      if (t instanceof f && t.status === 404 && this.redirectToParent())
+        return;
+      this.error = t instanceof Error ? t.message : "Unable to load catalog.";
+    } finally {
+      this.loading = !1, this.render();
+    }
+  }
+  drillTo(e) {
+    window.location.assign(this.getDocumentHref(e.key || String(e.id)));
+  }
+  restoreNodeFromHistory() {
+    const e = this.getNodeIdFromUrl();
+    !e || e === this.nodeId || (this.nodeId = e, this.query = "", this.page = 1, this.selectedProductKeys.clear(), this.load());
+  }
+  storeParentNode(e) {
+    var r;
+    const t = this.getParentStorageKey(e.current.key || String(e.current.id));
+    (r = e.parent) != null && r.key ? window.sessionStorage.setItem(t, e.parent.key) : window.sessionStorage.removeItem(t);
+  }
+  redirectToParent() {
+    var t, r;
+    const e = ((r = (t = this.data) == null ? void 0 : t.parent) == null ? void 0 : r.key) ?? window.sessionStorage.getItem(this.getParentStorageKey(this.nodeId));
+    return e ? (window.location.replace(this.getDocumentHref(e)), !0) : !1;
+  }
+  getParentStorageKey(e) {
+    return `${q}${e}`;
+  }
+  setQueryFromCollectionFilter(e) {
+    const t = "filter" in (e ?? {}) ? e.filter : void 0, r = typeof t == "string" ? t : "";
+    r !== this.query && (this.query = r, this.page = 1, this.nodeId && this.load());
+  }
+  setSort(e) {
+    if (v(e)) {
+      if (e === this.sort) {
+        y(e);
+        return;
+      }
+      this.sort = e, y(e), this.page = 1, this.load();
+    }
+  }
+  setPage(e) {
+    e < 1 || e === this.page || this.data != null && e > this.data.totalPages || (this.page = e, this.load());
+  }
+  updatePageSizeForViewport() {
+    const e = Math.max(0, this.clientWidth - 48);
+    if (e === 0)
+      return !1;
+    const r = Math.max(1, Math.floor((e + b) / (z + b))) * I;
+    return r === this.pageSize ? !1 : (this.pageSize = r, !0);
+  }
+  toggleProduct(e) {
+    this.selectedProductKeys.has(e.key) ? this.selectedProductKeys.delete(e.key) : this.selectedProductKeys.add(e.key), this.render();
+  }
+  toggleCurrentPage() {
+    var r;
+    const e = ((r = this.data) == null ? void 0 : r.products) ?? [], t = e.length > 0 && e.every((i) => this.selectedProductKeys.has(i.key));
+    for (const i of e)
+      t ? this.selectedProductKeys.delete(i.key) : this.selectedProductKeys.add(i.key);
+    this.render();
+  }
+  clearSelection() {
+    this.selectedProductKeys.clear(), this.render();
+  }
+  revealCollectionHost() {
+    const e = this.closestComposed("umb-collection-default"), t = e == null ? void 0 : e.shadowRoot, r = t == null ? void 0 : t.querySelector("#router"), i = t == null ? void 0 : t.querySelector("umb-body-layout"), a = t == null ? void 0 : t.querySelector("#empty-state");
+    r == null || r.style.setProperty("visibility", "visible", "important"), a == null || a.style.setProperty("display", "none", "important"), i == null || i.classList.add("has-items");
+  }
+  closestComposed(e) {
+    let t = this;
+    for (; t != null; ) {
+      if (t instanceof HTMLElement && t.matches(e))
+        return t;
+      t = t.parentNode ?? (t.getRootNode() instanceof ShadowRoot ? t.getRootNode().host : null);
+    }
+    return null;
+  }
+  render() {
+    this.innerHTML = `
+      <style>${N}</style>
+      <div class="catalog-shell">
+        ${this.renderContent()}
+      </div>
+    `, this.revealCollectionHost(), this.bindEvents();
+  }
+  renderContent() {
+    if (this.loading)
+      return '<div class="surface state">Loading catalog…</div>';
+    if (this.error)
+      return `<div class="surface state error"><strong>Catalog unavailable</strong><span>${l(this.error)}</span><button type="button" data-action="retry">Retry</button></div>`;
+    if (this.data == null)
+      return '<div class="surface state">No catalog data.</div>';
+    const e = this.selectedProductKeys.size;
+    return !this.query && this.data.productCount === 0 && this.data.subcategoryCount === 0 ? `
+        ${this.renderBreadcrumbs(this.data)}
+        ${this.renderHeader(this.data)}
+        ${this.renderEmptyCategory()}
+      ` : `
+      ${this.renderBreadcrumbs(this.data)}
+      ${this.renderHeader(this.data)}
+      ${this.renderToolbar(this.data)}
+      ${e > 0 ? this.renderBulkBar(e) : ""}
+      ${!this.query && this.data.subcategories.length > 0 ? this.renderSubcategories(this.data.subcategories) : ""}
+      ${this.renderProducts(this.data)}
+      ${this.renderPagination(this.data)}
+    `;
+  }
+  renderBreadcrumbs(e) {
+    return `<nav class="breadcrumbs">${e.breadcrumbs.map((t, r) => {
+      const i = r === e.breadcrumbs.length - 1, a = l(t.title || t.name);
+      return `${r > 0 ? '<span class="sep">/</span>' : ""}${i ? `<span>${a}</span>` : `<a href="${this.getDocumentHref(t.key)}">${a}</a>`}`;
+    }).join("")}</nav>`;
+  }
+  renderHeader(e) {
+    return `
+      <header class="catalog-header">
+        <button type="button" class="back" data-action="back" ${e.parent == null ? "disabled" : ""}>←</button>
+        <div>
+          <h1>${l(e.current.title || e.current.name)}</h1>
+          <p>${e.productCount} products · ${e.subcategoryCount} subcategories</p>
+        </div>
+      </header>
+    `;
+  }
+  renderToolbar(e) {
+    const t = e.products.length > 0 && e.products.every((r) => this.selectedProductKeys.has(r.key));
+    return `
+      <div class="toolbar">
+        <select data-field="sort">
+          ${this.renderSortOption("sortOrderAsc", "Sort order asc")}
+          ${this.renderSortOption("sortOrderDesc", "Sort order desc")}
+          ${this.renderSortOption("nameAsc", "Name asc")}
+          ${this.renderSortOption("nameDesc", "Name desc")}
+          ${this.renderSortOption("priceAsc", "Price asc")}
+          ${this.renderSortOption("priceDesc", "Price desc")}
+          ${this.renderSortOption("skuAsc", "SKU asc")}
+          ${this.renderSortOption("skuDesc", "SKU desc")}
+          ${this.renderSortOption("createdAsc", "Created asc")}
+          ${this.renderSortOption("createdDesc", "Created desc")}
+          ${this.renderSortOption("updatedAsc", "Updated asc")}
+          ${this.renderSortOption("updatedDesc", "Updated desc")}
+        </select>
+        <button type="button" class="select-all" data-action="toggle-page"><span class="fake-checkbox ${t ? "checked" : ""}"></span>Select all</button>
+      </div>
+    `;
+  }
+  renderSortOption(e, t) {
+    return `<option value="${e}" ${this.sort === e ? "selected" : ""}>${t}</option>`;
+  }
+  renderBulkBar(e) {
+    return `
+      <div class="bulk-bar">
+        <strong>${e} selected</strong>
+        <div>
+          <button type="button" disabled>Publish</button>
+          <button type="button" disabled>Unpublish</button>
+          <button type="button" disabled>Move</button>
+          <button type="button" class="clear" data-action="clear-selection">Clear ✕</button>
+        </div>
+      </div>
+    `;
+  }
+  renderSubcategories(e) {
+    return `
+      <section class="section">
+        <h2>Subcategories</h2>
+        <div class="chips">${e.map((t) => `
+          <a class="chip" href="${this.getDocumentHref(t.key)}">
+            <span class="tile">▦</span><span class="chip-text"><strong>${l(t.title || t.name)}</strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
+          </a>
+        `).join("")}</div>
+      </section>
+    `;
+  }
+  renderEmptyCategory() {
+    return `
+      <section class="section">
+        <div class="empty empty-category">
+          <strong>No catalog items in this category yet</strong>
+          <span>This category does not contain any direct products or subcategories.</span>
+        </div>
+      </section>
+    `;
+  }
+  renderProducts(e) {
+    const t = this.query ? `No products match &quot;${l(this.query)}&quot;` : "No products in this category yet";
+    return `
+      <section class="section">
+        <h2>Products (${e.filteredProductCount})</h2>
+        ${e.products.length === 0 ? `<div class="empty">${t}</div>` : `<div class="grid">${e.products.map((r) => this.renderProduct(r)).join("")}</div>`}
+      </section>
+    `;
+  }
+  renderProduct(e) {
+    const t = this.selectedProductKeys.has(e.key), r = `/umbraco/section/content/workspace/document/edit/${e.key}`;
+    return `
+      <article class="card ${t ? "selected" : ""}">
+        <button type="button" class="checkbox ${t ? "checked" : ""}" data-product-key="${e.key}">${t ? "✓" : ""}</button>
+        <a class="image ${e.published ? "" : "dimmed"}" href="${r}">${e.image ? `<umb-imaging-thumbnail unique="${l(e.image)}" width="320" height="160" alt="${l(e.title || e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
+        <div class="card-body">
+          <a class="title" href="${r}">${l(e.title || e.name)}</a>
+          <div class="meta"><span>${e.sku ? `SKU ${l(e.sku)}` : "No SKU"}</span><strong>${l(e.price)}</strong></div>
+          <div class="status-row"><span class="pill ${A(e.status)}"><i></i>${e.status}</span><strong class="availability ${e.available ? "ok" : "bad"}">${e.available ? "✓ Available" : "✕ Unavailable"}</strong></div>
+        </div>
+      </article>
+    `;
+  }
+  renderPagination(e) {
+    if (e.filteredProductCount === 0)
+      return "";
+    const t = (e.page - 1) * e.pageSize + 1, r = Math.min(e.page * e.pageSize, e.filteredProductCount);
+    return `
+      <footer class="pagination">
+        <div>
+          <button type="button" data-page="${e.page - 1}" ${e.page <= 1 ? "disabled" : ""}>‹ Prev</button>
+          ${this.paginationItems(e.page, e.totalPages).map((i) => i === "…" ? "<span>…</span>" : `<button type="button" class="${i === e.page ? "current" : ""}" data-page="${i}">${i}</button>`).join("")}
+          <button type="button" data-page="${e.page + 1}" ${e.page >= e.totalPages ? "disabled" : ""}>Next ›</button>
+        </div>
+        <span>${t}–${r} of ${e.filteredProductCount}</span>
+      </footer>
+    `;
+  }
+  paginationItems(e, t) {
+    if (t <= 7)
+      return Array.from({ length: t }, (c, o) => o + 1);
+    const i = [.../* @__PURE__ */ new Set([1, t, e - 1, e, e + 1])].filter((c) => c >= 1 && c <= t).sort((c, o) => c - o), a = [];
+    for (const c of i) {
+      const o = a[a.length - 1];
+      typeof o == "number" && c - o > 1 && a.push("…"), a.push(c);
+    }
+    return a;
+  }
+  bindEvents() {
+    var e, t, r, i, a, c;
+    (e = this.querySelector('[data-action="retry"]')) == null || e.addEventListener("click", () => void this.load()), (t = this.querySelector('[data-action="back"]')) == null || t.addEventListener("click", () => {
+      var o;
+      ((o = this.data) == null ? void 0 : o.parent) != null && this.drillTo(this.data.parent);
+    }), (r = this.querySelector('[data-action="toggle-page"]')) == null || r.addEventListener("click", () => this.toggleCurrentPage()), (i = this.querySelector('[data-action="clear-selection"]')) == null || i.addEventListener("click", () => this.clearSelection()), (a = this.querySelector('[data-field="sort"]')) == null || a.addEventListener("input", (o) => this.setSort(o.target.value)), (c = this.querySelector('[data-field="sort"]')) == null || c.addEventListener("change", (o) => this.setSort(o.target.value)), this.querySelectorAll("[data-product-key]").forEach((o) => {
+      o.addEventListener("click", (k) => {
+        var u;
+        k.preventDefault();
+        const w = o.dataset.productKey, p = (u = this.data) == null ? void 0 : u.products.find(($) => $.key === w);
+        p != null && this.toggleProduct(p);
+      });
+    }), this.querySelectorAll("[data-page]").forEach((o) => {
+      o.addEventListener("click", () => this.setPage(Number(o.dataset.page)));
+    });
+  }
+  getNodeIdFromUrl() {
+    const e = this.getCatalogNodeFromUrl();
+    if (e != null)
+      return e;
+    const t = window.location.href, r = t.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    if (r != null)
+      return r[0];
+    const i = t.match(/\/edit\/([^/?#]+)/i);
+    return (i == null ? void 0 : i[1]) ?? "";
+  }
+  getDocumentHref(e) {
+    const t = new URL(window.location.href);
+    return t.searchParams.delete(g), t.pathname.match(/\/edit\/[^/]+/i) != null ? (t.pathname = t.pathname.replace(/\/edit\/[^/]+/i, `/edit/${e}`), `${t.pathname}${t.search}${t.hash}`) : `/umbraco/section/content/workspace/document/edit/${e}`;
+  }
+  getCatalogNodeFromUrl() {
+    const e = new URL(window.location.href).searchParams.get(g);
+    return e && e.trim().length > 0 ? e : null;
+  }
+  async fetchJson(e) {
+    const t = await fetch(e, { credentials: "same-origin", headers: { Accept: "application/json" } });
+    if (!t.ok)
+      throw new f(await t.text() || `Request failed (${t.status}).`, t.status);
+    return await t.json();
+  }
+}
+class f extends Error {
+  constructor(d, e) {
+    super(d), this.status = e;
+  }
+}
+function l(s) {
+  return s.replace(/[&<>"]/g, (d) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[d] ?? d);
+}
+function A(s) {
+  return s === "Published" ? "published" : s === "Pending changes" ? "pending" : "unpublished";
+}
+function v(s) {
+  return [
+    "sortOrderAsc",
+    "sortOrderDesc",
+    "nameAsc",
+    "nameDesc",
+    "priceAsc",
+    "priceDesc",
+    "skuAsc",
+    "skuDesc",
+    "createdAsc",
+    "createdDesc",
+    "updatedAsc",
+    "updatedDesc"
+  ].includes(s);
+}
+function m() {
+  try {
+    const s = window.localStorage.getItem(x);
+    return s != null && v(s) ? s : h;
+  } catch {
+    return h;
+  }
+}
+function y(s) {
+  try {
+    window.localStorage.setItem(x, s);
+  } catch {
+  }
+}
+const N = `
+  ekom-catalog-collection-view { color: #1f1f1f; display: block !important; font-family: Lato, sans-serif; visibility: visible !important; }
+  .catalog-shell { background: #f6f4f4; min-height: 100%; padding: 24px; }
+  .surface, .empty { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; }
+  .state { padding: 24px; display: grid; gap: 10px; }
+  .error { color: #d42054; }
+  button, input, select { font: inherit; }
+  button { cursor: pointer; }
+  button:disabled { cursor: default; opacity: .45; }
+  .breadcrumbs { align-items: center; color: #777; display: flex; flex-wrap: wrap; font-size: 13px; gap: 8px; margin-bottom: 18px; }
+  .breadcrumbs a { color: #2152a3; text-decoration: none; }
+  .breadcrumbs a:hover { text-decoration: underline; }
+  .sep { color: #a5a5a5; }
+  .catalog-header { align-items: center; display: flex; gap: 14px; margin-bottom: 18px; }
+  .back { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; height: 36px; width: 36px; }
+  h1 { font-size: 24px; line-height: 1.2; margin: 0; }
+  p { color: #777; margin: 4px 0 0; }
+  .toolbar { display: flex; gap: 10px; justify-content: flex-end; margin-bottom: 14px; }
+  select, .select-all { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; height: 36px; padding: 0 10px; }
+  select { appearance: none; background-image: linear-gradient(45deg, transparent 50%, #777 50%), linear-gradient(135deg, #777 50%, transparent 50%); background-position: calc(100% - 16px) 15px, calc(100% - 11px) 15px; background-repeat: no-repeat; background-size: 5px 5px, 5px 5px; padding-right: 34px; }
+  .select-all { align-items: center; display: flex; gap: 8px; }
+  .fake-checkbox { border: 1px solid #b8b8b8; border-radius: 2px; height: 14px; width: 14px; }
+  .fake-checkbox.checked { background: #2152a3; border-color: #2152a3; }
+  .bulk-bar { align-items: center; background: #1b264f; border-radius: 3px; color: #fff; display: flex; justify-content: space-between; margin-bottom: 18px; padding: 12px 14px; }
+  .bulk-bar button { background: transparent; border: 1px solid rgba(255,255,255,.75); border-radius: 3px; color: #fff; margin-left: 8px; padding: 6px 10px; }
+  .bulk-bar .clear { border: 0; }
+  .section { margin-top: 22px; }
+  h2 { color: #777; font-size: 11px; letter-spacing: .08em; margin: 0 0 10px; text-transform: uppercase; }
+  .chips { display: flex; flex-wrap: wrap; gap: 10px; }
+  .chip { align-items: center; background: #fff; border: 1px solid #d8d7d9; border-radius: 999px; color: inherit; display: flex; gap: 10px; padding: 6px 11px 6px 6px; text-align: left; text-decoration: none; }
+  .chip-text { display: grid; gap: 1px; }
+  .chip-text small { color: #777; font-size: 11px; }
+  .tile { align-items: center; background: #f6f4f4; border-radius: 50%; color: #1b264f; display: inline-flex; height: 30px; justify-content: center; width: 30px; }
+  .grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
+  .card { background: #fff; border: 1px solid #e9e9eb; border-radius: 4px; overflow: hidden; position: relative; transition: box-shadow .15s, border-color .15s; }
+  .card:hover { box-shadow: 0 6px 16px rgba(0,0,0,.08); }
+  .card.selected { border-color: #2152a3; box-shadow: 0 0 0 1px #2152a3; }
+  .checkbox { background: rgba(255,255,255,.76); border: 1px solid #d8d7d9; border-radius: 3px; color: #fff; height: 20px; left: 10px; line-height: 18px; opacity: .6; padding: 0; position: absolute; top: 10px; width: 20px; z-index: 1; }
+  .card:hover .checkbox, .checkbox.checked { opacity: 1; }
+  .checkbox.checked { background: #2152a3; border-color: #2152a3; }
+  .image { align-items: center; background: linear-gradient(135deg, #f4f4f6, #e9e9eb); color: #888; display: flex; height: 160px; justify-content: center; text-decoration: none; }
+  .image.dimmed { opacity: .45; }
+  .image umb-imaging-thumbnail { height: 100%; width: 100%; }
+  .card-body { display: grid; gap: 10px; padding: 12px; }
+  .title { color: #1f1f1f; display: -webkit-box; font-size: 14px; font-weight: 700; line-clamp: 2; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-decoration: none; }
+  .title:hover { text-decoration: underline; }
+  .meta, .status-row { align-items: center; display: flex; justify-content: space-between; gap: 10px; }
+  .meta span { color: #777; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .meta strong { font-size: 14px; white-space: nowrap; }
+  .pill { align-items: center; background: #f4f4f6; border-radius: 999px; color: #555; display: inline-flex; font-size: 12px; gap: 6px; padding: 4px 8px; }
+  .pill i { border-radius: 50%; display: inline-block; height: 7px; width: 7px; }
+  .published i { background: #2bc37c; }
+  .pending i { background: #fbd142; }
+  .unpublished i { background: #c4c4c4; }
+  .availability { font-size: 12px; white-space: nowrap; }
+  .availability.ok { color: #1c7d3c; }
+  .availability.bad { color: #d42054; }
+  .empty { border-style: dashed; color: #777; padding: 30px; text-align: center; }
+  .empty-category { display: grid; gap: 6px; }
+  .empty-category strong { color: #1f1f1f; font-size: 15px; }
+  .pagination { align-items: center; display: flex; gap: 18px; justify-content: center; margin-top: 24px; }
+  .pagination div { display: flex; gap: 6px; }
+  .pagination button { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; min-width: 34px; padding: 7px 10px; }
+  .pagination .current { background: #1b264f; border-color: #1b264f; color: #fff; }
+`;
+customElements.define("ekom-catalog-collection-view", O);
+export {
+  O as default
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
@@ -92,6 +92,24 @@ const e = [
     ]
   },
   {
+    type: "collectionView",
+    alias: "Ekom.CollectionView.Catalog",
+    name: "Ekom Catalog Collection View",
+    element: "/App_Plugins/Ekom/dist/catalog-collection-view.element.js",
+    weight: 400,
+    meta: {
+      label: "Catalog",
+      icon: "icon-grid",
+      pathName: "catalog"
+    },
+    conditions: [
+      {
+        alias: "Umb.Condition.CollectionAlias",
+        match: "Umb.Collection.Document"
+      }
+    ]
+  },
+  {
     type: "propertyEditorSchema",
     alias: "Ekom.Cache",
     name: "Ekom Cache Editor",

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
@@ -1,0 +1,704 @@
+import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import '@umbraco-cms/backoffice/imaging';
+
+type CatalogNode = {
+  id: number;
+  key: string;
+  name: string;
+  title: string;
+  contentTypeAlias: string;
+  productCount: number;
+  subcategoryCount: number;
+};
+
+type CatalogProduct = CatalogNode & {
+  sku: string;
+  price: string;
+  status: 'Published' | 'Pending changes' | 'Unpublished';
+  published: boolean;
+  pendingChanges: boolean;
+  available: boolean;
+  image: string;
+};
+
+type CatalogResponse = {
+  current: CatalogNode;
+  parent?: CatalogNode;
+  breadcrumbs: CatalogNode[];
+  subcategories: CatalogNode[];
+  products: CatalogProduct[];
+  productCount: number;
+  subcategoryCount: number;
+  filteredProductCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+
+const DEFAULT_PAGE_SIZE = 16;
+const DEFAULT_SORT = 'sortOrderAsc';
+const CATALOG_NODE_QUERY = 'ekomCatalogNode';
+const GRID_GAP = 14;
+const GRID_MIN_CARD_WIDTH = 220;
+const MAX_PRODUCT_ROWS = 4;
+const PARENT_STORAGE_PREFIX = 'ekomCatalogParent:';
+const SORT_STORAGE_KEY = 'ekomCatalogSort';
+
+class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
+  private nodeId = '';
+  private query = '';
+  private sort = getStoredSort();
+  private page = 1;
+  private pageSize = DEFAULT_PAGE_SIZE;
+  private loading = true;
+  private error = '';
+  private data?: CatalogResponse;
+  private revealTimer?: number;
+  private resizeTimer?: number;
+  private readonly selectedProductKeys = new Set<string>();
+  private readonly onPopState = (): void => this.restoreNodeFromHistory();
+  private readonly onResize = (): void => {
+    if (this.resizeTimer != null) {
+      window.clearTimeout(this.resizeTimer);
+    }
+
+    this.resizeTimer = window.setTimeout(() => {
+      if (this.updatePageSizeForViewport() && this.nodeId && this.data != null && !this.loading) {
+        void this.load(false);
+      }
+    }, 150);
+  };
+  private readonly onWindowFocus = (): void => {
+    if (document.visibilityState !== 'hidden' && this.nodeId && !this.loading) {
+      void this.load(false);
+    }
+  };
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.style.setProperty('display', 'block', 'important');
+    this.style.setProperty('visibility', 'visible', 'important');
+    window.addEventListener('popstate', this.onPopState);
+    window.addEventListener('resize', this.onResize);
+    window.addEventListener('focus', this.onWindowFocus);
+    document.addEventListener('visibilitychange', this.onWindowFocus);
+    this.revealCollectionHost();
+    this.revealTimer = window.setTimeout(() => this.revealCollectionHost(), 250);
+
+    this.nodeId = this.getNodeIdFromUrl();
+    this.sort = getStoredSort();
+
+    this.consumeContext(UMB_COLLECTION_CONTEXT, context => {
+      const unique = context?.getConfig()?.unique;
+      if (this.getCatalogNodeFromUrl() == null && unique != null && unique !== this.nodeId) {
+        this.nodeId = unique;
+        void this.load();
+      }
+
+      this.observe(context?.filter, filter => this.setQueryFromCollectionFilter(filter), 'ekomCatalogCollectionFilter');
+    });
+
+    this.render();
+
+    if (this.nodeId) {
+      void this.load();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    window.removeEventListener('popstate', this.onPopState);
+    window.removeEventListener('resize', this.onResize);
+    window.removeEventListener('focus', this.onWindowFocus);
+    document.removeEventListener('visibilitychange', this.onWindowFocus);
+    if (this.revealTimer != null) {
+      window.clearTimeout(this.revealTimer);
+    }
+    if (this.resizeTimer != null) {
+      window.clearTimeout(this.resizeTimer);
+    }
+
+    super.disconnectedCallback();
+  }
+
+  private async load(showLoading = true): Promise<void> {
+    if (!this.nodeId) {
+      this.loading = false;
+      this.error = 'Unable to determine the current catalog node.';
+      this.render();
+      return;
+    }
+
+    this.loading = showLoading;
+    this.error = '';
+    this.updatePageSizeForViewport();
+    if (showLoading) {
+      this.render();
+    }
+
+    try {
+      const params = new URLSearchParams({
+        query: this.query,
+        sort: this.sort,
+        page: String(this.page),
+        pageSize: String(this.pageSize),
+      });
+      this.data = await this.fetchJson<CatalogResponse>(`/ekom/backoffice/CatalogCollection/${encodeURIComponent(this.nodeId)}?${params}`);
+      this.page = this.data.page;
+      this.pageSize = this.data.pageSize;
+      this.storeParentNode(this.data);
+    } catch (error) {
+      if (error instanceof CatalogRequestError && error.status === 404 && this.redirectToParent()) {
+        return;
+      }
+
+      this.error = error instanceof Error ? error.message : 'Unable to load catalog.';
+    } finally {
+      this.loading = false;
+      this.render();
+    }
+  }
+
+  private drillTo(node: CatalogNode): void {
+    window.location.assign(this.getDocumentHref(node.key || String(node.id)));
+  }
+
+  private restoreNodeFromHistory(): void {
+    const nodeId = this.getNodeIdFromUrl();
+    if (!nodeId || nodeId === this.nodeId) {
+      return;
+    }
+
+    this.nodeId = nodeId;
+    this.query = '';
+    this.page = 1;
+    this.selectedProductKeys.clear();
+    void this.load();
+  }
+
+  private storeParentNode(data: CatalogResponse): void {
+    const key = this.getParentStorageKey(data.current.key || String(data.current.id));
+    if (data.parent?.key) {
+      window.sessionStorage.setItem(key, data.parent.key);
+    } else {
+      window.sessionStorage.removeItem(key);
+    }
+  }
+
+  private redirectToParent(): boolean {
+    const parentId = this.data?.parent?.key ?? window.sessionStorage.getItem(this.getParentStorageKey(this.nodeId));
+    if (!parentId) {
+      return false;
+    }
+
+    window.location.replace(this.getDocumentHref(parentId));
+    return true;
+  }
+
+  private getParentStorageKey(nodeId: string): string {
+    return `${PARENT_STORAGE_PREFIX}${nodeId}`;
+  }
+
+  private setQueryFromCollectionFilter(value: object | undefined): void {
+    const filter = 'filter' in (value ?? {}) ? (value as { filter?: unknown }).filter : undefined;
+    const query = typeof filter === 'string' ? filter : '';
+    if (query === this.query) {
+      return;
+    }
+
+    this.query = query;
+    this.page = 1;
+    if (this.nodeId) {
+      void this.load();
+    }
+  }
+
+  private setSort(value: string): void {
+    if (!isSortOption(value)) {
+      return;
+    }
+
+    if (value === this.sort) {
+      setStoredSort(value);
+      return;
+    }
+
+    this.sort = value;
+    setStoredSort(value);
+    this.page = 1;
+    void this.load();
+  }
+
+  private setPage(page: number): void {
+    if (page < 1 || page === this.page || (this.data != null && page > this.data.totalPages)) {
+      return;
+    }
+
+    this.page = page;
+    void this.load();
+  }
+
+  private updatePageSizeForViewport(): boolean {
+    const width = Math.max(0, this.clientWidth - 48);
+    if (width === 0) {
+      return false;
+    }
+
+    const columns = Math.max(1, Math.floor((width + GRID_GAP) / (GRID_MIN_CARD_WIDTH + GRID_GAP)));
+    const pageSize = columns * MAX_PRODUCT_ROWS;
+    if (pageSize === this.pageSize) {
+      return false;
+    }
+
+    this.pageSize = pageSize;
+    return true;
+  }
+
+  private toggleProduct(product: CatalogProduct): void {
+    if (this.selectedProductKeys.has(product.key)) {
+      this.selectedProductKeys.delete(product.key);
+    } else {
+      this.selectedProductKeys.add(product.key);
+    }
+
+    this.render();
+  }
+
+  private toggleCurrentPage(): void {
+    const products = this.data?.products ?? [];
+    const allSelected = products.length > 0 && products.every(product => this.selectedProductKeys.has(product.key));
+
+    for (const product of products) {
+      if (allSelected) {
+        this.selectedProductKeys.delete(product.key);
+      } else {
+        this.selectedProductKeys.add(product.key);
+      }
+    }
+
+    this.render();
+  }
+
+  private clearSelection(): void {
+    this.selectedProductKeys.clear();
+    this.render();
+  }
+
+  private revealCollectionHost(): void {
+    const collection = this.closestComposed('umb-collection-default');
+    const collectionRoot = collection?.shadowRoot;
+    const router = collectionRoot?.querySelector<HTMLElement>('#router');
+    const bodyLayout = collectionRoot?.querySelector<HTMLElement>('umb-body-layout');
+    const emptyState = collectionRoot?.querySelector<HTMLElement>('#empty-state');
+
+    router?.style.setProperty('visibility', 'visible', 'important');
+    emptyState?.style.setProperty('display', 'none', 'important');
+    bodyLayout?.classList.add('has-items');
+  }
+
+  private closestComposed(selector: string): HTMLElement | null {
+    let node: Node | null = this;
+
+    while (node != null) {
+      if (node instanceof HTMLElement && node.matches(selector)) {
+        return node;
+      }
+
+      node = node.parentNode ?? (node.getRootNode() instanceof ShadowRoot ? (node.getRootNode() as ShadowRoot).host : null);
+    }
+
+    return null;
+  }
+
+  private render(): void {
+    this.innerHTML = `
+      <style>${styles}</style>
+      <div class="catalog-shell">
+        ${this.renderContent()}
+      </div>
+    `;
+    this.revealCollectionHost();
+    this.bindEvents();
+  }
+
+  private renderContent(): string {
+    if (this.loading) {
+      return '<div class="surface state">Loading catalog…</div>';
+    }
+
+    if (this.error) {
+      return `<div class="surface state error"><strong>Catalog unavailable</strong><span>${escapeHtml(this.error)}</span><button type="button" data-action="retry">Retry</button></div>`;
+    }
+
+    if (this.data == null) {
+      return '<div class="surface state">No catalog data.</div>';
+    }
+
+    const selectedCount = this.selectedProductKeys.size;
+    const isEmptyCategory = !this.query && this.data.productCount === 0 && this.data.subcategoryCount === 0;
+
+    if (isEmptyCategory) {
+      return `
+        ${this.renderBreadcrumbs(this.data)}
+        ${this.renderHeader(this.data)}
+        ${this.renderEmptyCategory()}
+      `;
+    }
+
+    return `
+      ${this.renderBreadcrumbs(this.data)}
+      ${this.renderHeader(this.data)}
+      ${this.renderToolbar(this.data)}
+      ${selectedCount > 0 ? this.renderBulkBar(selectedCount) : ''}
+      ${!this.query && this.data.subcategories.length > 0 ? this.renderSubcategories(this.data.subcategories) : ''}
+      ${this.renderProducts(this.data)}
+      ${this.renderPagination(this.data)}
+    `;
+  }
+
+  private renderBreadcrumbs(data: CatalogResponse): string {
+    return `<nav class="breadcrumbs">${data.breadcrumbs.map((item, index) => {
+      const isCurrent = index === data.breadcrumbs.length - 1;
+      const label = escapeHtml(item.title || item.name);
+      return `${index > 0 ? '<span class="sep">/</span>' : ''}${isCurrent ? `<span>${label}</span>` : `<a href="${this.getDocumentHref(item.key)}">${label}</a>`}`;
+    }).join('')}</nav>`;
+  }
+
+  private renderHeader(data: CatalogResponse): string {
+    return `
+      <header class="catalog-header">
+        <button type="button" class="back" data-action="back" ${data.parent == null ? 'disabled' : ''}>←</button>
+        <div>
+          <h1>${escapeHtml(data.current.title || data.current.name)}</h1>
+          <p>${data.productCount} products · ${data.subcategoryCount} subcategories</p>
+        </div>
+      </header>
+    `;
+  }
+
+  private renderToolbar(data: CatalogResponse): string {
+    const currentPageSelected = data.products.length > 0 && data.products.every(product => this.selectedProductKeys.has(product.key));
+
+    return `
+      <div class="toolbar">
+        <select data-field="sort">
+          ${this.renderSortOption('sortOrderAsc', 'Sort order asc')}
+          ${this.renderSortOption('sortOrderDesc', 'Sort order desc')}
+          ${this.renderSortOption('nameAsc', 'Name asc')}
+          ${this.renderSortOption('nameDesc', 'Name desc')}
+          ${this.renderSortOption('priceAsc', 'Price asc')}
+          ${this.renderSortOption('priceDesc', 'Price desc')}
+          ${this.renderSortOption('skuAsc', 'SKU asc')}
+          ${this.renderSortOption('skuDesc', 'SKU desc')}
+          ${this.renderSortOption('createdAsc', 'Created asc')}
+          ${this.renderSortOption('createdDesc', 'Created desc')}
+          ${this.renderSortOption('updatedAsc', 'Updated asc')}
+          ${this.renderSortOption('updatedDesc', 'Updated desc')}
+        </select>
+        <button type="button" class="select-all" data-action="toggle-page"><span class="fake-checkbox ${currentPageSelected ? 'checked' : ''}"></span>Select all</button>
+      </div>
+    `;
+  }
+
+  private renderSortOption(value: string, label: string): string {
+    return `<option value="${value}" ${this.sort === value ? 'selected' : ''}>${label}</option>`;
+  }
+
+  private renderBulkBar(selectedCount: number): string {
+    return `
+      <div class="bulk-bar">
+        <strong>${selectedCount} selected</strong>
+        <div>
+          <button type="button" disabled>Publish</button>
+          <button type="button" disabled>Unpublish</button>
+          <button type="button" disabled>Move</button>
+          <button type="button" class="clear" data-action="clear-selection">Clear ✕</button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSubcategories(subcategories: CatalogNode[]): string {
+    return `
+      <section class="section">
+        <h2>Subcategories</h2>
+        <div class="chips">${subcategories.map(category => `
+          <a class="chip" href="${this.getDocumentHref(category.key)}">
+            <span class="tile">▦</span><span class="chip-text"><strong>${escapeHtml(category.title || category.name)}</strong><small>${category.productCount} products · ${category.subcategoryCount} subcategories</small></span><span>›</span>
+          </a>
+        `).join('')}</div>
+      </section>
+    `;
+  }
+
+  private renderEmptyCategory(): string {
+    return `
+      <section class="section">
+        <div class="empty empty-category">
+          <strong>No catalog items in this category yet</strong>
+          <span>This category does not contain any direct products or subcategories.</span>
+        </div>
+      </section>
+    `;
+  }
+
+  private renderProducts(data: CatalogResponse): string {
+    const empty = this.query ? `No products match &quot;${escapeHtml(this.query)}&quot;` : 'No products in this category yet';
+
+    return `
+      <section class="section">
+        <h2>Products (${data.filteredProductCount})</h2>
+        ${data.products.length === 0 ? `<div class="empty">${empty}</div>` : `<div class="grid">${data.products.map(product => this.renderProduct(product)).join('')}</div>`}
+      </section>
+    `;
+  }
+
+  private renderProduct(product: CatalogProduct): string {
+    const selected = this.selectedProductKeys.has(product.key);
+    const href = `/umbraco/section/content/workspace/document/edit/${product.key}`;
+
+    return `
+      <article class="card ${selected ? 'selected' : ''}">
+        <button type="button" class="checkbox ${selected ? 'checked' : ''}" data-product-key="${product.key}">${selected ? '✓' : ''}</button>
+        <a class="image ${!product.published ? 'dimmed' : ''}" href="${href}">${product.image ? `<umb-imaging-thumbnail unique="${escapeHtml(product.image)}" width="320" height="160" alt="${escapeHtml(product.title || product.name)}"></umb-imaging-thumbnail>` : '<span>Product image</span>'}</a>
+        <div class="card-body">
+          <a class="title" href="${href}">${escapeHtml(product.title || product.name)}</a>
+          <div class="meta"><span>${product.sku ? `SKU ${escapeHtml(product.sku)}` : 'No SKU'}</span><strong>${escapeHtml(product.price)}</strong></div>
+          <div class="status-row"><span class="pill ${statusClass(product.status)}"><i></i>${product.status}</span><strong class="availability ${product.available ? 'ok' : 'bad'}">${product.available ? '✓ Available' : '✕ Unavailable'}</strong></div>
+        </div>
+      </article>
+    `;
+  }
+
+  private renderPagination(data: CatalogResponse): string {
+    if (data.filteredProductCount === 0) {
+      return '';
+    }
+
+    const from = (data.page - 1) * data.pageSize + 1;
+    const to = Math.min(data.page * data.pageSize, data.filteredProductCount);
+
+    return `
+      <footer class="pagination">
+        <div>
+          <button type="button" data-page="${data.page - 1}" ${data.page <= 1 ? 'disabled' : ''}>‹ Prev</button>
+          ${this.paginationItems(data.page, data.totalPages).map(item => item === '…' ? '<span>…</span>' : `<button type="button" class="${item === data.page ? 'current' : ''}" data-page="${item}">${item}</button>`).join('')}
+          <button type="button" data-page="${data.page + 1}" ${data.page >= data.totalPages ? 'disabled' : ''}>Next ›</button>
+        </div>
+        <span>${from}–${to} of ${data.filteredProductCount}</span>
+      </footer>
+    `;
+  }
+
+  private paginationItems(page: number, total: number): Array<number | '…'> {
+    if (total <= 7) {
+      return Array.from({ length: total }, (_, index) => index + 1);
+    }
+
+    const items = new Set([1, total, page - 1, page, page + 1]);
+    const sorted = [...items].filter(item => item >= 1 && item <= total).sort((a, b) => a - b);
+    const result: Array<number | '…'> = [];
+
+    for (const item of sorted) {
+      const previous = result[result.length - 1];
+      if (typeof previous === 'number' && item - previous > 1) {
+        result.push('…');
+      }
+
+      result.push(item);
+    }
+
+    return result;
+  }
+
+  private bindEvents(): void {
+    this.querySelector('[data-action="retry"]')?.addEventListener('click', () => void this.load());
+    this.querySelector('[data-action="back"]')?.addEventListener('click', () => {
+      if (this.data?.parent != null) {
+        this.drillTo(this.data.parent);
+      }
+    });
+    this.querySelector('[data-action="toggle-page"]')?.addEventListener('click', () => this.toggleCurrentPage());
+    this.querySelector('[data-action="clear-selection"]')?.addEventListener('click', () => this.clearSelection());
+    this.querySelector('[data-field="sort"]')?.addEventListener('input', event => this.setSort((event.target as HTMLSelectElement).value));
+    this.querySelector('[data-field="sort"]')?.addEventListener('change', event => this.setSort((event.target as HTMLSelectElement).value));
+    this.querySelectorAll<HTMLElement>('[data-product-key]').forEach(element => {
+      element.addEventListener('click', event => {
+        event.preventDefault();
+        const key = element.dataset.productKey;
+        const product = this.data?.products.find(item => item.key === key);
+        if (product != null) {
+          this.toggleProduct(product);
+        }
+      });
+    });
+    this.querySelectorAll<HTMLElement>('[data-page]').forEach(element => {
+      element.addEventListener('click', () => this.setPage(Number(element.dataset.page)));
+    });
+  }
+
+  private getNodeIdFromUrl(): string {
+    const catalogNode = this.getCatalogNodeFromUrl();
+    if (catalogNode != null) {
+      return catalogNode;
+    }
+
+    const href = window.location.href;
+    const guidMatch = href.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+
+    if (guidMatch != null) {
+      return guidMatch[0];
+    }
+
+    const editSegmentMatch = href.match(/\/edit\/([^/?#]+)/i);
+    return editSegmentMatch?.[1] ?? '';
+  }
+
+  private getDocumentHref(nodeId: string): string {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(CATALOG_NODE_QUERY);
+
+    if (url.pathname.match(/\/edit\/[^/]+/i) != null) {
+      url.pathname = url.pathname.replace(/\/edit\/[^/]+/i, `/edit/${nodeId}`);
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+
+    return `/umbraco/section/content/workspace/document/edit/${nodeId}`;
+  }
+
+  private getCatalogNodeFromUrl(): string | null {
+    const value = new URL(window.location.href).searchParams.get(CATALOG_NODE_QUERY);
+    return value && value.trim().length > 0 ? value : null;
+  }
+
+  private async fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url, { credentials: 'same-origin', headers: { Accept: 'application/json' } });
+    if (!response.ok) {
+      throw new CatalogRequestError(await response.text() || `Request failed (${response.status}).`, response.status);
+    }
+
+    return await response.json() as T;
+  }
+}
+
+class CatalogRequestError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"]/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[char] ?? char);
+}
+
+function statusClass(status: CatalogProduct['status']): string {
+  if (status === 'Published') {
+    return 'published';
+  }
+
+  return status === 'Pending changes' ? 'pending' : 'unpublished';
+}
+
+function isSortOption(value: string): boolean {
+  return [
+    'sortOrderAsc',
+    'sortOrderDesc',
+    'nameAsc',
+    'nameDesc',
+    'priceAsc',
+    'priceDesc',
+    'skuAsc',
+    'skuDesc',
+    'createdAsc',
+    'createdDesc',
+    'updatedAsc',
+    'updatedDesc',
+  ].includes(value);
+}
+
+function getStoredSort(): string {
+  try {
+    const value = window.localStorage.getItem(SORT_STORAGE_KEY);
+    return value != null && isSortOption(value) ? value : DEFAULT_SORT;
+  } catch {
+    return DEFAULT_SORT;
+  }
+}
+
+function setStoredSort(value: string): void {
+  try {
+    window.localStorage.setItem(SORT_STORAGE_KEY, value);
+  } catch {
+    // Ignore storage failures and keep the in-memory value for this view.
+  }
+}
+
+const styles = `
+  ekom-catalog-collection-view { color: #1f1f1f; display: block !important; font-family: Lato, sans-serif; visibility: visible !important; }
+  .catalog-shell { background: #f6f4f4; min-height: 100%; padding: 24px; }
+  .surface, .empty { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; }
+  .state { padding: 24px; display: grid; gap: 10px; }
+  .error { color: #d42054; }
+  button, input, select { font: inherit; }
+  button { cursor: pointer; }
+  button:disabled { cursor: default; opacity: .45; }
+  .breadcrumbs { align-items: center; color: #777; display: flex; flex-wrap: wrap; font-size: 13px; gap: 8px; margin-bottom: 18px; }
+  .breadcrumbs a { color: #2152a3; text-decoration: none; }
+  .breadcrumbs a:hover { text-decoration: underline; }
+  .sep { color: #a5a5a5; }
+  .catalog-header { align-items: center; display: flex; gap: 14px; margin-bottom: 18px; }
+  .back { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; height: 36px; width: 36px; }
+  h1 { font-size: 24px; line-height: 1.2; margin: 0; }
+  p { color: #777; margin: 4px 0 0; }
+  .toolbar { display: flex; gap: 10px; justify-content: flex-end; margin-bottom: 14px; }
+  select, .select-all { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; height: 36px; padding: 0 10px; }
+  select { appearance: none; background-image: linear-gradient(45deg, transparent 50%, #777 50%), linear-gradient(135deg, #777 50%, transparent 50%); background-position: calc(100% - 16px) 15px, calc(100% - 11px) 15px; background-repeat: no-repeat; background-size: 5px 5px, 5px 5px; padding-right: 34px; }
+  .select-all { align-items: center; display: flex; gap: 8px; }
+  .fake-checkbox { border: 1px solid #b8b8b8; border-radius: 2px; height: 14px; width: 14px; }
+  .fake-checkbox.checked { background: #2152a3; border-color: #2152a3; }
+  .bulk-bar { align-items: center; background: #1b264f; border-radius: 3px; color: #fff; display: flex; justify-content: space-between; margin-bottom: 18px; padding: 12px 14px; }
+  .bulk-bar button { background: transparent; border: 1px solid rgba(255,255,255,.75); border-radius: 3px; color: #fff; margin-left: 8px; padding: 6px 10px; }
+  .bulk-bar .clear { border: 0; }
+  .section { margin-top: 22px; }
+  h2 { color: #777; font-size: 11px; letter-spacing: .08em; margin: 0 0 10px; text-transform: uppercase; }
+  .chips { display: flex; flex-wrap: wrap; gap: 10px; }
+  .chip { align-items: center; background: #fff; border: 1px solid #d8d7d9; border-radius: 999px; color: inherit; display: flex; gap: 10px; padding: 6px 11px 6px 6px; text-align: left; text-decoration: none; }
+  .chip-text { display: grid; gap: 1px; }
+  .chip-text small { color: #777; font-size: 11px; }
+  .tile { align-items: center; background: #f6f4f4; border-radius: 50%; color: #1b264f; display: inline-flex; height: 30px; justify-content: center; width: 30px; }
+  .grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
+  .card { background: #fff; border: 1px solid #e9e9eb; border-radius: 4px; overflow: hidden; position: relative; transition: box-shadow .15s, border-color .15s; }
+  .card:hover { box-shadow: 0 6px 16px rgba(0,0,0,.08); }
+  .card.selected { border-color: #2152a3; box-shadow: 0 0 0 1px #2152a3; }
+  .checkbox { background: rgba(255,255,255,.76); border: 1px solid #d8d7d9; border-radius: 3px; color: #fff; height: 20px; left: 10px; line-height: 18px; opacity: .6; padding: 0; position: absolute; top: 10px; width: 20px; z-index: 1; }
+  .card:hover .checkbox, .checkbox.checked { opacity: 1; }
+  .checkbox.checked { background: #2152a3; border-color: #2152a3; }
+  .image { align-items: center; background: linear-gradient(135deg, #f4f4f6, #e9e9eb); color: #888; display: flex; height: 160px; justify-content: center; text-decoration: none; }
+  .image.dimmed { opacity: .45; }
+  .image umb-imaging-thumbnail { height: 100%; width: 100%; }
+  .card-body { display: grid; gap: 10px; padding: 12px; }
+  .title { color: #1f1f1f; display: -webkit-box; font-size: 14px; font-weight: 700; line-clamp: 2; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-decoration: none; }
+  .title:hover { text-decoration: underline; }
+  .meta, .status-row { align-items: center; display: flex; justify-content: space-between; gap: 10px; }
+  .meta span { color: #777; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .meta strong { font-size: 14px; white-space: nowrap; }
+  .pill { align-items: center; background: #f4f4f6; border-radius: 999px; color: #555; display: inline-flex; font-size: 12px; gap: 6px; padding: 4px 8px; }
+  .pill i { border-radius: 50%; display: inline-block; height: 7px; width: 7px; }
+  .published i { background: #2bc37c; }
+  .pending i { background: #fbd142; }
+  .unpublished i { background: #c4c4c4; }
+  .availability { font-size: 12px; white-space: nowrap; }
+  .availability.ok { color: #1c7d3c; }
+  .availability.bad { color: #d42054; }
+  .empty { border-style: dashed; color: #777; padding: 30px; text-align: center; }
+  .empty-category { display: grid; gap: 6px; }
+  .empty-category strong { color: #1f1f1f; font-size: 15px; }
+  .pagination { align-items: center; display: flex; gap: 18px; justify-content: center; margin-top: 24px; }
+  .pagination div { display: flex; gap: 6px; }
+  .pagination button { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; min-width: 34px; padding: 7px 10px; }
+  .pagination .current { background: #1b264f; border-color: #1b264f; color: #fff; }
+`;
+
+customElements.define('ekom-catalog-collection-view', EkomCatalogCollectionViewElement);
+
+export default EkomCatalogCollectionViewElement;

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
@@ -92,6 +92,24 @@ export const manifests: Array<UmbExtensionManifest> = [
     ],
   },
   {
+    type: 'collectionView',
+    alias: 'Ekom.CollectionView.Catalog',
+    name: 'Ekom Catalog Collection View',
+    element: '/App_Plugins/Ekom/dist/catalog-collection-view.element.js',
+    weight: 400,
+    meta: {
+      label: 'Catalog',
+      icon: 'icon-grid',
+      pathName: 'catalog',
+    },
+    conditions: [
+      {
+        alias: 'Umb.Condition.CollectionAlias',
+        match: 'Umb.Collection.Document',
+      },
+    ],
+  },
+  {
     type: 'propertyEditorSchema',
     alias: 'Ekom.Cache',
     name: 'Ekom Cache Editor',

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         'metafield-picker.element': 'src/property-editors/metafield-picker.element.ts',
         'metavalue-editor.element': 'src/property-editors/metavalue-editor.element.ts',
         'analytics-section-view.element': 'src/manager/analytics-section-view.element.ts',
+        'catalog-collection-view.element': 'src/catalog/catalog-collection-view.element.ts',
         'orders-section-view.element': 'src/manager/orders-section-view.element.ts',
         'price-editor.element': 'src/property-editors/price-editor.element.ts',
         'property-editor.element': 'src/property-editors/property-editor.element.ts',


### PR DESCRIPTION
## Summary
- Add a custom Umbraco 17 catalog collection view for Ekom categories and products.
- Add a backoffice API that loads direct catalog children, counts, breadcrumbs, product metadata, images, stock status, and default-currency pricing from content service data.
- Register the collection view in the U17 backoffice manifests and build output.
- Support header search, category navigation, direct child counts, pagination, sort persistence, and four rows of product cards per page.
- Handle empty categories and deleted-current-category navigation without relying on published-only content.

## Test Plan
- `npm run typecheck && npm run build`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj"`
- Open a catalog category in the Umbraco backoffice and switch to the Catalog view.
- Verify subcategory chips, product cards, header search, sort persistence, pagination, and empty category state.
- Verify product card prices use the default/current store currency.
