### PR TITLE
feat(catalog): improve collection navigation and loading

### DIFF
--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
@@ -1,25 +1,25 @@
-var S = Object.defineProperty;
-var P = (i, d, e) => d in i ? S(i, d, { enumerable: !0, configurable: !0, writable: !0, value: e }) : i[d] = e;
-var n = (i, d, e) => P(i, typeof d != "symbol" ? d + "" : d, e);
+var $ = Object.defineProperty;
+var P = (r, l, e) => l in r ? $(r, l, { enumerable: !0, configurable: !0, writable: !0, value: e }) : r[l] = e;
+var n = (r, l, e) => P(r, typeof l != "symbol" ? l + "" : l, e);
 import { UMB_COLLECTION_CONTEXT as C } from "@umbraco-cms/backoffice/collection";
 import { UmbElementMixin as E } from "@umbraco-cms/backoffice/element-api";
 import "@umbraco-cms/backoffice/imaging";
-const z = 16, h = "sortOrderAsc", g = "ekomCatalogNode", b = 14, T = 220, O = 4, q = "ekomCatalogParent:", x = "ekomCatalogSort";
-class I extends E(HTMLElement) {
+const I = 16, u = "sortOrderAsc", b = "ekomCatalogNode", f = 14, T = 220, z = 4, O = "ekomCatalogParent:", k = "ekomCatalogSort", p = "ekomCatalog";
+class N extends E(HTMLElement) {
   constructor() {
     super(...arguments);
     n(this, "nodeId", "");
     n(this, "query", "");
-    n(this, "sort", m());
+    n(this, "sort", y());
     n(this, "page", 1);
-    n(this, "pageSize", z);
+    n(this, "pageSize", I);
     n(this, "loading", !0);
     n(this, "error", "");
     n(this, "data");
     n(this, "revealTimer");
     n(this, "resizeTimer");
     n(this, "collectionPaginationObserver");
-    n(this, "selectedProductKeys", /* @__PURE__ */ new Set());
+    n(this, "selection");
     n(this, "onPopState", () => this.restoreNodeFromHistory());
     n(this, "onResize", () => {
       this.resizeTimer != null && window.clearTimeout(this.resizeTimer), this.resizeTimer = window.setTimeout(() => {
@@ -28,10 +28,10 @@ class I extends E(HTMLElement) {
     });
   }
   connectedCallback() {
-    super.connectedCallback(), this.style.setProperty("display", "block", "important"), this.style.setProperty("visibility", "visible", "important"), window.addEventListener("popstate", this.onPopState), window.addEventListener("resize", this.onResize), this.revealCollectionHost(), this.revealTimer = window.setTimeout(() => this.revealCollectionHost(), 250), this.nodeId = this.getNodeIdFromUrl(), this.sort = m(), this.consumeContext(C, (e) => {
-      var r;
-      const t = (r = e == null ? void 0 : e.getConfig()) == null ? void 0 : r.unique;
-      this.getCatalogNodeFromUrl() == null && t != null && t !== this.nodeId && (this.nodeId = t, this.load()), this.observe(e == null ? void 0 : e.filter, (o) => this.setQueryFromCollectionFilter(o), "ekomCatalogCollectionFilter");
+    super.connectedCallback(), this.style.setProperty("display", "block", "important"), this.style.setProperty("visibility", "visible", "important"), window.addEventListener("popstate", this.onPopState), window.addEventListener("resize", this.onResize), this.revealCollectionHost(), this.revealTimer = window.setTimeout(() => this.revealCollectionHost(), 250), this.nodeId = this.getNodeIdFromUrl(), this.sort = y(), this.restorePageFromHistory(), this.consumeContext(C, (e) => {
+      var o;
+      const t = (o = e == null ? void 0 : e.getConfig()) == null ? void 0 : o.unique;
+      this.getCatalogNodeFromUrl() == null && t != null && t !== this.nodeId && (this.nodeId = t, this.restorePageFromHistory(), this.load()), (e == null ? void 0 : e.selection) != null && (this.selection = e.selection, this.selection.setSelectable(!0), this.selection.setMultiple(!0), this.observe(e.selection.selection, () => this.render(), "ekomCatalogCollectionSelection")), this.observe(e == null ? void 0 : e.filter, (i) => this.setQueryFromCollectionFilter(i), "ekomCatalogCollectionFilter");
     }), this.render(), this.nodeId && this.load();
   }
   disconnectedCallback() {
@@ -53,7 +53,7 @@ class I extends E(HTMLElement) {
       });
       this.data = await this.fetchJson(`/ekom/backoffice/CatalogCollection/${encodeURIComponent(this.nodeId)}?${t}`), this.page = this.data.page, this.pageSize = this.data.pageSize, this.storeParentNode(this.data);
     } catch (t) {
-      if (t instanceof f && t.status === 404 && this.redirectToParent())
+      if (t instanceof m && t.status === 404 && this.redirectToParent())
         return;
       this.error = t instanceof Error ? t.message : "Unable to load catalog.";
     } finally {
@@ -61,65 +61,91 @@ class I extends E(HTMLElement) {
     }
   }
   drillTo(e) {
-    window.location.assign(this.getDocumentHref(e.key || String(e.id)));
+    var i;
+    const t = e.key || String(e.id), o = history.state != null && typeof history.state == "object" ? history.state : {};
+    history.pushState({
+      ...o,
+      [p]: {
+        nodeId: t,
+        page: 1
+      }
+    }, "", this.getDocumentHref(t)), this.nodeId = t, this.query = "", this.page = 1, (i = this.selection) == null || i.clearSelection(), this.load();
   }
   restoreNodeFromHistory() {
+    var t;
     const e = this.getNodeIdFromUrl();
-    !e || e === this.nodeId || (this.nodeId = e, this.query = "", this.page = 1, this.selectedProductKeys.clear(), this.load());
+    e && (this.nodeId = e, this.query = "", this.page = 1, this.restorePageFromHistory(), (t = this.selection) == null || t.clearSelection(), this.load());
   }
   storeParentNode(e) {
-    var r;
+    var o;
     const t = this.getParentStorageKey(e.current.key || String(e.current.id));
-    (r = e.parent) != null && r.key ? window.sessionStorage.setItem(t, e.parent.key) : window.sessionStorage.removeItem(t);
+    (o = e.parent) != null && o.key ? window.sessionStorage.setItem(t, e.parent.key) : window.sessionStorage.removeItem(t);
   }
   redirectToParent() {
-    var t, r;
-    const e = ((r = (t = this.data) == null ? void 0 : t.parent) == null ? void 0 : r.key) ?? window.sessionStorage.getItem(this.getParentStorageKey(this.nodeId));
+    var t, o;
+    const e = ((o = (t = this.data) == null ? void 0 : t.parent) == null ? void 0 : o.key) ?? window.sessionStorage.getItem(this.getParentStorageKey(this.nodeId));
     return e ? (window.location.replace(this.getDocumentHref(e)), !0) : !1;
   }
   getParentStorageKey(e) {
-    return `${q}${e}`;
+    return `${O}${e}`;
+  }
+  restorePageFromHistory() {
+    const e = history.state, t = e == null ? void 0 : e[p];
+    if (t == null || typeof t != "object")
+      return;
+    const { nodeId: o, page: i } = t;
+    o === this.nodeId && typeof i == "number" && Number.isInteger(i) && i > 0 && (this.page = i);
+  }
+  storePageInHistory() {
+    if (!this.nodeId)
+      return;
+    const e = history.state != null && typeof history.state == "object" ? history.state : {};
+    history.replaceState({
+      ...e,
+      [p]: {
+        nodeId: this.nodeId,
+        page: this.page
+      }
+    }, "", window.location.href);
   }
   setQueryFromCollectionFilter(e) {
-    const t = "filter" in (e ?? {}) ? e.filter : void 0, r = typeof t == "string" ? t : "";
-    r !== this.query && (this.query = r, this.page = 1, this.nodeId && this.load());
+    const t = "filter" in (e ?? {}) ? e.filter : void 0, o = typeof t == "string" ? t : "";
+    o !== this.query && (this.query = o, this.page = 1, this.storePageInHistory(), this.nodeId && this.load());
   }
   setSort(e) {
     if (v(e)) {
       if (e === this.sort) {
-        y(e);
+        x(e);
         return;
       }
-      this.sort = e, y(e), this.page = 1, this.load();
+      this.sort = e, x(e), this.page = 1, this.storePageInHistory(), this.load();
     }
   }
   setPage(e) {
-    e < 1 || e === this.page || this.data != null && e > this.data.totalPages || (this.page = e, this.load());
+    e < 1 || e === this.page || this.data != null && e > this.data.totalPages || (this.page = e, this.storePageInHistory(), this.load());
   }
   updatePageSizeForViewport() {
     const e = Math.max(0, this.clientWidth - 48);
     if (e === 0)
       return !1;
-    const r = Math.max(1, Math.floor((e + b) / (T + b))) * O;
-    return r === this.pageSize ? !1 : (this.pageSize = r, !0);
+    const o = Math.max(1, Math.floor((e + f) / (T + f))) * z;
+    return o === this.pageSize ? !1 : (this.pageSize = o, !0);
   }
   toggleProduct(e) {
-    this.selectedProductKeys.has(e.key) ? this.selectedProductKeys.delete(e.key) : this.selectedProductKeys.add(e.key), this.render();
+    var t;
+    (t = this.selection) == null || t.toggleSelect(e.key);
   }
   toggleCurrentPage() {
-    var r;
-    const e = ((r = this.data) == null ? void 0 : r.products) ?? [], t = e.length > 0 && e.every((o) => this.selectedProductKeys.has(o.key));
-    for (const o of e)
-      t ? this.selectedProductKeys.delete(o.key) : this.selectedProductKeys.add(o.key);
-    this.render();
-  }
-  clearSelection() {
-    this.selectedProductKeys.clear(), this.render();
+    var a;
+    if (this.selection == null)
+      return;
+    const t = (((a = this.data) == null ? void 0 : a.products) ?? []).map((s) => s.key), o = t.length > 0 && t.every((s) => this.selection.isSelected(s)), i = this.selection.getSelection();
+    this.selection.setSelection(o ? i.filter((s) => !t.includes(s)) : [.../* @__PURE__ */ new Set([...i, ...t])]);
   }
   revealCollectionHost() {
     for (const e of this.getComposedAncestors("umb-collection-default")) {
-      const t = e.shadowRoot, r = t == null ? void 0 : t.querySelector("#router"), o = t == null ? void 0 : t.querySelector("umb-body-layout"), a = t == null ? void 0 : t.querySelector("#empty-state");
-      r == null || r.style.setProperty("visibility", "visible", "important"), a == null || a.style.setProperty("display", "none", "important"), o == null || o.classList.add("has-items");
+      const t = e.shadowRoot, o = t == null ? void 0 : t.querySelector("#router"), i = t == null ? void 0 : t.querySelector("umb-body-layout"), a = t == null ? void 0 : t.querySelector("#empty-state");
+      o == null || o.style.setProperty("visibility", "visible", "important"), a == null || a.style.setProperty("display", "none", "important"), i == null || i.classList.add("has-items");
     }
     for (const e of this.getComposedShadowRoots())
       this.hideDefaultCollectionPagination(e), this.observeDefaultCollectionPagination(e);
@@ -133,17 +159,17 @@ class I extends E(HTMLElement) {
   }
   getComposedAncestors(e) {
     const t = [];
-    let r = this;
-    for (; r != null; )
-      r instanceof HTMLElement && r.matches(e) && t.push(r), r = r.parentNode ?? (r.getRootNode() instanceof ShadowRoot ? r.getRootNode().host : null);
+    let o = this;
+    for (; o != null; )
+      o instanceof HTMLElement && o.matches(e) && t.push(o), o = o.parentNode ?? (o.getRootNode() instanceof ShadowRoot ? o.getRootNode().host : null);
     return t;
   }
   getComposedShadowRoots() {
     const e = /* @__PURE__ */ new Set();
     let t = this;
     for (; t != null; ) {
-      const r = t.getRootNode();
-      r instanceof ShadowRoot && e.add(r), t = t.parentNode ?? (r instanceof ShadowRoot ? r.host : null);
+      const o = t.getRootNode();
+      o instanceof ShadowRoot && e.add(o), t = t.parentNode ?? (o instanceof ShadowRoot ? o.host : null);
     }
     return [...e];
   }
@@ -156,14 +182,7 @@ class I extends E(HTMLElement) {
     `, this.revealCollectionHost(), this.bindEvents();
   }
   renderContent() {
-    if (this.loading)
-      return '<div class="surface state">Loading catalog…</div>';
-    if (this.error)
-      return `<div class="surface state error"><strong>Catalog unavailable</strong><span>${c(this.error)}</span><button type="button" data-action="retry">Retry</button></div>`;
-    if (this.data == null)
-      return '<div class="surface state">No catalog data.</div>';
-    const e = this.selectedProductKeys.size;
-    return !this.query && this.data.productCount === 0 && this.data.subcategoryCount === 0 ? `
+    return this.loading ? this.renderLoading() : this.error ? `<div class="surface state error"><strong>Catalog unavailable</strong><span>${d(this.error)}</span><button type="button" data-action="retry">Retry</button></div>` : this.data == null ? '<div class="surface state">No catalog data.</div>' : !this.query && this.data.productCount === 0 && this.data.subcategoryCount === 0 ? `
         ${this.renderBreadcrumbs(this.data)}
         ${this.renderHeader(this.data)}
         ${this.renderEmptyCategory()}
@@ -171,16 +190,52 @@ class I extends E(HTMLElement) {
       ${this.renderBreadcrumbs(this.data)}
       ${this.renderHeader(this.data)}
       ${this.renderToolbar(this.data)}
-      ${e > 0 ? this.renderBulkBar(e) : ""}
       ${!this.query && this.data.subcategories.length > 0 ? this.renderSubcategories(this.data.subcategories) : ""}
       ${this.renderProducts(this.data)}
       ${this.renderPagination(this.data)}
     `;
   }
+  renderLoading() {
+    return `
+      <div class="catalog-loading" aria-busy="true" aria-label="Loading catalog" role="status">
+        <div class="loading-breadcrumbs">
+          <span class="skeleton skeleton-breadcrumb"></span>
+          <span class="skeleton skeleton-breadcrumb"></span>
+          <span class="skeleton skeleton-breadcrumb current"></span>
+        </div>
+        <div class="loading-header">
+          <span class="skeleton skeleton-back"></span>
+          <div>
+            <span class="skeleton skeleton-title"></span>
+            <span class="skeleton skeleton-summary"></span>
+          </div>
+        </div>
+        <div class="loading-toolbar">
+          <span class="skeleton skeleton-control"></span>
+          <span class="skeleton skeleton-control"></span>
+        </div>
+        <section class="loading-section">
+          <span class="skeleton skeleton-section-title"></span>
+          <div class="loading-chips">
+            <span class="skeleton skeleton-chip"></span>
+            <span class="skeleton skeleton-chip"></span>
+            <span class="skeleton skeleton-chip"></span>
+          </div>
+        </section>
+        <section class="loading-section">
+          <span class="skeleton skeleton-section-title"></span>
+          <div class="loading-grid">
+            ${Array.from({ length: 8 }, () => '<article class="loading-card"><span class="skeleton skeleton-image"></span><div class="loading-card-body"><span class="skeleton skeleton-product-title"></span><span class="skeleton skeleton-product-meta"></span><span class="skeleton skeleton-product-status"></span></div></article>').join("")}
+          </div>
+        </section>
+        <span class="visually-hidden">Loading catalog…</span>
+      </div>
+    `;
+  }
   renderBreadcrumbs(e) {
-    return `<nav class="breadcrumbs">${e.breadcrumbs.map((t, r) => {
-      const o = r === e.breadcrumbs.length - 1, a = c(t.title || t.name);
-      return `${r > 0 ? '<span class="sep">/</span>' : ""}${o ? `<span>${a}</span>` : `<a href="${this.getDocumentHref(t.key)}">${a}</a>`}`;
+    return `<nav class="breadcrumbs">${e.breadcrumbs.map((t, o) => {
+      const i = o === e.breadcrumbs.length - 1, a = d(t.title || t.name);
+      return `${o > 0 ? '<span class="sep">/</span>' : ""}${i ? `<span>${a}</span>` : `<a href="${this.getDocumentHref(t.key)}">${a}</a>`}`;
     }).join("")}</nav>`;
   }
   renderHeader(e) {
@@ -188,14 +243,17 @@ class I extends E(HTMLElement) {
       <header class="catalog-header">
         <button type="button" class="back" data-action="back" ${e.parent == null ? "disabled" : ""}>←</button>
         <div>
-          <h1>${c(e.current.title || e.current.name)}</h1>
+          <h1>${d(e.current.title || e.current.name)}</h1>
           <p>${e.productCount} products · ${e.subcategoryCount} subcategories</p>
         </div>
       </header>
     `;
   }
   renderToolbar(e) {
-    const t = e.products.length > 0 && e.products.every((r) => this.selectedProductKeys.has(r.key));
+    const t = e.products.length > 0 && e.products.every((o) => {
+      var i;
+      return (i = this.selection) == null ? void 0 : i.isSelected(o.key);
+    });
     return `
       <div class="toolbar">
         <select data-field="sort">
@@ -215,26 +273,13 @@ class I extends E(HTMLElement) {
   renderSortOption(e, t) {
     return `<option value="${e}" ${this.sort === e ? "selected" : ""}>${t}</option>`;
   }
-  renderBulkBar(e) {
-    return `
-      <div class="bulk-bar">
-        <strong>${e} selected</strong>
-        <div>
-          <button type="button" disabled>Publish</button>
-          <button type="button" disabled>Unpublish</button>
-          <button type="button" disabled>Move</button>
-          <button type="button" class="clear" data-action="clear-selection">Clear ✕</button>
-        </div>
-      </div>
-    `;
-  }
   renderSubcategories(e) {
     return `
       <section class="section">
         <h2>Subcategories</h2>
         <div class="chips">${e.map((t) => `
           <a class="chip" href="${this.getDocumentHref(t.key)}">
-            <span class="tile">▦</span><span class="chip-text"><strong>${c(t.title || t.name)}</strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
+            <span class="tile">▦</span><span class="chip-text"><strong>${d(t.title || t.name)}</strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
           </a>
         `).join("")}</div>
       </section>
@@ -251,24 +296,25 @@ class I extends E(HTMLElement) {
     `;
   }
   renderProducts(e) {
-    const t = this.query ? `No products match &quot;${c(this.query)}&quot;` : "No products in this category yet";
+    const t = this.query ? `No products match &quot;${d(this.query)}&quot;` : "No products in this category yet";
     return `
       <section class="section">
         <h2>Products (${e.filteredProductCount})</h2>
-        ${e.products.length === 0 ? `<div class="empty">${t}</div>` : `<div class="grid">${e.products.map((r) => this.renderProduct(r)).join("")}</div>`}
+        ${e.products.length === 0 ? `<div class="empty">${t}</div>` : `<div class="grid">${e.products.map((o) => this.renderProduct(o)).join("")}</div>`}
       </section>
     `;
   }
   renderProduct(e) {
-    const t = this.selectedProductKeys.has(e.key), r = `/umbraco/section/content/workspace/document/edit/${e.key}`;
+    var i;
+    const t = ((i = this.selection) == null ? void 0 : i.isSelected(e.key)) ?? !1, o = `/umbraco/section/content/workspace/document/edit/${e.key}`;
     return `
       <article class="card ${t ? "selected" : ""}">
         <button type="button" class="checkbox ${t ? "checked" : ""}" data-product-key="${e.key}">${t ? "✓" : ""}</button>
-        <a class="image ${e.published ? "" : "dimmed"}" href="${r}">${e.image ? `<umb-imaging-thumbnail unique="${c(e.image)}" width="320" height="160" alt="${c(e.title || e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
+        <a class="image ${e.published ? "" : "dimmed"}" href="${o}">${e.image ? `<umb-imaging-thumbnail unique="${d(e.image)}" width="320" height="160" alt="${d(e.title || e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
         <div class="card-body">
-          <a class="title" href="${r}">${c(e.title || e.name)}</a>
-          <div class="meta"><span>${e.sku ? `SKU ${c(e.sku)}` : "No SKU"}</span><strong>${c(e.price)}</strong></div>
-          <div class="status-row"><span class="pill ${N(e.status)}"><i></i>${e.status}</span><strong class="availability ${e.available ? "ok" : "bad"}">${e.available ? "✓ Available" : "✕ Unavailable"}</strong></div>
+          <a class="title" href="${o}">${d(e.title || e.name)}</a>
+          <div class="meta"><span>${e.sku ? `SKU ${d(e.sku)}` : "No SKU"}</span><strong>${d(e.price)}</strong></div>
+          <div class="status-row"><span class="pill ${q(e.status)}"><i></i>${e.status}</span><strong class="availability ${e.available ? "ok" : "bad"}">${e.available ? "✓ Available" : "✕ Unavailable"}</strong></div>
         </div>
       </article>
     `;
@@ -276,39 +322,39 @@ class I extends E(HTMLElement) {
   renderPagination(e) {
     if (e.filteredProductCount === 0 || e.totalPages <= 1)
       return "";
-    const t = (e.page - 1) * e.pageSize + 1, r = Math.min(e.page * e.pageSize, e.filteredProductCount);
+    const t = (e.page - 1) * e.pageSize + 1, o = Math.min(e.page * e.pageSize, e.filteredProductCount);
     return `
       <footer class="pagination">
         <div>
           <button type="button" data-page="${e.page - 1}" ${e.page <= 1 ? "disabled" : ""}>‹ Prev</button>
-          ${this.paginationItems(e.page, e.totalPages).map((o) => o === "…" ? "<span>…</span>" : `<button type="button" class="${o === e.page ? "current" : ""}" data-page="${o}">${o}</button>`).join("")}
+          ${this.paginationItems(e.page, e.totalPages).map((i) => i === "…" ? "<span>…</span>" : `<button type="button" class="${i === e.page ? "current" : ""}" data-page="${i}">${i}</button>`).join("")}
           <button type="button" data-page="${e.page + 1}" ${e.page >= e.totalPages ? "disabled" : ""}>Next ›</button>
         </div>
-        <span>${t}–${r} of ${e.filteredProductCount}</span>
+        <span>${t}–${o} of ${e.filteredProductCount}</span>
       </footer>
     `;
   }
   paginationItems(e, t) {
     if (t <= 7)
-      return Array.from({ length: t }, (l, s) => s + 1);
-    const o = [.../* @__PURE__ */ new Set([1, t, e - 1, e, e + 1])].filter((l) => l >= 1 && l <= t).sort((l, s) => l - s), a = [];
-    for (const l of o) {
-      const s = a[a.length - 1];
-      typeof s == "number" && l - s > 1 && a.push("…"), a.push(l);
+      return Array.from({ length: t }, (s, c) => c + 1);
+    const i = [.../* @__PURE__ */ new Set([1, t, e - 1, e, e + 1])].filter((s) => s >= 1 && s <= t).sort((s, c) => s - c), a = [];
+    for (const s of i) {
+      const c = a[a.length - 1];
+      typeof c == "number" && s - c > 1 && a.push("…"), a.push(s);
     }
     return a;
   }
   bindEvents() {
-    var e, t, r, o, a, l;
+    var e, t, o, i, a;
     (e = this.querySelector('[data-action="retry"]')) == null || e.addEventListener("click", () => void this.load()), (t = this.querySelector('[data-action="back"]')) == null || t.addEventListener("click", () => {
       var s;
       ((s = this.data) == null ? void 0 : s.parent) != null && this.drillTo(this.data.parent);
-    }), (r = this.querySelector('[data-action="toggle-page"]')) == null || r.addEventListener("click", () => this.toggleCurrentPage()), (o = this.querySelector('[data-action="clear-selection"]')) == null || o.addEventListener("click", () => this.clearSelection()), (a = this.querySelector('[data-field="sort"]')) == null || a.addEventListener("input", (s) => this.setSort(s.target.value)), (l = this.querySelector('[data-field="sort"]')) == null || l.addEventListener("change", (s) => this.setSort(s.target.value)), this.querySelectorAll("[data-product-key]").forEach((s) => {
-      s.addEventListener("click", (k) => {
-        var u;
-        k.preventDefault();
-        const w = s.dataset.productKey, p = (u = this.data) == null ? void 0 : u.products.find(($) => $.key === w);
-        p != null && this.toggleProduct(p);
+    }), (o = this.querySelector('[data-action="toggle-page"]')) == null || o.addEventListener("click", () => this.toggleCurrentPage()), (i = this.querySelector('[data-field="sort"]')) == null || i.addEventListener("input", (s) => this.setSort(s.target.value)), (a = this.querySelector('[data-field="sort"]')) == null || a.addEventListener("change", (s) => this.setSort(s.target.value)), this.querySelectorAll("[data-product-key]").forEach((s) => {
+      s.addEventListener("click", (c) => {
+        var g;
+        c.preventDefault();
+        const w = s.dataset.productKey, h = (g = this.data) == null ? void 0 : g.products.find((S) => S.key === w);
+        h != null && this.toggleProduct(h);
       });
     }), this.querySelectorAll("[data-page]").forEach((s) => {
       s.addEventListener("click", () => this.setPage(Number(s.dataset.page)));
@@ -318,39 +364,39 @@ class I extends E(HTMLElement) {
     const e = this.getCatalogNodeFromUrl();
     if (e != null)
       return e;
-    const t = window.location.href, r = t.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
-    if (r != null)
-      return r[0];
-    const o = t.match(/\/edit\/([^/?#]+)/i);
-    return (o == null ? void 0 : o[1]) ?? "";
+    const t = window.location.href, o = t.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    if (o != null)
+      return o[0];
+    const i = t.match(/\/edit\/([^/?#]+)/i);
+    return (i == null ? void 0 : i[1]) ?? "";
   }
   getDocumentHref(e) {
     const t = new URL(window.location.href);
-    return t.searchParams.delete(g), t.pathname.match(/\/edit\/[^/]+/i) != null ? (t.pathname = t.pathname.replace(/\/edit\/[^/]+/i, `/edit/${e}`), `${t.pathname}${t.search}${t.hash}`) : `/umbraco/section/content/workspace/document/edit/${e}`;
+    return t.searchParams.delete(b), t.pathname.match(/\/edit\/[^/]+/i) != null ? (t.pathname = t.pathname.replace(/\/edit\/[^/]+/i, `/edit/${e}`), `${t.pathname}${t.search}${t.hash}`) : `/umbraco/section/content/workspace/document/edit/${e}`;
   }
   getCatalogNodeFromUrl() {
-    const e = new URL(window.location.href).searchParams.get(g);
+    const e = new URL(window.location.href).searchParams.get(b);
     return e && e.trim().length > 0 ? e : null;
   }
   async fetchJson(e) {
     const t = await fetch(e, { credentials: "same-origin", headers: { Accept: "application/json" } });
     if (!t.ok)
-      throw new f(await t.text() || `Request failed (${t.status}).`, t.status);
+      throw new m(await t.text() || `Request failed (${t.status}).`, t.status);
     return await t.json();
   }
 }
-class f extends Error {
-  constructor(d, e) {
-    super(d), this.status = e;
+class m extends Error {
+  constructor(l, e) {
+    super(l), this.status = e;
   }
 }
-function c(i) {
-  return i.replace(/[&<>"]/g, (d) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[d] ?? d);
+function d(r) {
+  return r.replace(/[&<>"]/g, (l) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[l] ?? l);
 }
-function N(i) {
-  return i === "Published" ? "published" : i === "Pending changes" ? "pending" : "unpublished";
+function q(r) {
+  return r === "Published" ? "published" : r === "Pending changes" ? "pending" : "unpublished";
 }
-function v(i) {
+function v(r) {
   return [
     "sortOrderAsc",
     "sortOrderDesc",
@@ -360,19 +406,19 @@ function v(i) {
     "createdDesc",
     "updatedAsc",
     "updatedDesc"
-  ].includes(i);
+  ].includes(r);
 }
-function m() {
+function y() {
   try {
-    const i = window.localStorage.getItem(x);
-    return i != null && v(i) ? i : h;
+    const r = window.localStorage.getItem(k);
+    return r != null && v(r) ? r : u;
   } catch {
-    return h;
+    return u;
   }
 }
-function y(i) {
+function x(r) {
   try {
-    window.localStorage.setItem(x, i);
+    window.localStorage.setItem(k, r);
   } catch {
   }
 }
@@ -382,6 +428,33 @@ const A = `
   .surface, .empty { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; }
   .state { padding: 24px; display: grid; gap: 10px; }
   .error { color: #d42054; }
+  .catalog-loading { animation: loading-enter .18s ease-out; }
+  .skeleton { animation: skeleton-shimmer 1.4s ease-in-out infinite; background: linear-gradient(100deg, #e9e9eb 35%, #f8f8f9 50%, #e9e9eb 65%); background-size: 200% 100%; border-radius: 3px; display: block; }
+  .loading-breadcrumbs { display: flex; gap: 8px; margin-bottom: 18px; }
+  .skeleton-breadcrumb { height: 13px; width: 58px; }
+  .skeleton-breadcrumb.current { width: 82px; }
+  .loading-header { align-items: center; display: flex; gap: 14px; margin-bottom: 18px; }
+  .skeleton-back { border-radius: 50%; height: 36px; width: 36px; }
+  .loading-header div { display: grid; gap: 8px; }
+  .skeleton-title { height: 28px; width: 176px; }
+  .skeleton-summary { height: 13px; width: 132px; }
+  .loading-toolbar { display: flex; gap: 10px; justify-content: flex-end; margin-bottom: 14px; }
+  .skeleton-control { height: 36px; width: 118px; }
+  .loading-section { margin-top: 22px; }
+  .skeleton-section-title { height: 11px; margin-bottom: 10px; width: 96px; }
+  .loading-chips { display: flex; flex-wrap: wrap; gap: 10px; }
+  .skeleton-chip { border-radius: 999px; height: 42px; width: 172px; }
+  .loading-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
+  .loading-card { background: #fff; border: 1px solid #e9e9eb; border-radius: 4px; overflow: hidden; }
+  .skeleton-image { border-radius: 0; height: 160px; }
+  .loading-card-body { display: grid; gap: 12px; padding: 12px; }
+  .skeleton-product-title { height: 16px; width: 76%; }
+  .skeleton-product-meta { height: 13px; width: 58%; }
+  .skeleton-product-status { height: 24px; width: 88%; }
+  .visually-hidden { height: 1px; margin: -1px; overflow: hidden; position: absolute; width: 1px; clip: rect(0, 0, 0, 0); }
+  @keyframes loading-enter { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes skeleton-shimmer { from { background-position: 100% 0; } to { background-position: -100% 0; } }
+  @media (prefers-reduced-motion: reduce) { .catalog-loading, .skeleton { animation: none; } }
   button, input, select { font: inherit; }
   button { cursor: pointer; }
   button:disabled { cursor: default; opacity: .45; }
@@ -399,9 +472,6 @@ const A = `
   .select-all { align-items: center; display: flex; gap: 8px; }
   .fake-checkbox { border: 1px solid #b8b8b8; border-radius: 2px; height: 14px; width: 14px; }
   .fake-checkbox.checked { background: #2152a3; border-color: #2152a3; }
-  .bulk-bar { align-items: center; background: #1b264f; border-radius: 3px; color: #fff; display: flex; justify-content: space-between; margin-bottom: 18px; padding: 12px 14px; }
-  .bulk-bar button { background: transparent; border: 1px solid rgba(255,255,255,.75); border-radius: 3px; color: #fff; margin-left: 8px; padding: 6px 10px; }
-  .bulk-bar .clear { border: 0; }
   .section { margin-top: 22px; }
   h2 { color: #777; font-size: 11px; letter-spacing: .08em; margin: 0 0 10px; text-transform: uppercase; }
   .chips { display: flex; flex-wrap: wrap; gap: 10px; }
@@ -442,7 +512,7 @@ const A = `
   .pagination button { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; min-width: 34px; padding: 7px 10px; }
   .pagination .current { background: #1b264f; border-color: #1b264f; color: #fff; }
 `;
-customElements.define("ekom-catalog-collection-view", I);
+customElements.define("ekom-catalog-collection-view", N);
 export {
-  I as default
+  N as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
@@ -173,7 +173,23 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
   }
 
   private drillTo(node: CatalogNode): void {
-    window.location.assign(this.getDocumentHref(node.key || String(node.id)));
+    const nodeId = node.key || String(node.id);
+    const state = history.state != null && typeof history.state === 'object'
+      ? history.state as Record<string, unknown>
+      : {};
+    history.pushState({
+      ...state,
+      [HISTORY_STATE_KEY]: {
+        nodeId,
+        page: 1,
+      },
+    }, '', this.getDocumentHref(nodeId));
+
+    this.nodeId = nodeId;
+    this.query = '';
+    this.page = 1;
+    this.selection?.clearSelection();
+    void this.load();
   }
 
   private restoreNodeFromHistory(): void {
@@ -394,7 +410,7 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
 
   private renderContent(): string {
     if (this.loading) {
-      return '<div class="surface state">Loading catalog…</div>';
+      return this.renderLoading();
     }
 
     if (this.error) {
@@ -422,6 +438,44 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
       ${!this.query && this.data.subcategories.length > 0 ? this.renderSubcategories(this.data.subcategories) : ''}
       ${this.renderProducts(this.data)}
       ${this.renderPagination(this.data)}
+    `;
+  }
+
+  private renderLoading(): string {
+    return `
+      <div class="catalog-loading" aria-busy="true" aria-label="Loading catalog" role="status">
+        <div class="loading-breadcrumbs">
+          <span class="skeleton skeleton-breadcrumb"></span>
+          <span class="skeleton skeleton-breadcrumb"></span>
+          <span class="skeleton skeleton-breadcrumb current"></span>
+        </div>
+        <div class="loading-header">
+          <span class="skeleton skeleton-back"></span>
+          <div>
+            <span class="skeleton skeleton-title"></span>
+            <span class="skeleton skeleton-summary"></span>
+          </div>
+        </div>
+        <div class="loading-toolbar">
+          <span class="skeleton skeleton-control"></span>
+          <span class="skeleton skeleton-control"></span>
+        </div>
+        <section class="loading-section">
+          <span class="skeleton skeleton-section-title"></span>
+          <div class="loading-chips">
+            <span class="skeleton skeleton-chip"></span>
+            <span class="skeleton skeleton-chip"></span>
+            <span class="skeleton skeleton-chip"></span>
+          </div>
+        </section>
+        <section class="loading-section">
+          <span class="skeleton skeleton-section-title"></span>
+          <div class="loading-grid">
+            ${Array.from({ length: 8 }, () => `<article class="loading-card"><span class="skeleton skeleton-image"></span><div class="loading-card-body"><span class="skeleton skeleton-product-title"></span><span class="skeleton skeleton-product-meta"></span><span class="skeleton skeleton-product-status"></span></div></article>`).join('')}
+          </div>
+        </section>
+        <span class="visually-hidden">Loading catalog…</span>
+      </div>
     `;
   }
 
@@ -685,6 +739,33 @@ const styles = `
   .surface, .empty { background: #fff; border: 1px solid #d8d7d9; border-radius: 3px; }
   .state { padding: 24px; display: grid; gap: 10px; }
   .error { color: #d42054; }
+  .catalog-loading { animation: loading-enter .18s ease-out; }
+  .skeleton { animation: skeleton-shimmer 1.4s ease-in-out infinite; background: linear-gradient(100deg, #e9e9eb 35%, #f8f8f9 50%, #e9e9eb 65%); background-size: 200% 100%; border-radius: 3px; display: block; }
+  .loading-breadcrumbs { display: flex; gap: 8px; margin-bottom: 18px; }
+  .skeleton-breadcrumb { height: 13px; width: 58px; }
+  .skeleton-breadcrumb.current { width: 82px; }
+  .loading-header { align-items: center; display: flex; gap: 14px; margin-bottom: 18px; }
+  .skeleton-back { border-radius: 50%; height: 36px; width: 36px; }
+  .loading-header div { display: grid; gap: 8px; }
+  .skeleton-title { height: 28px; width: 176px; }
+  .skeleton-summary { height: 13px; width: 132px; }
+  .loading-toolbar { display: flex; gap: 10px; justify-content: flex-end; margin-bottom: 14px; }
+  .skeleton-control { height: 36px; width: 118px; }
+  .loading-section { margin-top: 22px; }
+  .skeleton-section-title { height: 11px; margin-bottom: 10px; width: 96px; }
+  .loading-chips { display: flex; flex-wrap: wrap; gap: 10px; }
+  .skeleton-chip { border-radius: 999px; height: 42px; width: 172px; }
+  .loading-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
+  .loading-card { background: #fff; border: 1px solid #e9e9eb; border-radius: 4px; overflow: hidden; }
+  .skeleton-image { border-radius: 0; height: 160px; }
+  .loading-card-body { display: grid; gap: 12px; padding: 12px; }
+  .skeleton-product-title { height: 16px; width: 76%; }
+  .skeleton-product-meta { height: 13px; width: 58%; }
+  .skeleton-product-status { height: 24px; width: 88%; }
+  .visually-hidden { height: 1px; margin: -1px; overflow: hidden; position: absolute; width: 1px; clip: rect(0, 0, 0, 0); }
+  @keyframes loading-enter { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes skeleton-shimmer { from { background-position: 100% 0; } to { background-position: -100% 0; } }
+  @media (prefers-reduced-motion: reduce) { .catalog-loading, .skeleton { animation: none; } }
   button, input, select { font: inherit; }
   button { cursor: pointer; }
   button:disabled { cursor: default; opacity: .45; }


### PR DESCRIPTION
## Summary
- Navigate to a catalog parent in place from the header back button while preserving browser history.
- Replace the plain catalog loading message with an animated, accessible skeleton that mirrors the collection layout.
- Regenerate the Umbraco backoffice catalog asset.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Verify the header back button updates the URL and reloads catalog data without a page refresh.
- [x] Verify the catalog loading state shows shimmer skeletons and honors reduced-motion preferences.
