### PR TITLE
fix(cache): exclude unpublished U17 content

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/NodeService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/NodeService.cs
@@ -63,13 +63,20 @@ internal sealed class NodeService : INodeService
             return Array.Empty<UmbracoContent>();
         }
 
-        var nodes = _documentCacheService.GetByContentType(contentType).ToList();
+        var nodes = _documentCacheService.GetByContentType(contentType)
+            .Where(x => x.IsPublished())
+            .ToList();
 
         var metadata = BuildContentMetadata(nodes, rootNode);
+        var publishedKeys = _publishedContentQuery.Content(
+                metadata.Values.SelectMany(x => x.PathKeys).Distinct())
+            .Select(x => x.Key)
+            .ToHashSet();
         var rootPathValue = rootNode.Id.ToString();
         nodes = nodes
             .Where(x => metadata.TryGetValue(x.Key, out var itemMetadata)
-                && itemMetadata.Path.Split(',').Contains(rootPathValue))
+                && itemMetadata.Path.Split(',').Contains(rootPathValue)
+                && itemMetadata.PathKeys.All(publishedKeys.Contains))
             .ToList();
 
         var results = nodes
@@ -131,7 +138,8 @@ internal sealed class NodeService : INodeService
             metadata[node.Key] = new ContentMetadata(
                 parentKey.HasValue && idsByKey.TryGetValue(parentKey.Value, out var parentId) ? parentId : null,
                 parentKey,
-                string.Join(',', pathIds));
+                string.Join(',', pathIds),
+                pathKeys);
         }
 
         return metadata;
@@ -501,5 +509,9 @@ internal sealed class NodeService : INodeService
         return false;
     }
 
-    private sealed record ContentMetadata(int? ParentId, Guid? ParentKey, string Path);
+    private sealed record ContentMetadata(
+        int? ParentId,
+        Guid? ParentKey,
+        string Path,
+        IReadOnlyList<Guid> PathKeys);
 }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
@@ -129,6 +129,8 @@ internal sealed class UmbracoEventListeners :
     {
         foreach (var node in notification.UnpublishedEntities)
         {
+            RemoveDescendantsFromCaches(node.Id);
+
             if (!node.ContentType.Alias.StartsWith("ekm", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
@@ -139,7 +141,6 @@ internal sealed class UmbracoEventListeners :
             var cacheEntry = FindMatchingCache(node.ContentType.Alias);
             cacheEntry?.Remove(node.Key);
 
-            RefreshCacheForRelatedNodes(node.Id, true);
             _ = RevalidateAsync(node, cancellationToken);
         }
 
@@ -351,6 +352,42 @@ internal sealed class UmbracoEventListeners :
         {
             var cacheEntry = FindMatchingCache(ancestor.ContentType.Alias);
             cacheEntry?.AddReplace(new Umbraco17Content(ancestor));
+        }
+    }
+
+    private void RemoveDescendantsFromCaches(int parentId)
+    {
+        const int pageSize = 2_000;
+        long pageIndex = 0;
+        long descendantCount = 0;
+
+        while (true)
+        {
+            var batch = _contentService.GetPagedDescendants(parentId, pageIndex, pageSize, out var totalRecords);
+            var descendants = batch as IList<IContent> ?? batch.ToList();
+
+            if (descendants.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var descendant in descendants)
+            {
+                if (!descendant.ContentType.Alias.StartsWith("ekm", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                FindMatchingCache(descendant.ContentType.Alias)?.Remove(descendant.Key);
+            }
+
+            descendantCount += descendants.Count;
+            if (descendantCount >= totalRecords)
+            {
+                return;
+            }
+
+            pageIndex++;
         }
     }
 


### PR DESCRIPTION
## Summary
- exclude unpublished U17 content and content below unpublished ancestors during cache population
- evict cached Ekom descendants whenever an ancestor is unpublished

## Test Plan
- `dotnet build \"Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj\" --no-restore`
- `dotnet test \"Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj\" --no-restore` *(fails on existing `PriceTests.ISK_PerUnit_VatIncluded_LineLevelVat_1538x4_24pct` due to a null Configuration service provider; 325 tests pass)*