### PR TITLE
feat(tracking): add checkout tracking events

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Events/OrderEvents.cs
+++ b/Ekom/Ekom.Core/Ekom/Events/OrderEvents.cs
@@ -107,6 +107,11 @@ public static class OrderEvents
     public static Task OnAddedOrderlineAsync(object sender, AddedOrderlineEventArgs args, CancellationToken ct = default)
         => AsyncEventInvoker.InvokeAsync(AddedOrderlineAsync, sender, args, ct);
 
+    public static event Func<object, RemovedOrderlineEventArgs, CancellationToken, Task>? RemovedOrderlineAsync;
+
+    public static Task OnRemovedOrderlineAsync(object sender, RemovedOrderlineEventArgs args, CancellationToken ct = default)
+        => AsyncEventInvoker.InvokeAsync(RemovedOrderlineAsync, sender, args, ct);
+
     public static event EventHandler<UpdatedOrderlineEventArgs>? UpdatedOrderline;
 
     internal static void OnUpdatedOrderline(object sender, UpdatedOrderlineEventArgs args)
@@ -116,6 +121,16 @@ public static class OrderEvents
 
     public static Task OnUpdatedOrderlineAsync(object sender, UpdatedOrderlineEventArgs args, CancellationToken ct = default)
         => AsyncEventInvoker.InvokeAsync(UpdatedOrderlineAsync, sender, args, ct);
+
+    public static event Func<object, ShippingProviderAddedEventArgs, CancellationToken, Task>? ShippingProviderAddedAsync;
+
+    public static Task OnShippingProviderAddedAsync(object sender, ShippingProviderAddedEventArgs args, CancellationToken ct = default)
+        => AsyncEventInvoker.InvokeAsync(ShippingProviderAddedAsync, sender, args, ct);
+
+    public static event Func<object, PaymentProviderAddedEventArgs, CancellationToken, Task>? PaymentProviderAddedAsync;
+
+    public static Task OnPaymentProviderAddedAsync(object sender, PaymentProviderAddedEventArgs args, CancellationToken ct = default)
+        => AsyncEventInvoker.InvokeAsync(PaymentProviderAddedAsync, sender, args, ct);
 }
 
 /// <summary>For changing and changed <see cref="OrderStatus"/> events</summary>
@@ -172,7 +187,23 @@ public sealed class AddedOrderlineEventArgs : EventArgs
     public required OrderLine OrderLine { get; set; }
 }
 
+public sealed class RemovedOrderlineEventArgs : EventArgs
+{
+    public required OrderInfo OrderInfo { get; set; }
+    public required OrderLine OrderLine { get; set; }
+}
+
 public sealed class UpdatedOrderlineEventArgs : EventArgs
+{
+    public required OrderInfo OrderInfo { get; set; }
+}
+
+public sealed class ShippingProviderAddedEventArgs : EventArgs
+{
+    public required OrderInfo OrderInfo { get; set; }
+}
+
+public sealed class PaymentProviderAddedEventArgs : EventArgs
 {
     public required OrderInfo OrderInfo { get; set; }
 }

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -869,11 +869,11 @@ partial class OrderService
         }
         try
         {
-            IOrderLine? orderLine = orderInfo.OrderLines.FirstOrDefault(x => x.Key == lineId);
+            OrderLine? orderLine = orderInfo.OrderLines.FirstOrDefault(x => x.Key == lineId) as OrderLine;
 
             if (orderLine != null)
             {
-                RemoveOrderLine(orderInfo, orderLine as OrderLine);
+                RemoveOrderLine(orderInfo, orderLine);
             }
             else
             {
@@ -889,6 +889,11 @@ partial class OrderService
             {
                 OrderEvents.OnUpdatedOrderline(this, updatedEventArgs);
                 await OrderEvents.OnUpdatedOrderlineAsync(this, updatedEventArgs, ct);
+                await OrderEvents.OnRemovedOrderlineAsync(this, new RemovedOrderlineEventArgs
+                {
+                    OrderInfo = orderInfo,
+                    OrderLine = orderLine
+                }, ct);
             }
 
             return await UpdateOrderAndOrderInfoAsync(updatedEventArgs.OrderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
@@ -1815,6 +1820,14 @@ partial class OrderService
                         logType: OrderActivityLogType.Info,
                         ct: ct)
                     .ConfigureAwait(false);
+
+                if (settings.FireEvents)
+                {
+                    await OrderEvents.OnShippingProviderAddedAsync(this, new ShippingProviderAddedEventArgs
+                    {
+                        OrderInfo = updatedOrderInfo
+                    }, ct);
+                }
             }
 
             return updatedOrderInfo;
@@ -1890,6 +1903,14 @@ partial class OrderService
                         logType: OrderActivityLogType.Info,
                         ct: ct)
                     .ConfigureAwait(false);
+
+                if (settings.FireEvents)
+                {
+                    await OrderEvents.OnPaymentProviderAddedAsync(this, new PaymentProviderAddedEventArgs
+                    {
+                        OrderInfo = updatedOrderInfo
+                    }, ct);
+                }
             }
 
             return updatedOrderInfo;

--- a/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
@@ -53,10 +53,39 @@ public sealed class Ga4TrackingService : IGa4TrackingService
         return request;
     }
 
+    public Ga4PurchaseRequest CreateRemovedFromCartRequest(IOrderInfo orderInfo, IOrderLine orderLine)
+    {
+        var request = CreateRequest(orderInfo, "remove_from_cart");
+        request.Value = orderLine.Amount.WithoutVat.Value * orderLine.Quantity;
+        request.Items = [CreateItem(orderLine, orderInfo.StoreInfo.Alias)];
+
+        return request;
+    }
+
     public Ga4PurchaseRequest CreateStartedCheckoutRequest(IOrderInfo orderInfo)
     {
         var request = CreateRequest(orderInfo, "begin_checkout");
         request.Value = orderInfo.ChargedAmount.Value;
+        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
+
+        return request;
+    }
+
+    public Ga4PurchaseRequest CreateAddedShippingInfoRequest(IOrderInfo orderInfo)
+    {
+        var request = CreateRequest(orderInfo, "add_shipping_info");
+        request.Value = orderInfo.ChargedAmount.Value;
+        request.ShippingTier = orderInfo.ShippingProvider?.Title;
+        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
+
+        return request;
+    }
+
+    public Ga4PurchaseRequest CreateAddedPaymentInfoRequest(IOrderInfo orderInfo)
+    {
+        var request = CreateRequest(orderInfo, "add_payment_info");
+        request.Value = orderInfo.ChargedAmount.Value;
+        request.PaymentType = orderInfo.PaymentProvider?.Title;
         request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
 
         return request;
@@ -207,7 +236,17 @@ public sealed class Ga4TrackingService : IGa4TrackingService
             parameters["transaction_id"] = request.TransactionId;
             parameters["shipping"] = request.Shipping;
             parameters["tax"] = request.Tax;
+        }
+
+        if (string.Equals(request.EventName, "purchase", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(request.EventName, "add_payment_info", StringComparison.OrdinalIgnoreCase))
+        {
             parameters["payment_type"] = request.PaymentType;
+        }
+
+        if (string.Equals(request.EventName, "purchase", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(request.EventName, "add_shipping_info", StringComparison.OrdinalIgnoreCase))
+        {
             parameters["shipping_tier"] = request.ShippingTier;
         }
 

--- a/Ekom/Ekom.Core/Ekom/Tracking/IGa4TrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/IGa4TrackingService.cs
@@ -6,6 +6,9 @@ public interface IGa4TrackingService
 {
     Ga4PurchaseRequest CreatePurchaseRequest(IOrderInfo orderInfo);
     Ga4PurchaseRequest CreateAddedToCartRequest(IOrderInfo orderInfo, IOrderLine orderLine);
+    Ga4PurchaseRequest CreateRemovedFromCartRequest(IOrderInfo orderInfo, IOrderLine orderLine);
     Ga4PurchaseRequest CreateStartedCheckoutRequest(IOrderInfo orderInfo);
+    Ga4PurchaseRequest CreateAddedShippingInfoRequest(IOrderInfo orderInfo);
+    Ga4PurchaseRequest CreateAddedPaymentInfoRequest(IOrderInfo orderInfo);
     Task SendPurchaseAsync(Ga4PurchaseRequest request, CancellationToken ct = default);
 }

--- a/Ekom/Ekom.Core/Ekom/Tracking/IMetaTrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/IMetaTrackingService.cs
@@ -6,6 +6,9 @@ public interface IMetaTrackingService
 {
     MetaPurchaseRequest CreatePurchaseRequest(IOrderInfo orderInfo);
     MetaPurchaseRequest CreateAddedToCartRequest(IOrderInfo orderInfo, IOrderLine orderLine);
+    MetaPurchaseRequest CreateRemovedFromCartRequest(IOrderInfo orderInfo, IOrderLine orderLine);
     MetaPurchaseRequest CreateStartedCheckoutRequest(IOrderInfo orderInfo);
+    MetaPurchaseRequest CreateAddedShippingInfoRequest(IOrderInfo orderInfo);
+    MetaPurchaseRequest CreateAddedPaymentInfoRequest(IOrderInfo orderInfo);
     Task SendPurchaseAsync(MetaPurchaseRequest request, CancellationToken ct = default);
 }

--- a/Ekom/Ekom.Core/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/MetaTrackingService.cs
@@ -50,9 +50,36 @@ public sealed class MetaTrackingService : IMetaTrackingService
         return request;
     }
 
+    public MetaPurchaseRequest CreateRemovedFromCartRequest(IOrderInfo orderInfo, IOrderLine orderLine)
+    {
+        var request = CreateRequest(orderInfo, "RemoveFromCart", $"{orderInfo.OrderNumber}:{orderLine.Key}:remove_from_cart");
+        request.Value = orderLine.Amount.WithVat.Value * orderLine.Quantity;
+        request.Contents = [CreateContent(orderLine)];
+
+        return request;
+    }
+
     public MetaPurchaseRequest CreateStartedCheckoutRequest(IOrderInfo orderInfo)
     {
         var request = CreateRequest(orderInfo, "InitiateCheckout", $"{orderInfo.OrderNumber}:initiate_checkout");
+        request.Value = orderInfo.ChargedAmount.Value;
+        request.Contents = orderInfo.OrderLines.Select(CreateContent).ToList();
+
+        return request;
+    }
+
+    public MetaPurchaseRequest CreateAddedShippingInfoRequest(IOrderInfo orderInfo)
+    {
+        var request = CreateRequest(orderInfo, "AddShippingInfo", $"{orderInfo.OrderNumber}:add_shipping_info:{orderInfo.ShippingProvider?.Key}");
+        request.Value = orderInfo.ChargedAmount.Value;
+        request.Contents = orderInfo.OrderLines.Select(CreateContent).ToList();
+
+        return request;
+    }
+
+    public MetaPurchaseRequest CreateAddedPaymentInfoRequest(IOrderInfo orderInfo)
+    {
+        var request = CreateRequest(orderInfo, "AddPaymentInfo", $"{orderInfo.OrderNumber}:add_payment_info:{orderInfo.PaymentProvider?.Key}");
         request.Value = orderInfo.ChargedAmount.Value;
         request.Contents = orderInfo.OrderLines.Select(CreateContent).ToList();
 

--- a/Ekom/Ekom.Core/Ekom/Tracking/TrackingOptions.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/TrackingOptions.cs
@@ -53,7 +53,10 @@ public sealed class Ga4TrackingProviderOptions : TrackingProviderOptions
 public sealed class Ga4TrackingEventsOptions
 {
     public bool AddedToCart { get; set; }
+    public bool RemovedFromCart { get; set; }
     public bool StartedCheckout { get; set; }
+    public bool AddedShippingInfo { get; set; }
+    public bool AddedPaymentInfo { get; set; }
 }
 
 public sealed class MetaTrackingProviderOptions : TrackingProviderOptions
@@ -64,7 +67,10 @@ public sealed class MetaTrackingProviderOptions : TrackingProviderOptions
 public sealed class MetaTrackingEventsOptions
 {
     public bool AddedToCart { get; set; }
+    public bool RemovedFromCart { get; set; }
     public bool StartedCheckout { get; set; }
+    public bool AddedShippingInfo { get; set; }
+    public bool AddedPaymentInfo { get; set; }
 }
 
 public sealed class TrackingDispatchOptions

--- a/Ekom/Ekom.Umbraco/Ekom.U10/TrackingAutomationEvents.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/TrackingAutomationEvents.cs
@@ -24,8 +24,14 @@ internal sealed class TrackingAutomationEvents : IComponent
         CheckoutEvents.CompleteCheckoutAsync += OnCompleteCheckoutAsync;
         OrderEvents.AddedOrderlineAsync += OnAddedOrderlineAsync;
         OrderEvents.AddedOrderlineAsync += OnAddedOrderlineMetaAsync;
+        OrderEvents.RemovedOrderlineAsync += OnRemovedOrderlineAsync;
+        OrderEvents.RemovedOrderlineAsync += OnRemovedOrderlineMetaAsync;
         OrderEvents.CustomerEmailAddedAsync += OnCustomerEmailAddedAsync;
         OrderEvents.CustomerEmailAddedAsync += OnCustomerEmailAddedMetaAsync;
+        OrderEvents.ShippingProviderAddedAsync += OnShippingProviderAddedAsync;
+        OrderEvents.ShippingProviderAddedAsync += OnShippingProviderAddedMetaAsync;
+        OrderEvents.PaymentProviderAddedAsync += OnPaymentProviderAddedAsync;
+        OrderEvents.PaymentProviderAddedAsync += OnPaymentProviderAddedMetaAsync;
     }
 
     public void Terminate()
@@ -33,8 +39,14 @@ internal sealed class TrackingAutomationEvents : IComponent
         CheckoutEvents.CompleteCheckoutAsync -= OnCompleteCheckoutAsync;
         OrderEvents.AddedOrderlineAsync -= OnAddedOrderlineAsync;
         OrderEvents.AddedOrderlineAsync -= OnAddedOrderlineMetaAsync;
+        OrderEvents.RemovedOrderlineAsync -= OnRemovedOrderlineAsync;
+        OrderEvents.RemovedOrderlineAsync -= OnRemovedOrderlineMetaAsync;
         OrderEvents.CustomerEmailAddedAsync -= OnCustomerEmailAddedAsync;
         OrderEvents.CustomerEmailAddedAsync -= OnCustomerEmailAddedMetaAsync;
+        OrderEvents.ShippingProviderAddedAsync -= OnShippingProviderAddedAsync;
+        OrderEvents.ShippingProviderAddedAsync -= OnShippingProviderAddedMetaAsync;
+        OrderEvents.PaymentProviderAddedAsync -= OnPaymentProviderAddedAsync;
+        OrderEvents.PaymentProviderAddedAsync -= OnPaymentProviderAddedMetaAsync;
     }
 
     private async Task OnAddedOrderlineAsync(object sender, AddedOrderlineEventArgs args, CancellationToken ct)
@@ -67,6 +79,36 @@ internal sealed class TrackingAutomationEvents : IComponent
         await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
     }
 
+    private async Task OnRemovedOrderlineAsync(object sender, RemovedOrderlineEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.RemovedFromCart)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
+        var request = ga4Service.CreateRemovedFromCartRequest(args.OrderInfo, args.OrderLine);
+        request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IGa4TrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private async Task OnRemovedOrderlineMetaAsync(object sender, RemovedOrderlineEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Meta.Enabled || !_options.Meta.Events.RemovedFromCart)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
+        var request = metaService.CreateRemovedFromCartRequest(args.OrderInfo, args.OrderLine);
+        request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
+    }
+
     private async Task OnCustomerEmailAddedAsync(object sender, CustomerEmailAddedEventArgs args, CancellationToken ct)
     {
         if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.StartedCheckout)
@@ -91,6 +133,66 @@ internal sealed class TrackingAutomationEvents : IComponent
         var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
         var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
         var request = metaService.CreateStartedCheckoutRequest(args.OrderInfo);
+        request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private async Task OnShippingProviderAddedAsync(object sender, ShippingProviderAddedEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.AddedShippingInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
+        var request = ga4Service.CreateAddedShippingInfoRequest(args.OrderInfo);
+        request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IGa4TrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private async Task OnShippingProviderAddedMetaAsync(object sender, ShippingProviderAddedEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Meta.Enabled || !_options.Meta.Events.AddedShippingInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
+        var request = metaService.CreateAddedShippingInfoRequest(args.OrderInfo);
+        request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private async Task OnPaymentProviderAddedAsync(object sender, PaymentProviderAddedEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.AddedPaymentInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
+        var request = ga4Service.CreateAddedPaymentInfoRequest(args.OrderInfo);
+        request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IGa4TrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, ct).ConfigureAwait(false);
+    }
+
+    private async Task OnPaymentProviderAddedMetaAsync(object sender, PaymentProviderAddedEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Meta.Enabled || !_options.Meta.Events.AddedPaymentInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
+        var request = metaService.CreateAddedPaymentInfoRequest(args.OrderInfo);
         request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
 
         var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/TrackingAutomationEvents.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/TrackingAutomationEvents.cs
@@ -23,8 +23,14 @@ internal sealed class TrackingAutomationEvents : IComponent
         CheckoutEvents.CompleteCheckoutAsync += OnCompleteCheckoutAsync;
         OrderEvents.AddedOrderlineAsync += OnAddedOrderlineAsync;
         OrderEvents.AddedOrderlineAsync += OnAddedOrderlineMetaAsync;
+        OrderEvents.RemovedOrderlineAsync += OnRemovedOrderlineAsync;
+        OrderEvents.RemovedOrderlineAsync += OnRemovedOrderlineMetaAsync;
         OrderEvents.CustomerEmailAddedAsync += OnCustomerEmailAddedAsync;
         OrderEvents.CustomerEmailAddedAsync += OnCustomerEmailAddedMetaAsync;
+        OrderEvents.ShippingProviderAddedAsync += OnShippingProviderAddedAsync;
+        OrderEvents.ShippingProviderAddedAsync += OnShippingProviderAddedMetaAsync;
+        OrderEvents.PaymentProviderAddedAsync += OnPaymentProviderAddedAsync;
+        OrderEvents.PaymentProviderAddedAsync += OnPaymentProviderAddedMetaAsync;
     }
 
     public void Terminate()
@@ -32,8 +38,14 @@ internal sealed class TrackingAutomationEvents : IComponent
         CheckoutEvents.CompleteCheckoutAsync -= OnCompleteCheckoutAsync;
         OrderEvents.AddedOrderlineAsync -= OnAddedOrderlineAsync;
         OrderEvents.AddedOrderlineAsync -= OnAddedOrderlineMetaAsync;
+        OrderEvents.RemovedOrderlineAsync -= OnRemovedOrderlineAsync;
+        OrderEvents.RemovedOrderlineAsync -= OnRemovedOrderlineMetaAsync;
         OrderEvents.CustomerEmailAddedAsync -= OnCustomerEmailAddedAsync;
         OrderEvents.CustomerEmailAddedAsync -= OnCustomerEmailAddedMetaAsync;
+        OrderEvents.ShippingProviderAddedAsync -= OnShippingProviderAddedAsync;
+        OrderEvents.ShippingProviderAddedAsync -= OnShippingProviderAddedMetaAsync;
+        OrderEvents.PaymentProviderAddedAsync -= OnPaymentProviderAddedAsync;
+        OrderEvents.PaymentProviderAddedAsync -= OnPaymentProviderAddedMetaAsync;
     }
 
     private async Task OnAddedOrderlineAsync(object sender, AddedOrderlineEventArgs args, CancellationToken cancellationToken)
@@ -66,6 +78,36 @@ internal sealed class TrackingAutomationEvents : IComponent
         await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
+    private async Task OnRemovedOrderlineAsync(object sender, RemovedOrderlineEventArgs args, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.RemovedFromCart)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
+        var request = ga4Service.CreateRemovedFromCartRequest(args.OrderInfo, args.OrderLine);
+        request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IGa4TrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task OnRemovedOrderlineMetaAsync(object sender, RemovedOrderlineEventArgs args, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || !_options.Meta.Enabled || !_options.Meta.Events.RemovedFromCart)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
+        var request = metaService.CreateRemovedFromCartRequest(args.OrderInfo, args.OrderLine);
+        request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
     private async Task OnCustomerEmailAddedAsync(object sender, CustomerEmailAddedEventArgs args, CancellationToken cancellationToken)
     {
         if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.StartedCheckout)
@@ -90,6 +132,66 @@ internal sealed class TrackingAutomationEvents : IComponent
         var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
         var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
         var request = metaService.CreateStartedCheckoutRequest(args.OrderInfo);
+        request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task OnShippingProviderAddedAsync(object sender, ShippingProviderAddedEventArgs args, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.AddedShippingInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
+        var request = ga4Service.CreateAddedShippingInfoRequest(args.OrderInfo);
+        request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IGa4TrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task OnShippingProviderAddedMetaAsync(object sender, ShippingProviderAddedEventArgs args, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || !_options.Meta.Enabled || !_options.Meta.Events.AddedShippingInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
+        var request = metaService.CreateAddedShippingInfoRequest(args.OrderInfo);
+        request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task OnPaymentProviderAddedAsync(object sender, PaymentProviderAddedEventArgs args, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || !_options.Ga4.Enabled || !_options.Ga4.Events.AddedPaymentInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var ga4Service = scope.ServiceProvider.GetRequiredService<IGa4TrackingService>();
+        var request = ga4Service.CreateAddedPaymentInfoRequest(args.OrderInfo);
+        request.HasAnalyticsConsent = consentService.CanCaptureAnalytics(args.OrderInfo.Consent);
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IGa4TrackingDispatcher>();
+        await dispatcher.EnqueueAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task OnPaymentProviderAddedMetaAsync(object sender, PaymentProviderAddedEventArgs args, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || !_options.Meta.Enabled || !_options.Meta.Events.AddedPaymentInfo)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var consentService = scope.ServiceProvider.GetRequiredService<ITrackingConsentService>();
+        var metaService = scope.ServiceProvider.GetRequiredService<IMetaTrackingService>();
+        var request = metaService.CreateAddedPaymentInfoRequest(args.OrderInfo);
         request.HasMarketingConsent = consentService.CanCaptureMarketing(args.OrderInfo.Consent);
 
         var dispatcher = scope.ServiceProvider.GetRequiredService<IMetaTrackingDispatcher>();

--- a/Ekom/Tests/Ekom.Tests/Tests/Ga4TrackingServiceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/Ga4TrackingServiceTests.cs
@@ -71,7 +71,65 @@ public sealed class Ga4TrackingServiceTests
         var options = new TrackingOptions();
 
         Assert.False(options.Ga4.Events.AddedToCart);
+        Assert.False(options.Ga4.Events.RemovedFromCart);
         Assert.False(options.Ga4.Events.StartedCheckout);
+        Assert.False(options.Ga4.Events.AddedShippingInfo);
+        Assert.False(options.Ga4.Events.AddedPaymentInfo);
+    }
+
+    [Theory]
+    [InlineData("add_shipping_info", "shipping_tier", "Delivery")]
+    [InlineData("add_payment_info", "payment_type", "Card")]
+    public async Task SendPurchaseAsync_CheckoutEvent_IncludesSelectedProvider(string eventName, string parameterName, string parameterValue)
+    {
+        using var handler = new RecordingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+        var sut = new Ga4TrackingService(
+            new StaticHttpClientFactory(httpClient),
+            Options.Create(new TrackingOptions
+            {
+                Ga4 = new Ga4TrackingProviderOptions
+                {
+                    Stores =
+                    [
+                        new TrackingStoreOptions
+                        {
+                            Alias = "Store",
+                            MeasurementId = "G-XXXXXXXXXX",
+                            ApiSecret = "api-secret",
+                        },
+                    ],
+                },
+            }),
+            new ThrowingServiceScopeFactory(),
+            NullLogger<Ga4TrackingService>.Instance);
+
+        await sut.SendPurchaseAsync(new Ga4PurchaseRequest
+        {
+            StoreAlias = "Store",
+            ClientId = "123.456",
+            EventName = eventName,
+            Value = 10,
+            Currency = "ISK",
+            ShippingTier = eventName == "add_shipping_info" ? parameterValue : null,
+            PaymentType = eventName == "add_payment_info" ? parameterValue : null,
+            Items =
+            [
+                new Ga4PurchaseItem
+                {
+                    ItemId = "SKU-1",
+                    ItemName = "Product",
+                    Price = 10,
+                    Quantity = 1,
+                },
+            ],
+        });
+
+        using var document = JsonDocument.Parse(handler.Payload);
+        var parameters = document.RootElement.GetProperty("events")[0].GetProperty("params");
+
+        Assert.Equal(parameterValue, parameters.GetProperty(parameterName).GetString());
+        Assert.False(parameters.TryGetProperty("transaction_id", out _));
     }
 
     private sealed class StaticHttpClientFactory(HttpClient client) : IHttpClientFactory

--- a/Ekom/Tests/Ekom.Tests/Tests/MetaTrackingServiceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/MetaTrackingServiceTests.cs
@@ -16,7 +16,10 @@ public sealed class MetaTrackingServiceTests
         var options = new TrackingOptions();
 
         Assert.False(options.Meta.Events.AddedToCart);
+        Assert.False(options.Meta.Events.RemovedFromCart);
         Assert.False(options.Meta.Events.StartedCheckout);
+        Assert.False(options.Meta.Events.AddedShippingInfo);
+        Assert.False(options.Meta.Events.AddedPaymentInfo);
     }
 
     [Fact]

--- a/README.md
+++ b/README.md
@@ -273,7 +273,10 @@ Full tracking config example:
     "Testing": false,
     "Events": {
       "AddedToCart": false,
-      "StartedCheckout": false
+      "RemovedFromCart": false,
+      "StartedCheckout": false,
+      "AddedShippingInfo": false,
+      "AddedPaymentInfo": false
     },
     "Dispatching": {
       "Capacity": 1000,
@@ -292,7 +295,10 @@ Full tracking config example:
     "Testing": false,
     "Events": {
       "AddedToCart": false,
-      "StartedCheckout": false
+      "RemovedFromCart": false,
+      "StartedCheckout": false,
+      "AddedShippingInfo": false,
+      "AddedPaymentInfo": false
     },
     "Dispatching": {
       "Capacity": 1000,
@@ -313,9 +319,9 @@ Full tracking config example:
 Notes:
 
 - `Ga4:Stores[*]` uses `MeasurementId` and `ApiSecret` for Measurement Protocol purchase events.
-- `Ga4:Events:AddedToCart` and `Ga4:Events:StartedCheckout` enable `add_to_cart` and `begin_checkout` events. Both default to `false`.
+- `Ga4:Events:AddedToCart`, `Ga4:Events:RemovedFromCart`, `Ga4:Events:StartedCheckout`, `Ga4:Events:AddedShippingInfo`, and `Ga4:Events:AddedPaymentInfo` enable `add_to_cart`, `remove_from_cart`, `begin_checkout`, `add_shipping_info`, and `add_payment_info` events. All default to `false`.
 - `Meta:Stores[*]` uses `PixelId` and `AccessToken` for Conversion API purchase events.
-- `Meta:Events:AddedToCart` and `Meta:Events:StartedCheckout` enable `AddToCart` and `InitiateCheckout` events. Both default to `false`.
+- `Meta:Events:AddedToCart`, `Meta:Events:RemovedFromCart`, `Meta:Events:StartedCheckout`, `Meta:Events:AddedShippingInfo`, and `Meta:Events:AddedPaymentInfo` enable `AddToCart`, `RemoveFromCart`, `InitiateCheckout`, `AddShippingInfo`, and `AddPaymentInfo` events. All default to `false`.
 - `Ga4:Testing` sends events through the GA4 debug endpoint.
 - `Meta:Testing` uses `TestEventCode` when configured for the store.
 - `Dispatching:Capacity` and `Dispatching:MaxConcurrency` control the background queue used for provider dispatching.


### PR DESCRIPTION
## Summary
- add opt-in GA4 and Meta events for cart removal, shipping selection, and payment selection
- dispatch the new events for Umbraco 10 and 17 after successful order updates
- document configuration and cover event defaults and GA4 checkout payload parameters

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~Ga4TrackingServiceTests|FullyQualifiedName~MetaTrackingServiceTests"`
- `dotnet build "Ekom Build.sln" --no-restore`
