### PR TITLE
feat(ekom): Extend coupon result object

### DIFF
--- a/Ekom/Ekom.Core/Ekom.AspNetCore/Registrations.cs
+++ b/Ekom/Ekom.Core/Ekom.AspNetCore/Registrations.cs
@@ -72,6 +72,7 @@ static class Registrations
                 f.GetRequiredService<Catalog>(),
                 f.GetRequiredService<ICouponCache>(),
                 f.GetRequiredService<DiscountCache>(),
+                f.GetRequiredService<INodeService>(),
                 f.GetRequiredService<IStoreService>()
             )
         );

--- a/Ekom/Ekom.Core/Ekom/Models/OrderDiscountCalculationResult.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderDiscountCalculationResult.cs
@@ -3,6 +3,8 @@ namespace Ekom.Models;
 public class OrderDiscountCalculationResult
 {
     public bool Applied { get; set; }
+    public bool OrderConstraintsMet { get; set; }
+    public bool HasApplicableLines { get; set; }
     public required string CouponCode { get; set; }
     public Guid? DiscountId { get; set; }
     public string? DiscountTitle { get; set; }
@@ -19,6 +21,7 @@ public class OrderDiscountCalculationLineResult
     public required string Sku { get; set; }
     public string? VariantSku { get; set; }
     public decimal Quantity { get; set; }
+    public bool CouponApplicable { get; set; }
     public decimal UnitPriceBeforeDiscount { get; set; }
     public decimal LineTotalBeforeDiscount { get; set; }
     public decimal DiscountAmount { get; set; }

--- a/Ekom/Ekom.Core/Ekom/Models/OrderInfo.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderInfo.cs
@@ -148,10 +148,10 @@ public class OrderInfo : IOrderInfo
     private Price LinePriceWithOrderDiscount(IOrderLine line)
     {
         OrderedDiscount? discount = Discount;
-        if (discount?.DiscountItems.Any() == true)
+        if (discount != null)
         {
-            // Filters order discounts to their applicable DiscountItems
-            if (!OrderService.IsDiscountApplicable(this, line, discount))
+            // Filters order discounts to their applicable include/exclude targets.
+            if (!DiscountApplicability.MatchesLineTargets(line, discount))
             {
                 discount = null;
             }

--- a/Ekom/Ekom.Core/Ekom/Models/OrderLine.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderLine.cs
@@ -1,7 +1,5 @@
-using Ekom.API;
 using Ekom.Services;
 using Ekom.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 using System.Xml.Serialization;
 
 namespace Ekom.Models;
@@ -68,29 +66,8 @@ public class OrderLine : IOrderLine
 
         OrderedDiscount? discount = orderlinePrice.Discount;
 
-        var paths = new HashSet<string>(Product.Path.Split(','));
-        var categoriesUdi = Product.Properties.GetValue("categories").Split(',');
-
-        using var scope = Configuration.Resolver.GetRequiredService<IServiceScopeFactory>().CreateScope();
-        var nodeService = scope.ServiceProvider.GetRequiredService<INodeService>();
-
-        if (categoriesUdi.Any())
-        {
-            foreach (var categoryUdi in categoriesUdi)
-            {
-                var categoryNode = nodeService.NodeById(categoryUdi, false);
-
-                if (categoryNode != null)
-                {
-                    paths.UnionWith(categoryNode.Path.Split(','));
-                }
-            }
-        }
-
-        var uniquePaths = paths.ToList();
-
         if (OrderInfo?.Discount != null &&
-            (OrderInfo.Discount.DiscountItems.Any() && paths.Intersect(OrderInfo.Discount.DiscountItems).Any() || OrderInfo.Discount.GlobalDiscount))
+            DiscountApplicability.MatchesLineTargets(this, OrderInfo.Discount))
         {
             if (Product.Price.HasDiscount && OrderInfo.Discount.Stackable)
             {

--- a/Ekom/Ekom.Core/Ekom/Services/DiscountApplicability.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/DiscountApplicability.cs
@@ -1,0 +1,129 @@
+using Ekom.Models;
+using Ekom.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ekom.Services;
+
+internal static class DiscountApplicability
+{
+    public static bool AreOrderConstraintsMet(IOrderInfo orderInfo, IDiscount discount)
+    {
+        if (discount is IProductDiscount)
+        {
+            return false;
+        }
+
+        return AreConstraintsMet(orderInfo, discount);
+    }
+
+    public static bool IsDiscountApplicable(
+        IOrderInfo orderInfo,
+        IOrderLine orderLine,
+        IDiscount discount,
+        INodeService? nodeService = null)
+    {
+        if (!AreConstraintsMet(orderInfo, discount))
+        {
+            return false;
+        }
+
+        if (!discount.Stackable && orderLine.Product.ProductDiscount != null)
+        {
+            return false;
+        }
+
+        return MatchesLineTargets(orderLine, discount, nodeService);
+    }
+
+    private static bool AreConstraintsMet(IOrderInfo orderInfo, IDiscount discount)
+    {
+        return discount.Constraints == null
+            || discount.Constraints.IsValid(orderInfo.StoreInfo.Culture, orderInfo.OrderLineTotal.Value);
+    }
+
+    public static bool MatchesLineTargets(
+        IOrderLine orderLine,
+        IDiscount discount,
+        INodeService? nodeService = null)
+    {
+        var includeItems = discount.DiscountItems ?? [];
+        var excludeItems = discount.ExcludeDiscountItems ?? [];
+        var targetItems = GetOrderLineDiscountTargetItems(orderLine, nodeService);
+
+        var matchesInclude = discount.GlobalDiscount
+            || (includeItems.Count > 0 && targetItems.Overlaps(includeItems));
+
+        if (!matchesInclude)
+        {
+            return false;
+        }
+
+        if (excludeItems.Count > 0 && targetItems.Overlaps(excludeItems))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static HashSet<string> GetOrderLineDiscountTargetItems(
+        IOrderLine orderLine,
+        INodeService? nodeService)
+    {
+        var targetItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        AddSplitItems(targetItems, orderLine.Product.Path);
+
+        var categories = orderLine.Product.Properties.GetValue("categories");
+        if (string.IsNullOrWhiteSpace(categories))
+        {
+            return targetItems;
+        }
+
+        if (nodeService != null)
+        {
+            AddCategoryTargetItems(targetItems, categories, nodeService);
+            return targetItems;
+        }
+
+        var scopeFactory = Configuration.Resolver.GetService<IServiceScopeFactory>();
+        if (scopeFactory == null)
+        {
+            return targetItems;
+        }
+
+        using var scope = scopeFactory.CreateScope();
+        var scopedNodeService = scope.ServiceProvider.GetRequiredService<INodeService>();
+        AddCategoryTargetItems(targetItems, categories, scopedNodeService);
+
+        return targetItems;
+    }
+
+    private static void AddCategoryTargetItems(
+        HashSet<string> targetItems,
+        string categories,
+        INodeService nodeService)
+    {
+        foreach (var category in categories.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var categoryNode = nodeService.NodeById(category, false);
+            if (categoryNode != null)
+            {
+                AddSplitItems(targetItems, categoryNode.Path);
+            }
+        }
+    }
+
+    private static void AddSplitItems(HashSet<string> targetItems, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        foreach (var item in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            targetItems.Add(item);
+        }
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Services/OrderDiscountCalculationService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderDiscountCalculationService.cs
@@ -12,17 +12,20 @@ public sealed class OrderDiscountCalculationService : IOrderDiscountCalculationS
     private readonly Catalog _catalog;
     private readonly ICouponCache _couponCache;
     private readonly DiscountCache _discountCache;
+    private readonly INodeService _nodeService;
     private readonly IStoreService _storeService;
 
     internal OrderDiscountCalculationService(
         Catalog catalog,
         ICouponCache couponCache,
         DiscountCache discountCache,
+        INodeService nodeService,
         IStoreService storeService)
     {
         _catalog = catalog;
         _couponCache = couponCache;
         _discountCache = discountCache;
+        _nodeService = nodeService;
         _storeService = storeService;
     }
 
@@ -52,11 +55,14 @@ public sealed class OrderDiscountCalculationService : IOrderDiscountCalculationS
         var beforeTotals = orderInfo.orderLines
             .Select(line => line.Amount.Value)
             .ToArray();
+        var couponLineTargets = orderInfo.orderLines
+            .Select(line => DiscountApplicability.MatchesLineTargets(line, discount, _nodeService))
+            .ToArray();
 
         var messages = new List<string>();
-        var applied = IsOrderDiscountApplicable(orderInfo, discount);
+        var orderDiscountConstraintsMet = DiscountApplicability.AreOrderConstraintsMet(orderInfo, discount);
 
-        if (applied)
+        if (orderDiscountConstraintsMet)
         {
             orderInfo.Discount = new OrderedDiscount(discount);
             orderInfo.Coupon = couponCode;
@@ -74,24 +80,31 @@ public sealed class OrderDiscountCalculationService : IOrderDiscountCalculationS
             var lineTotalBeforeDiscount = beforeTotals[index];
             var lineTotalAfterDiscount = amount.Value;
             var discountAmount = lineTotalBeforeDiscount - lineTotalAfterDiscount;
+            var discountApplied = line.Discount?.Key == discount.Key;
 
             lineResults.Add(new OrderDiscountCalculationLineResult
             {
                 Sku = line.Product.SKU,
                 VariantSku = line.Variant?.SKU,
                 Quantity = line.Quantity,
+                CouponApplicable = orderDiscountConstraintsMet && couponLineTargets[index],
                 UnitPriceBeforeDiscount = line.Quantity == 0 ? 0 : lineTotalBeforeDiscount / line.Quantity,
                 LineTotalBeforeDiscount = lineTotalBeforeDiscount,
                 DiscountAmount = discountAmount,
                 LineTotalAfterDiscount = lineTotalAfterDiscount,
                 Vat = amount.Vat.Value,
-                DiscountApplied = line.Discount?.Key == discount.Key,
+                DiscountApplied = discountApplied,
             });
         }
 
+        var hasApplicableLines = lineResults.Any(line => line.CouponApplicable);
+        var hasAppliedLines = lineResults.Any(line => line.DiscountApplied);
+
         return new OrderDiscountCalculationResult
         {
-            Applied = applied && lineResults.Any(line => line.DiscountApplied),
+            Applied = orderDiscountConstraintsMet && hasAppliedLines,
+            OrderConstraintsMet = orderDiscountConstraintsMet,
+            HasApplicableLines = hasApplicableLines,
             CouponCode = couponCode,
             DiscountId = discount.Key,
             DiscountTitle = discount.Title,
@@ -221,23 +234,4 @@ public sealed class OrderDiscountCalculationService : IOrderDiscountCalculationS
         return variant;
     }
 
-    private static bool IsOrderDiscountApplicable(IOrderInfo orderInfo, IDiscount discount)
-    {
-        if (discount is IProductDiscount)
-        {
-            return false;
-        }
-
-        if (discount.Constraints == null)
-        {
-            return true;
-        }
-
-        if (!discount.GlobalDiscount && !discount.DiscountItems.Any())
-        {
-            return false;
-        }
-
-        return discount.Constraints.IsValid(orderInfo.StoreInfo.Culture, orderInfo.OrderLineTotal.Value);
-    }
 }

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.Discounts.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.Discounts.cs
@@ -763,22 +763,13 @@ partial class OrderService
     /// <returns></returns>
     private bool IsDiscountApplicable(IOrderInfo orderInfo, IDiscount discount)
     {
-        // Constraints is set to null if there are no constraints
-        if (discount.Constraints == null)
-        {
-            return true;
-        }
-        if (!discount.GlobalDiscount && !discount.DiscountItems.Any())
-        {
-            return false;
-        }
-
-        return discount.Constraints.IsValid(orderInfo.StoreInfo.Culture, orderInfo.OrderLineTotal.Value);
+        return DiscountApplicability.AreOrderConstraintsMet(orderInfo, discount)
+            && orderInfo.OrderLines.Any(line => DiscountApplicability.MatchesLineTargets(line, discount));
     }
 
 
     /// <summary>
-    /// Do constraints hold and do discount items match if any
+    /// Do constraints hold and do discount targets match the order line.
     /// </summary>
     /// <param name="orderInfo"></param>
     /// <param name="orderLine"></param>
@@ -786,54 +777,7 @@ partial class OrderService
     /// <returns></returns>
     public static bool IsDiscountApplicable(IOrderInfo orderInfo, IOrderLine orderLine, IDiscount discount)
     {
-        // Constraints is set to null if there are no constraints
-        if (discount.Constraints == null)
-        {
-            return true;
-        }
-        if (!discount.Stackable && orderLine.Product.ProductDiscount != null)
-        {
-            return false;
-        }
-
-
-        var constraintsOk = discount.Constraints.IsValid(
-            orderInfo.StoreInfo.Culture,
-            orderInfo.OrderLineTotal.Value
-        );
-
-        // Collect path items
-        var pathItems = string.IsNullOrWhiteSpace(orderLine.Product.Path)
-            ? Array.Empty<string>()
-            : orderLine.Product.Path.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        // Collect category IDs (mapped via INodeService)
-        using var scope = Configuration.Resolver.GetRequiredService<IServiceScopeFactory>().CreateScope();
-        var nodeSvc = scope.ServiceProvider.GetRequiredService<INodeService>();
-        var categoryIds = ((orderLine.Product.Properties.GetPropertyValue("categories") as string) ?? string.Empty)
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(x => nodeSvc.NodeById(x)?.Id.ToString())
-            .Where(id => !string.IsNullOrEmpty(id))
-            .ToArray();
-
-
-        var includeSet = new HashSet<string>(discount.DiscountItems ?? Enumerable.Empty<string>(),
-            StringComparer.OrdinalIgnoreCase);
-        var excludeSet = new HashSet<string>(discount.ExcludeDiscountItems ?? Enumerable.Empty<string>(),
-            StringComparer.OrdinalIgnoreCase);
-
-        // Matches include rules (empty include == match all)
-        bool matchesInclude =
-            includeSet.Count == 0 ||
-            pathItems.Any(includeSet.Contains) ||
-            categoryIds.Any(includeSet.Contains);
-
-        // Matches exclusion
-        bool matchesExclude =
-            excludeSet.Count > 0 &&
-            (pathItems.Any(excludeSet.Contains) || categoryIds.Any(excludeSet.Contains));
-
-        return constraintsOk && matchesInclude && !matchesExclude;
+        return DiscountApplicability.IsDiscountApplicable(orderInfo, orderLine, discount);
     }
 
     public async Task InsertCouponCodeAsync(string couponCode, int numberAvailable, Guid discountId, CancellationToken ct = default)


### PR DESCRIPTION
## Summary
- Extend coupon calculation responses with order constraint and line applicability details.
- Centralize discount applicability checks for constraints, include targets, exclude targets, and stackability.
- Reuse applicability logic when applying order discounts and calculating line totals.

## Testing
- Not run (PR creation only).