### PR TITLE
fix(tracking): remove GA4 client ID warning

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -1299,7 +1299,6 @@ partial class OrderService
     private async Task<OrderInfo> UpdateOrderAndOrderInfoAsync(
         OrderInfo orderInfo,
         bool fireOnOrderUpdatedEvents = true,
-        string? previousCustomerEmail = null,
         CancellationToken ct = default)
     {
         try
@@ -1394,20 +1393,6 @@ partial class OrderService
                 {
                     OrderInfo = orderInfo
                 }, ct);
-
-                var newCustomerEmail = orderInfo.CustomerInformation.Customer.Email;
-
-                if (string.IsNullOrWhiteSpace(previousCustomerEmail)
-                    && !string.IsNullOrWhiteSpace(newCustomerEmail))
-                {
-
-                    await OrderEvents.OnCustomerEmailAddedAsync(this, new CustomerEmailAddedEventArgs
-                    {
-                        OrderInfo = orderInfo,
-                        PreviousCustomerEmail = previousCustomerEmail,
-                        NewCustomerEmail = newCustomerEmail
-                    }, ct);
-                }
             }
 
             return orderInfo;
@@ -1700,8 +1685,21 @@ partial class OrderService
             }
         }
 
-        orderInfo = await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, previousCustomerEmail: previousCustomerEmail, ct: ct)
+        orderInfo = await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct: ct)
             .ConfigureAwait(false);
+
+        var newCustomerEmail = orderInfo.CustomerInformation.Customer.Email;
+        if (settings.FireOnOrderUpdatedEvent
+            && string.IsNullOrWhiteSpace(previousCustomerEmail)
+            && !string.IsNullOrWhiteSpace(newCustomerEmail))
+        {
+            await OrderEvents.OnCustomerEmailAddedAsync(this, new CustomerEmailAddedEventArgs
+            {
+                OrderInfo = orderInfo,
+                PreviousCustomerEmail = previousCustomerEmail,
+                NewCustomerEmail = newCustomerEmail
+            }, ct);
+        }
 
         if (settings.FireEvents)
         {

--- a/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
@@ -66,11 +66,10 @@ public sealed class Ga4TrackingService : IGa4TrackingService
     {
         var tracking = orderInfo.Tracking ?? new OrderTracking();
         var clientId = tracking.Ga4.ClientId;
-        var generatedClientId = false;
+
         if (string.IsNullOrWhiteSpace(clientId))
         {
             clientId = GenerateClientId();
-            generatedClientId = true;
         }
 
         var sessionId = ParseLong(tracking.Ga4.SessionId);
@@ -95,11 +94,6 @@ public sealed class Ga4TrackingService : IGa4TrackingService
             Gclid = string.Equals(tracking.ClickIdType, "gclid", StringComparison.OrdinalIgnoreCase) ? tracking.ClickId : null,
             Parameters = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
         };
-
-        if (generatedClientId)
-        {
-            _logger.LogWarning("GA4 client_id missing for order {OrderNumber}. Generated fallback client_id for store {StoreAlias}.", orderInfo.OrderNumber, orderInfo.StoreInfo.Alias);
-        }
 
         foreach (var entry in tracking.Ga4.Data)
             request.Parameters[entry.Key] = entry.Value;


### PR DESCRIPTION
## Summary
- Remove the warning emitted when a GA4 client ID is absent.
- Retain fallback client ID generation for tracking requests.

## Test Plan
- Not run (logging-only change).