### PR TITLE
fix(catalog): page large category collections

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/CatalogCollectionService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/CatalogCollectionService.cs
@@ -5,8 +5,10 @@ using Newtonsoft.Json;
 using System.Globalization;
 using System.Net;
 using System.Text.Json;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Persistence.Querying;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
 
@@ -18,11 +20,16 @@ internal sealed class CatalogCollectionService : ICatalogCollectionService
     private static readonly HashSet<string> CatalogAliases = new(StringComparer.OrdinalIgnoreCase) { "ekmCategory", "ekmProduct" };
 
     private readonly IContentService _contentService;
+    private readonly IContentTypeService _contentTypeService;
     private readonly IScopeProvider _scopeProvider;
 
-    public CatalogCollectionService(IContentService contentService, IScopeProvider scopeProvider)
+    public CatalogCollectionService(
+        IContentService contentService,
+        IContentTypeService contentTypeService,
+        IScopeProvider scopeProvider)
     {
         _contentService = contentService;
+        _contentTypeService = contentTypeService;
         _scopeProvider = scopeProvider;
     }
 
@@ -43,9 +50,7 @@ internal sealed class CatalogCollectionService : ICatalogCollectionService
 
         var pageSize = Math.Clamp(request.PageSize <= 0 ? 80 : request.PageSize, 1, MaxPageSize);
         var page = Math.Max(request.Page, 1);
-        var children = GetCatalogChildren(current.Id);
-        var subcategoryContent = children
-            .Where(x => x.ContentType.Alias.Equals("ekmCategory", StringComparison.OrdinalIgnoreCase))
+        var subcategoryContent = GetCatalogChildren(current.Id, "ekmCategory")
             .OrderBy(x => x.SortOrder)
             .ThenBy(x => x.Name)
             .ToList();
@@ -53,20 +58,43 @@ internal sealed class CatalogCollectionService : ICatalogCollectionService
         var subcategories = subcategoryContent
             .Select(category => MapNode(category, subcategoryCounts.GetValueOrDefault(category.Id)))
             .ToList();
-        var products = children
-            .Where(x => x.ContentType.Alias.Equals("ekmProduct", StringComparison.OrdinalIgnoreCase))
-            .Select(MapProduct)
-            .ToList();
+        var hasQuery = !string.IsNullOrWhiteSpace(request.Query);
+        var productCount = 0;
+        var filteredProductCount = 0;
+        var totalPages = 1;
+        IReadOnlyList<CatalogCollectionProduct> pagedProducts;
 
-        var filteredProducts = FilterProducts(products, request.Query);
-        filteredProducts = SortProducts(filteredProducts, request.Sort);
+        if (hasQuery)
+        {
+            var products = GetCatalogChildren(current.Id, "ekmProduct")
+                .Select(MapProduct)
+                .ToList();
+            var filteredProducts = SortProducts(FilterProducts(products, request.Query), request.Sort);
 
-        var totalPages = Math.Max(1, (int)Math.Ceiling(filteredProducts.Count / (double)pageSize));
-        page = Math.Min(page, totalPages);
-        var pagedProducts = filteredProducts
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToList();
+            productCount = products.Count;
+            filteredProductCount = filteredProducts.Count;
+            totalPages = Math.Max(1, (int)Math.Ceiling(filteredProductCount / (double)pageSize));
+            page = Math.Min(page, totalPages);
+            pagedProducts = filteredProducts
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+        }
+        else
+        {
+            var productContent = GetPagedProducts(current.Id, page - 1, pageSize, request.Sort, out var totalProducts);
+            productCount = (int)Math.Min(totalProducts, int.MaxValue);
+            filteredProductCount = productCount;
+            totalPages = Math.Max(1, (int)Math.Ceiling(productCount / (double)pageSize));
+            page = Math.Min(page, totalPages);
+
+            if (page - 1 != request.Page - 1)
+            {
+                productContent = GetPagedProducts(current.Id, page - 1, pageSize, request.Sort, out _);
+            }
+
+            pagedProducts = productContent.Select(MapProduct).ToList();
+        }
 
         return new CatalogCollectionResponse
         {
@@ -75,9 +103,9 @@ internal sealed class CatalogCollectionService : ICatalogCollectionService
             Breadcrumbs = GetBreadcrumbs(current),
             Subcategories = subcategories,
             Products = pagedProducts,
-            ProductCount = products.Count,
+            ProductCount = productCount,
             SubcategoryCount = subcategories.Count,
-            FilteredProductCount = filteredProducts.Count,
+            FilteredProductCount = filteredProductCount,
             Page = page,
             PageSize = pageSize,
             TotalPages = totalPages,
@@ -100,11 +128,58 @@ internal sealed class CatalogCollectionService : ICatalogCollectionService
         return content ?? throw new Exceptions.HttpResponseException(HttpStatusCode.NotFound);
     }
 
-    private IReadOnlyList<IContent> GetCatalogChildren(int parentId)
+    private IReadOnlyList<IContent> GetCatalogChildren(int parentId, string contentTypeAlias)
     {
-        return _contentService.GetPagedChildren(parentId, 0, int.MaxValue, out _)
-            .Where(x => !x.Trashed && CatalogAliases.Contains(x.ContentType.Alias))
+        var contentType = _contentTypeService.Get(contentTypeAlias)
+            ?? throw new InvalidOperationException($"Content type {contentTypeAlias} not found.");
+        var filter = new Query<IContent>(_scopeProvider.SqlContext)
+            .Where(x => !x.Trashed && x.ContentTypeId == contentType.Id);
+
+        return _contentService.GetPagedChildren(
+                parentId,
+                0,
+                int.MaxValue,
+                out _,
+                filter,
+                Ordering.ByDefault())
             .ToList();
+    }
+
+    private IReadOnlyList<IContent> GetPagedProducts(
+        int parentId,
+        int pageIndex,
+        int pageSize,
+        string? sort,
+        out long totalRecords)
+    {
+        var productType = _contentTypeService.Get("ekmProduct")
+            ?? throw new InvalidOperationException("Content type ekmProduct not found.");
+        var filter = new Query<IContent>(_scopeProvider.SqlContext)
+            .Where(x => !x.Trashed && x.ContentTypeId == productType.Id);
+
+        return _contentService.GetPagedChildren(
+                parentId,
+                pageIndex,
+                pageSize,
+                out totalRecords,
+                filter,
+                GetProductOrdering(sort))
+            .ToList();
+    }
+
+    private static Ordering GetProductOrdering(string? sort)
+    {
+        return (sort ?? string.Empty).ToUpperInvariant() switch
+        {
+            "SORTORDERDESC" => Ordering.By("sortOrder", Direction.Descending),
+            "NAMEASC" => Ordering.By("name", Direction.Ascending),
+            "NAMEDESC" => Ordering.By("name", Direction.Descending),
+            "CREATEDASC" => Ordering.By("createDate", Direction.Ascending),
+            "CREATEDDESC" => Ordering.By("createDate", Direction.Descending),
+            "UPDATEDASC" => Ordering.By("updateDate", Direction.Ascending),
+            "UPDATEDDESC" => Ordering.By("updateDate", Direction.Descending),
+            _ => Ordering.By("sortOrder", Direction.Ascending),
+        };
     }
 
     private CatalogCollectionNode? GetParent(IContent content)
@@ -164,10 +239,6 @@ internal sealed class CatalogCollectionService : ICatalogCollectionService
         {
             "SORTORDERDESC" => products.OrderByDescending(x => x.SortOrder).ThenBy(x => x.Title).ToList(),
             "NAMEDESC" => products.OrderByDescending(x => x.Title).ThenBy(x => x.Sku).ToList(),
-            "PRICEASC" => products.OrderBy(x => x.PriceValue ?? decimal.MaxValue).ThenBy(x => x.Title).ToList(),
-            "PRICEDESC" => products.OrderByDescending(x => x.PriceValue ?? decimal.MinValue).ThenBy(x => x.Title).ToList(),
-            "SKUASC" => products.OrderBy(x => x.Sku).ThenBy(x => x.Title).ToList(),
-            "SKUDESC" => products.OrderByDescending(x => x.Sku).ThenBy(x => x.Title).ToList(),
             "CREATEDASC" => products.OrderBy(x => x.CreatedDate).ThenBy(x => x.Title).ToList(),
             "CREATEDDESC" => products.OrderByDescending(x => x.CreatedDate).ThenBy(x => x.Title).ToList(),
             "UPDATEDASC" => products.OrderBy(x => x.UpdatedDate).ThenBy(x => x.Title).ToList(),

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
@@ -5,7 +5,7 @@ import { UMB_COLLECTION_CONTEXT as C } from "@umbraco-cms/backoffice/collection"
 import { UmbElementMixin as E } from "@umbraco-cms/backoffice/element-api";
 import "@umbraco-cms/backoffice/imaging";
 const z = 16, h = "sortOrderAsc", g = "ekomCatalogNode", b = 14, T = 220, O = 4, q = "ekomCatalogParent:", x = "ekomCatalogSort";
-class A extends E(HTMLElement) {
+class I extends E(HTMLElement) {
   constructor() {
     super(...arguments);
     n(this, "nodeId", "");
@@ -149,7 +149,7 @@ class A extends E(HTMLElement) {
   }
   render() {
     this.innerHTML = `
-      <style>${N}</style>
+      <style>${A}</style>
       <div class="catalog-shell">
         ${this.renderContent()}
       </div>
@@ -159,7 +159,7 @@ class A extends E(HTMLElement) {
     if (this.loading)
       return '<div class="surface state">Loading catalog…</div>';
     if (this.error)
-      return `<div class="surface state error"><strong>Catalog unavailable</strong><span>${l(this.error)}</span><button type="button" data-action="retry">Retry</button></div>`;
+      return `<div class="surface state error"><strong>Catalog unavailable</strong><span>${c(this.error)}</span><button type="button" data-action="retry">Retry</button></div>`;
     if (this.data == null)
       return '<div class="surface state">No catalog data.</div>';
     const e = this.selectedProductKeys.size;
@@ -179,7 +179,7 @@ class A extends E(HTMLElement) {
   }
   renderBreadcrumbs(e) {
     return `<nav class="breadcrumbs">${e.breadcrumbs.map((t, r) => {
-      const o = r === e.breadcrumbs.length - 1, a = l(t.title || t.name);
+      const o = r === e.breadcrumbs.length - 1, a = c(t.title || t.name);
       return `${r > 0 ? '<span class="sep">/</span>' : ""}${o ? `<span>${a}</span>` : `<a href="${this.getDocumentHref(t.key)}">${a}</a>`}`;
     }).join("")}</nav>`;
   }
@@ -188,7 +188,7 @@ class A extends E(HTMLElement) {
       <header class="catalog-header">
         <button type="button" class="back" data-action="back" ${e.parent == null ? "disabled" : ""}>←</button>
         <div>
-          <h1>${l(e.current.title || e.current.name)}</h1>
+          <h1>${c(e.current.title || e.current.name)}</h1>
           <p>${e.productCount} products · ${e.subcategoryCount} subcategories</p>
         </div>
       </header>
@@ -203,10 +203,6 @@ class A extends E(HTMLElement) {
           ${this.renderSortOption("sortOrderDesc", "Sort order desc")}
           ${this.renderSortOption("nameAsc", "Name asc")}
           ${this.renderSortOption("nameDesc", "Name desc")}
-          ${this.renderSortOption("priceAsc", "Price asc")}
-          ${this.renderSortOption("priceDesc", "Price desc")}
-          ${this.renderSortOption("skuAsc", "SKU asc")}
-          ${this.renderSortOption("skuDesc", "SKU desc")}
           ${this.renderSortOption("createdAsc", "Created asc")}
           ${this.renderSortOption("createdDesc", "Created desc")}
           ${this.renderSortOption("updatedAsc", "Updated asc")}
@@ -238,7 +234,7 @@ class A extends E(HTMLElement) {
         <h2>Subcategories</h2>
         <div class="chips">${e.map((t) => `
           <a class="chip" href="${this.getDocumentHref(t.key)}">
-            <span class="tile">▦</span><span class="chip-text"><strong>${l(t.title || t.name)}</strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
+            <span class="tile">▦</span><span class="chip-text"><strong>${c(t.title || t.name)}</strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
           </a>
         `).join("")}</div>
       </section>
@@ -255,7 +251,7 @@ class A extends E(HTMLElement) {
     `;
   }
   renderProducts(e) {
-    const t = this.query ? `No products match &quot;${l(this.query)}&quot;` : "No products in this category yet";
+    const t = this.query ? `No products match &quot;${c(this.query)}&quot;` : "No products in this category yet";
     return `
       <section class="section">
         <h2>Products (${e.filteredProductCount})</h2>
@@ -268,11 +264,11 @@ class A extends E(HTMLElement) {
     return `
       <article class="card ${t ? "selected" : ""}">
         <button type="button" class="checkbox ${t ? "checked" : ""}" data-product-key="${e.key}">${t ? "✓" : ""}</button>
-        <a class="image ${e.published ? "" : "dimmed"}" href="${r}">${e.image ? `<umb-imaging-thumbnail unique="${l(e.image)}" width="320" height="160" alt="${l(e.title || e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
+        <a class="image ${e.published ? "" : "dimmed"}" href="${r}">${e.image ? `<umb-imaging-thumbnail unique="${c(e.image)}" width="320" height="160" alt="${c(e.title || e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
         <div class="card-body">
-          <a class="title" href="${r}">${l(e.title || e.name)}</a>
-          <div class="meta"><span>${e.sku ? `SKU ${l(e.sku)}` : "No SKU"}</span><strong>${l(e.price)}</strong></div>
-          <div class="status-row"><span class="pill ${I(e.status)}"><i></i>${e.status}</span><strong class="availability ${e.available ? "ok" : "bad"}">${e.available ? "✓ Available" : "✕ Unavailable"}</strong></div>
+          <a class="title" href="${r}">${c(e.title || e.name)}</a>
+          <div class="meta"><span>${e.sku ? `SKU ${c(e.sku)}` : "No SKU"}</span><strong>${c(e.price)}</strong></div>
+          <div class="status-row"><span class="pill ${N(e.status)}"><i></i>${e.status}</span><strong class="availability ${e.available ? "ok" : "bad"}">${e.available ? "✓ Available" : "✕ Unavailable"}</strong></div>
         </div>
       </article>
     `;
@@ -294,20 +290,20 @@ class A extends E(HTMLElement) {
   }
   paginationItems(e, t) {
     if (t <= 7)
-      return Array.from({ length: t }, (c, s) => s + 1);
-    const o = [.../* @__PURE__ */ new Set([1, t, e - 1, e, e + 1])].filter((c) => c >= 1 && c <= t).sort((c, s) => c - s), a = [];
-    for (const c of o) {
+      return Array.from({ length: t }, (l, s) => s + 1);
+    const o = [.../* @__PURE__ */ new Set([1, t, e - 1, e, e + 1])].filter((l) => l >= 1 && l <= t).sort((l, s) => l - s), a = [];
+    for (const l of o) {
       const s = a[a.length - 1];
-      typeof s == "number" && c - s > 1 && a.push("…"), a.push(c);
+      typeof s == "number" && l - s > 1 && a.push("…"), a.push(l);
     }
     return a;
   }
   bindEvents() {
-    var e, t, r, o, a, c;
+    var e, t, r, o, a, l;
     (e = this.querySelector('[data-action="retry"]')) == null || e.addEventListener("click", () => void this.load()), (t = this.querySelector('[data-action="back"]')) == null || t.addEventListener("click", () => {
       var s;
       ((s = this.data) == null ? void 0 : s.parent) != null && this.drillTo(this.data.parent);
-    }), (r = this.querySelector('[data-action="toggle-page"]')) == null || r.addEventListener("click", () => this.toggleCurrentPage()), (o = this.querySelector('[data-action="clear-selection"]')) == null || o.addEventListener("click", () => this.clearSelection()), (a = this.querySelector('[data-field="sort"]')) == null || a.addEventListener("input", (s) => this.setSort(s.target.value)), (c = this.querySelector('[data-field="sort"]')) == null || c.addEventListener("change", (s) => this.setSort(s.target.value)), this.querySelectorAll("[data-product-key]").forEach((s) => {
+    }), (r = this.querySelector('[data-action="toggle-page"]')) == null || r.addEventListener("click", () => this.toggleCurrentPage()), (o = this.querySelector('[data-action="clear-selection"]')) == null || o.addEventListener("click", () => this.clearSelection()), (a = this.querySelector('[data-field="sort"]')) == null || a.addEventListener("input", (s) => this.setSort(s.target.value)), (l = this.querySelector('[data-field="sort"]')) == null || l.addEventListener("change", (s) => this.setSort(s.target.value)), this.querySelectorAll("[data-product-key]").forEach((s) => {
       s.addEventListener("click", (k) => {
         var u;
         k.preventDefault();
@@ -348,10 +344,10 @@ class f extends Error {
     super(d), this.status = e;
   }
 }
-function l(i) {
+function c(i) {
   return i.replace(/[&<>"]/g, (d) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[d] ?? d);
 }
-function I(i) {
+function N(i) {
   return i === "Published" ? "published" : i === "Pending changes" ? "pending" : "unpublished";
 }
 function v(i) {
@@ -360,10 +356,6 @@ function v(i) {
     "sortOrderDesc",
     "nameAsc",
     "nameDesc",
-    "priceAsc",
-    "priceDesc",
-    "skuAsc",
-    "skuDesc",
     "createdAsc",
     "createdDesc",
     "updatedAsc",
@@ -384,7 +376,7 @@ function y(i) {
   } catch {
   }
 }
-const N = `
+const A = `
   ekom-catalog-collection-view { color: #1f1f1f; display: block !important; font-family: Lato, sans-serif; visibility: visible !important; }
   .catalog-shell { background: #f6f4f4; min-height: 100%; padding: 24px; }
   .surface, .empty { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; }
@@ -450,7 +442,7 @@ const N = `
   .pagination button { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; min-width: 34px; padding: 7px 10px; }
   .pagination .current { background: #1b264f; border-color: #1b264f; color: #fff; }
 `;
-customElements.define("ekom-catalog-collection-view", A);
+customElements.define("ekom-catalog-collection-view", I);
 export {
-  A as default
+  I as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
@@ -414,10 +414,6 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
           ${this.renderSortOption('sortOrderDesc', 'Sort order desc')}
           ${this.renderSortOption('nameAsc', 'Name asc')}
           ${this.renderSortOption('nameDesc', 'Name desc')}
-          ${this.renderSortOption('priceAsc', 'Price asc')}
-          ${this.renderSortOption('priceDesc', 'Price desc')}
-          ${this.renderSortOption('skuAsc', 'SKU asc')}
-          ${this.renderSortOption('skuDesc', 'SKU desc')}
           ${this.renderSortOption('createdAsc', 'Created asc')}
           ${this.renderSortOption('createdDesc', 'Created desc')}
           ${this.renderSortOption('updatedAsc', 'Updated asc')}
@@ -633,10 +629,6 @@ function isSortOption(value: string): boolean {
     'sortOrderDesc',
     'nameAsc',
     'nameDesc',
-    'priceAsc',
-    'priceDesc',
-    'skuAsc',
-    'skuDesc',
     'createdAsc',
     'createdDesc',
     'updatedAsc',


### PR DESCRIPTION
## Summary
- page unfiltered category products through Umbraco's content service instead of loading every child
- retain full custom filtering when a search query is supplied
- limit catalog sorting to fields supported by server-side paging

## Test Plan
- `dotnet build \"Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj\" --no-restore`
- `npm run typecheck`
- `npm run build`