### PR TITLE
fix(tracking): improve multi-store analytics events

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Models/CurrencyModel.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/CurrencyModel.cs
@@ -20,6 +20,25 @@ public class CurrencyModel
             return TryGetRegionInfo()?.ISOCurrencySymbol ?? string.Empty;
         }
     }
+    public int CurrencyDecimalDigits
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(CurrencyValue))
+            {
+                return 2;
+            }
+
+            try
+            {
+                return CultureInfo.GetCultureInfo(CurrencyValue).NumberFormat.CurrencyDecimalDigits;
+            }
+            catch (CultureNotFoundException)
+            {
+                return 2;
+            }
+        }
+    }
 
     private RegionInfo? TryGetRegionInfo()
     {

--- a/Ekom/Ekom.Core/Ekom/Tracking/Ga4PurchaseRequest.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/Ga4PurchaseRequest.cs
@@ -5,10 +5,12 @@ public sealed class Ga4PurchaseRequest
     public Guid OrderUniqueId { get; set; }
     public string StoreAlias { get; set; } = string.Empty;
     public bool HasAnalyticsConsent { get; set; }
+    public bool HasCapturedSessionId { get; set; }
     public string? ClientId { get; set; }
     public long? SessionId { get; set; }
     public string EventName { get; set; } = "purchase";
     public string? TransactionId { get; set; }
+    public string? Coupon { get; set; }
     public decimal Value { get; set; }
     public decimal Shipping { get; set; }
     public decimal Tax { get; set; }
@@ -33,6 +35,7 @@ public sealed class Ga4PurchaseItem
     public string? ItemCategory2 { get; set; }
     public decimal Price { get; set; }
     public decimal Discount { get; set; }
-    public int Quantity { get; set; }
+    public decimal Quantity { get; set; }
     public string? ItemVariant { get; set; }
+    public string? Coupon { get; set; }
 }

--- a/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
@@ -5,6 +5,7 @@ using Ekom.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 
@@ -32,32 +33,41 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
     public Ga4PurchaseRequest CreatePurchaseRequest(IOrderInfo orderInfo)
     {
+        using var cultureScope = UseCulture(orderInfo.Culture);
+        var currencyDecimalDigits = orderInfo.StoreInfo.Currency.CurrencyDecimalDigits;
         var request = CreateRequest(orderInfo, "purchase");
         request.TransactionId = orderInfo.OrderNumber;
-        request.Value = orderInfo.ChargedAmount.Value;
-        request.Shipping = orderInfo.ShippingProvider?.Price.Value ?? 0;
-        request.Tax = orderInfo.Vat.Value;
+        request.Shipping = NormalizeAmount(orderInfo.ShippingProvider?.Price.WithoutVat.Value ?? 0, currencyDecimalDigits);
+        request.Tax = NormalizeAmount(orderInfo.Vat.Value, currencyDecimalDigits);
         request.PaymentType = orderInfo.PaymentProvider?.Title;
         request.ShippingTier = orderInfo.ShippingProvider?.Title;
-        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
+        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo, currencyDecimalDigits)).ToList();
+        request.Coupon = !string.IsNullOrWhiteSpace(orderInfo.Coupon) && request.Items.Any(item => string.Equals(item.Coupon, orderInfo.Coupon, StringComparison.Ordinal))
+            ? orderInfo.Coupon
+            : null;
+        request.Value = CalculateEventValue(request.Items, currencyDecimalDigits);
 
         return request;
     }
 
     public Ga4PurchaseRequest CreateAddedToCartRequest(IOrderInfo orderInfo, IOrderLine orderLine)
     {
+        using var cultureScope = UseCulture(orderInfo.Culture);
+        var currencyDecimalDigits = orderInfo.StoreInfo.Currency.CurrencyDecimalDigits;
         var request = CreateRequest(orderInfo, "add_to_cart");
-        request.Value = orderLine.Amount.WithoutVat.Value * orderLine.Quantity;
-        request.Items = [CreateItem(orderLine, orderInfo.StoreInfo.Alias)];
+        request.Items = [CreateItem(orderLine, orderInfo, currencyDecimalDigits)];
+        request.Value = CalculateEventValue(request.Items, currencyDecimalDigits);
 
         return request;
     }
 
     public Ga4PurchaseRequest CreateStartedCheckoutRequest(IOrderInfo orderInfo)
     {
+        using var cultureScope = UseCulture(orderInfo.Culture);
+        var currencyDecimalDigits = orderInfo.StoreInfo.Currency.CurrencyDecimalDigits;
         var request = CreateRequest(orderInfo, "begin_checkout");
-        request.Value = orderInfo.ChargedAmount.Value;
-        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
+        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo, currencyDecimalDigits)).ToList();
+        request.Value = CalculateEventValue(request.Items, currencyDecimalDigits);
 
         return request;
     }
@@ -74,6 +84,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
         }
 
         var sessionId = ParseLong(tracking.Ga4.SessionId);
+        var hasCapturedSessionId = sessionId.HasValue;
         if (!sessionId.HasValue)
         {
             sessionId = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -85,6 +96,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
             StoreAlias = orderInfo.StoreInfo.Alias,
             ClientId = clientId,
             SessionId = sessionId,
+            HasCapturedSessionId = hasCapturedSessionId,
             EventName = eventName,
             Currency = orderInfo.StoreInfo.Currency.ISOCurrencySymbol,
             Source = tracking.Source,
@@ -107,9 +119,11 @@ public sealed class Ga4TrackingService : IGa4TrackingService
         return request;
     }
 
-    private static Ga4PurchaseItem CreateItem(IOrderLine orderLine, string storeAlias)
+    private static Ga4PurchaseItem CreateItem(IOrderLine orderLine, IOrderInfo orderInfo, int currencyDecimalDigits)
     {
-        var catalogProduct = Catalog.Instance.GetProduct(orderLine.ProductKey, storeAlias);
+        var catalogProduct = Catalog.Instance.GetProduct(orderLine.ProductKey, orderInfo.StoreInfo.Alias);
+        var unitPrice = CalculateUnitPrice(orderLine.Amount.BeforeDiscountWithOutVat.Value, orderLine.Quantity, currencyDecimalDigits);
+        var discountedUnitPrice = CalculateUnitPrice(orderLine.Amount.AfterDiscountWithOutVat.Value, orderLine.Quantity, currencyDecimalDigits);
 
         return new Ga4PurchaseItem
         {
@@ -117,11 +131,76 @@ public sealed class Ga4TrackingService : IGa4TrackingService
             ItemName = orderLine.Product.Title,
             ItemCategory = catalogProduct?.Categories.FirstOrDefault()?.Title,
             ItemCategory2 = catalogProduct?.CategoryAncestors.LastOrDefault()?.Title,
-            Price = orderLine.Amount.WithoutVat.Value,
-            Discount = 0,
-            Quantity = Convert.ToInt32(orderLine.Quantity),
-            ItemVariant = orderLine.Variant?.Title
+            Price = unitPrice,
+            Discount = NormalizeAmount(unitPrice - discountedUnitPrice, currencyDecimalDigits),
+            Quantity = orderLine.Quantity,
+            ItemVariant = orderLine.Variant?.Title,
+            Coupon = ResolveCoupon(orderLine, orderInfo)
         };
+    }
+
+    private static string? ResolveCoupon(IOrderLine orderLine, IOrderInfo orderInfo)
+    {
+        if (orderLine.Discount != null && !string.IsNullOrWhiteSpace(orderLine.Coupon))
+        {
+            return orderLine.Coupon;
+        }
+
+        return orderInfo.Discount != null
+            && ReferenceEquals(orderLine.Discount, orderInfo.Discount)
+            && !string.IsNullOrWhiteSpace(orderInfo.Coupon)
+            ? orderInfo.Coupon
+            : null;
+    }
+
+    private static decimal CalculateUnitPrice(decimal lineAmount, decimal quantity, int currencyDecimalDigits)
+    {
+        if (quantity == 0)
+        {
+            return 0;
+        }
+
+        return NormalizeAmount(lineAmount / quantity, currencyDecimalDigits);
+    }
+
+    private static decimal CalculateEventValue(IEnumerable<Ga4PurchaseItem> items, int currencyDecimalDigits)
+        => NormalizeAmount(items.Sum(item => (item.Price - item.Discount) * item.Quantity), currencyDecimalDigits);
+
+    private static decimal NormalizeAmount(decimal amount, int currencyDecimalDigits)
+        => Math.Round(amount, currencyDecimalDigits, MidpointRounding.AwayFromZero);
+
+    private static IDisposable UseCulture(string culture)
+        => string.IsNullOrWhiteSpace(culture)
+            ? EmptyDisposable.Instance
+            : new CultureScope(new CultureInfo(culture));
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo _currentCulture;
+        private readonly CultureInfo _currentUICulture;
+
+        public CultureScope(CultureInfo culture)
+        {
+            _currentCulture = CultureInfo.CurrentCulture;
+            _currentUICulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+
+        public void Dispose()
+        {
+            CultureInfo.CurrentCulture = _currentCulture;
+            CultureInfo.CurrentUICulture = _currentUICulture;
+        }
+    }
+
+    private sealed class EmptyDisposable : IDisposable
+    {
+        public static readonly EmptyDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
     }
 
     public async Task SendPurchaseAsync(Ga4PurchaseRequest request, CancellationToken ct = default)
@@ -151,7 +230,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
         var endpoint = _options.Value.Ga4.Testing ? "debug/mp/collect" : "mp/collect";
         var url = $"https://www.google-analytics.com/{endpoint}?measurement_id={storeOptions.MeasurementId}&api_secret={storeOptions.ApiSecret}";
         var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
-        if (_options.Value.LogPurchaseEventData)
+        if (_options.Value.ShouldLogEventData(request.EventName))
         {
             _logger.LogInformation("GA4 {EventName} event payload for store {StoreAlias}: {Payload}", request.EventName, request.StoreAlias, payloadJson);
         }
@@ -183,11 +262,11 @@ public sealed class Ga4TrackingService : IGa4TrackingService
         {
             ["value"] = request.Value,
             ["currency"] = request.Currency,
-            ["source"] = request.Source,
-            ["medium"] = request.Medium,
-            ["campaign"] = request.Campaign,
-            ["term"] = request.Term,
-            ["content"] = request.Content,
+            ["campaign_source"] = request.Source,
+            ["campaign_medium"] = request.Medium,
+            ["campaign_name"] = request.Campaign,
+            ["campaign_term"] = request.Term,
+            ["campaign_content"] = request.Content,
             ["gclid"] = request.Gclid,
             ["items"] = request.Items.Select(item => new Dictionary<string, object?>
             {
@@ -198,13 +277,15 @@ public sealed class Ga4TrackingService : IGa4TrackingService
                 ["price"] = item.Price,
                 ["discount"] = item.Discount,
                 ["quantity"] = item.Quantity,
-                ["item_variant"] = item.ItemVariant
+                ["item_variant"] = item.ItemVariant,
+                ["coupon"] = item.Coupon
             }).Select(FilterNullValues).ToList()
         };
 
         if (string.Equals(request.EventName, "purchase", StringComparison.OrdinalIgnoreCase))
         {
             parameters["transaction_id"] = request.TransactionId;
+            parameters["coupon"] = request.Coupon;
             parameters["shipping"] = request.Shipping;
             parameters["tax"] = request.Tax;
             parameters["payment_type"] = request.PaymentType;
@@ -219,6 +300,9 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         foreach (var item in request.Parameters)
             parameters[item.Key] = item.Value;
+
+        if (request.HasAnalyticsConsent && request.HasCapturedSessionId)
+            parameters["engagement_time_msec"] = 1;
 
         return FilterNullValues(parameters);
     }
@@ -235,6 +319,7 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
         request.ClientId = GenerateClientId();
         request.SessionId = null;
+        request.HasCapturedSessionId = false;
         request.Parameters.Clear();
     }
 

--- a/Ekom/Ekom.Core/Ekom/Tracking/MetaTrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/MetaTrackingService.cs
@@ -130,7 +130,7 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
         var url = $"{storeOptions.PixelId}/events?access_token={storeOptions.AccessToken}";
         var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
-        if (_options.Value.LogPurchaseEventData)
+        if (_options.Value.ShouldLogEventData(request.EventName))
         {
             _logger.LogInformation("Meta {EventName} event payload for store {StoreAlias}: {Payload}", request.EventName, request.StoreAlias, payloadJson);
         }
@@ -204,7 +204,7 @@ public sealed class MetaTrackingService : IMetaTrackingService
 
     private string? BuildEventSourceUrl(IOrderInfo orderInfo, OrderTracking tracking)
     {
-        var baseUrl = tracking.LandingUrl ?? _options.Value.SiteBaseUrl;
+        var baseUrl = tracking.LandingUrl ?? ResolveSiteBaseUrl(orderInfo.StoreInfo.Alias);
         if (string.IsNullOrWhiteSpace(baseUrl))
             return null;
 
@@ -222,6 +222,15 @@ public sealed class MetaTrackingService : IMetaTrackingService
         return QueryHelpers.AddQueryString(
             baseUrl,
             query.Where(x => !string.IsNullOrWhiteSpace(x.Value)).ToDictionary(x => x.Key, x => x.Value!));
+    }
+
+    private string? ResolveSiteBaseUrl(string storeAlias)
+    {
+        var storeBaseUrl = _options.Value.Stores
+            .FirstOrDefault(x => string.Equals(x.Alias, storeAlias, StringComparison.OrdinalIgnoreCase))?
+            .SiteBaseUrl;
+
+        return string.IsNullOrWhiteSpace(storeBaseUrl) ? _options.Value.SiteBaseUrl : storeBaseUrl;
     }
 
     private TrackingStoreOptions? ResolveStore(string storeAlias)

--- a/Ekom/Ekom.Core/Ekom/Tracking/TrackingOptions.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/TrackingOptions.cs
@@ -6,13 +6,24 @@ public sealed class TrackingOptions
 {
     public bool Enabled { get; set; }
     public bool CaptureEnabled { get; set; } = true;
+    public bool LogEventData { get; set; }
     public bool LogPurchaseEventData { get; set; }
     public string CookieName { get; set; } = "EkomTracking";
     public double CookieLifetimeDays { get; set; } = 30;
     public string? SiteBaseUrl { get; set; }
+    public List<TrackingStoreUrlOptions> Stores { get; set; } = [];
     public TrackingConsentOptions Consent { get; set; } = new();
     public Ga4TrackingProviderOptions Ga4 { get; set; } = new();
     public MetaTrackingProviderOptions Meta { get; set; } = new();
+
+    public bool ShouldLogEventData(string eventName)
+        => LogEventData || (LogPurchaseEventData && string.Equals(eventName, "purchase", StringComparison.OrdinalIgnoreCase));
+}
+
+public sealed class TrackingStoreUrlOptions
+{
+    public string Alias { get; set; } = string.Empty;
+    public string? SiteBaseUrl { get; set; }
 }
 
 public class TrackingConsentOptions

--- a/Ekom/Tests/Ekom.Tests/Tests/Ga4TrackingServiceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/Ga4TrackingServiceTests.cs
@@ -3,7 +3,9 @@ using Ekom.Tracking;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using System.Net;
+using System.Reflection;
 using System.Text.Json;
 using Xunit;
 
@@ -40,9 +42,17 @@ public sealed class Ga4TrackingServiceTests
         {
             StoreAlias = "Store",
             ClientId = "123.456",
+            HasAnalyticsConsent = true,
+            HasCapturedSessionId = true,
+            SessionId = 123,
             EventName = "add_to_cart",
-            Value = 10,
+            Value = 12,
             Currency = "ISK",
+            Source = "Klaviyo",
+            Medium = "email",
+            Campaign = "spring-sale",
+            Term = "coffee",
+            Content = "newsletter",
             Items =
             [
                 new Ga4PurchaseItem
@@ -50,7 +60,9 @@ public sealed class Ga4TrackingServiceTests
                     ItemId = "SKU-1",
                     ItemName = "Product",
                     Price = 10,
-                    Quantity = 1,
+                    Discount = 2,
+                    Quantity = 1.5m,
+                    Coupon = "ITEM-COUPON"
                 },
             ],
         });
@@ -62,7 +74,64 @@ public sealed class Ga4TrackingServiceTests
         Assert.Equal("add_to_cart", ga4Event.GetProperty("name").GetString());
         Assert.False(parameters.TryGetProperty("transaction_id", out _));
         Assert.False(parameters.TryGetProperty("shipping", out _));
-        Assert.Equal(10, parameters.GetProperty("value").GetDecimal());
+        Assert.Equal(12, parameters.GetProperty("value").GetDecimal());
+        Assert.Equal(1, parameters.GetProperty("engagement_time_msec").GetInt32());
+        Assert.Equal("Klaviyo", parameters.GetProperty("campaign_source").GetString());
+        Assert.Equal("email", parameters.GetProperty("campaign_medium").GetString());
+        Assert.Equal("spring-sale", parameters.GetProperty("campaign_name").GetString());
+        Assert.Equal("coffee", parameters.GetProperty("campaign_term").GetString());
+        Assert.Equal("newsletter", parameters.GetProperty("campaign_content").GetString());
+        Assert.False(parameters.TryGetProperty("source", out _));
+        Assert.False(parameters.TryGetProperty("medium", out _));
+        Assert.False(parameters.TryGetProperty("campaign", out _));
+        Assert.False(parameters.TryGetProperty("term", out _));
+        Assert.False(parameters.TryGetProperty("content", out _));
+        var item = parameters.GetProperty("items")[0];
+        Assert.Equal(2, item.GetProperty("discount").GetDecimal());
+        Assert.Equal(1.5m, item.GetProperty("quantity").GetDecimal());
+        Assert.Equal("ITEM-COUPON", item.GetProperty("coupon").GetString());
+    }
+
+    [Fact]
+    public async Task SendPurchaseAsync_DoesNotIncludeEngagementTime_When_AnalyticsConsent_IsMissing()
+    {
+        using var handler = new RecordingHttpMessageHandler();
+        using var httpClient = new HttpClient(handler);
+        var sut = new Ga4TrackingService(
+            new StaticHttpClientFactory(httpClient),
+            Options.Create(new TrackingOptions
+            {
+                Ga4 = new Ga4TrackingProviderOptions
+                {
+                    Stores =
+                    [
+                        new TrackingStoreOptions
+                        {
+                            Alias = "Store",
+                            MeasurementId = "G-XXXXXXXXXX",
+                            ApiSecret = "api-secret",
+                        },
+                    ],
+                },
+            }),
+            new ThrowingServiceScopeFactory(),
+            NullLogger<Ga4TrackingService>.Instance);
+
+        await sut.SendPurchaseAsync(new Ga4PurchaseRequest
+        {
+            StoreAlias = "Store",
+            ClientId = "123.456",
+            HasCapturedSessionId = true,
+            SessionId = 123,
+            EventName = "add_to_cart",
+            Value = 10,
+            Currency = "ISK",
+        });
+
+        using var document = JsonDocument.Parse(handler.Payload);
+        var parameters = document.RootElement.GetProperty("events")[0].GetProperty("params");
+
+        Assert.False(parameters.TryGetProperty("engagement_time_msec", out _));
     }
 
     [Fact]
@@ -72,6 +141,97 @@ public sealed class Ga4TrackingServiceTests
 
         Assert.False(options.Ga4.Events.AddedToCart);
         Assert.False(options.Ga4.Events.StartedCheckout);
+    }
+
+    [Theory]
+    [InlineData(false, false, "purchase", false)]
+    [InlineData(false, true, "purchase", true)]
+    [InlineData(false, true, "add_to_cart", false)]
+    [InlineData(true, false, "add_to_cart", true)]
+    [InlineData(true, true, "InitiateCheckout", true)]
+    public void ShouldLogEventData_Respects_AllEvent_And_PurchaseOnly_Options(bool logEventData, bool logPurchaseEventData, string eventName, bool expected)
+    {
+        var options = new TrackingOptions
+        {
+            LogEventData = logEventData,
+            LogPurchaseEventData = logPurchaseEventData
+        };
+
+        Assert.Equal(expected, options.ShouldLogEventData(eventName));
+    }
+
+    [Theory]
+    [InlineData(12.845814977973568, 2, 2, 6.42)]
+    [InlineData(4960, 4, 0, 1240)]
+    public void CalculateUnitPrice_Uses_The_Rounded_Unit_Price(decimal lineAmount, decimal quantity, int currencyDecimalDigits, decimal expectedPrice)
+    {
+        var result = InvokeCalculateUnitPrice(lineAmount, quantity, currencyDecimalDigits);
+
+        Assert.Equal(expectedPrice, result);
+    }
+
+    [Fact]
+    public void CalculateEventValue_Uses_Rounded_Unit_Prices_And_Quantities()
+    {
+        var items = new List<Ga4PurchaseItem>
+        {
+            new() { Price = 6.42m, Discount = 0.42m, Quantity = 2 },
+            new() { Price = 6.16m, Discount = 0.16m, Quantity = 3 }
+        };
+
+        var result = InvokeCalculateEventValue(items, 2);
+
+        Assert.Equal(30m, result);
+    }
+
+    [Theory]
+    [InlineData("fi-FI", 2)]
+    [InlineData("is-IS", 0)]
+    public void CurrencyDecimalDigits_Uses_The_Store_Currency(string currencyValue, int expectedDecimalDigits)
+    {
+        var currency = new Ekom.Models.CurrencyModel { CurrencyValue = currencyValue };
+
+        Assert.Equal(expectedDecimalDigits, currency.CurrencyDecimalDigits);
+    }
+
+    [Fact]
+    public void UseCulture_Sets_And_Restores_The_Order_Culture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUICulture = CultureInfo.CurrentUICulture;
+
+        using (InvokeUseCulture("fi-FI"))
+        {
+            Assert.Equal("fi-FI", CultureInfo.CurrentCulture.Name);
+            Assert.Equal("fi-FI", CultureInfo.CurrentUICulture.Name);
+        }
+
+        Assert.Equal(originalCulture, CultureInfo.CurrentCulture);
+        Assert.Equal(originalUICulture, CultureInfo.CurrentUICulture);
+    }
+
+    private static decimal InvokeCalculateUnitPrice(decimal lineAmount, decimal quantity, int currencyDecimalDigits)
+    {
+        var method = typeof(Ga4TrackingService).GetMethod("CalculateUnitPrice", BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        return (decimal)method.Invoke(null, [lineAmount, quantity, currencyDecimalDigits])!;
+    }
+
+    private static decimal InvokeCalculateEventValue(IEnumerable<Ga4PurchaseItem> items, int currencyDecimalDigits)
+    {
+        var method = typeof(Ga4TrackingService).GetMethod("CalculateEventValue", BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        return (decimal)method.Invoke(null, [items, currencyDecimalDigits])!;
+    }
+
+    private static IDisposable InvokeUseCulture(string culture)
+    {
+        var method = typeof(Ga4TrackingService).GetMethod("UseCulture", BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        return (IDisposable)method.Invoke(null, [culture])!;
     }
 
     private sealed class StaticHttpClientFactory(HttpClient client) : IHttpClientFactory

--- a/Ekom/Tests/Ekom.Tests/Tests/MetaTrackingServiceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/MetaTrackingServiceTests.cs
@@ -3,7 +3,9 @@ using Ekom.Tracking;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using System.Net;
+using System.Reflection;
 using Xunit;
 
 namespace Ekom.Tests.Tests;
@@ -46,6 +48,61 @@ public sealed class MetaTrackingServiceTests
         Assert.Equal(0, handler.CallCount);
         Assert.Equal("customer@example.com", request.Email);
     }
+
+    [Theory]
+    [InlineData("uk", false, true)]
+    [InlineData("UK", false, true)]
+    [InlineData("other", false, false)]
+    [InlineData("uk", true, false)]
+    public void BuildEventSourceUrl_Uses_Landing_Url_Then_Store_Override_Then_Global_Fallback(string storeAlias, bool hasLandingUrl, bool usesStoreOverride)
+    {
+        var options = new TrackingOptions
+        {
+            SiteBaseUrl = "https://default.example.com",
+            Stores =
+            [
+                new TrackingStoreUrlOptions
+                {
+                    Alias = "uk",
+                    SiteBaseUrl = "https://uk.example.com"
+                }
+            ]
+        };
+        var sut = new MetaTrackingService(
+            new HttpClient(),
+            Options.Create(options),
+            new ThrowingServiceScopeFactory(),
+            NullLogger<MetaTrackingService>.Instance);
+        var orderInfo = new Mock<Ekom.Models.IOrderInfo>();
+        orderInfo.SetupGet(x => x.StoreInfo).Returns(CreateStoreInfo(storeAlias));
+        var landingUrl = hasLandingUrl ? "https://landing.example.com" : null;
+        var expectedUrl = hasLandingUrl
+            ? landingUrl
+            : usesStoreOverride ? "https://uk.example.com" : "https://default.example.com";
+
+        var result = InvokeBuildEventSourceUrl(sut, orderInfo.Object, new Ekom.Models.OrderTracking { LandingUrl = landingUrl });
+
+        Assert.Equal(expectedUrl, result);
+    }
+
+    private static string? InvokeBuildEventSourceUrl(MetaTrackingService service, Ekom.Models.IOrderInfo orderInfo, Ekom.Models.OrderTracking tracking)
+    {
+        var method = typeof(MetaTrackingService).GetMethod("BuildEventSourceUrl", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        return (string?)method.Invoke(service, [orderInfo, tracking]);
+    }
+
+    private static Ekom.Models.StoreInfo CreateStoreInfo(string alias)
+        => new(
+            Guid.NewGuid(),
+            new Ekom.Models.CurrencyModel(),
+            [],
+            "en-GB",
+            alias,
+            false,
+            0,
+            false);
 
     private sealed class CountingHttpMessageHandler : HttpMessageHandler
     {

--- a/README.md
+++ b/README.md
@@ -232,9 +232,11 @@ Ekom tracking supports order-level `Consent` and `Tracking` data for automatic G
 
 - `Ekom:Tracking:Enabled` turns tracking features on or off.
 - `Ekom:Tracking:CaptureEnabled` controls whether Ekom captures consent and browser tracking data from incoming requests.
-- `Ekom:Tracking:LogPurchaseEventData` controls whether outbound GA4 and Meta purchase payloads are logged before dispatch.
+- `Ekom:Tracking:LogEventData` controls whether all outbound GA4 and Meta event payloads are logged before dispatch.
+- `Ekom:Tracking:LogPurchaseEventData` controls whether only outbound GA4 and Meta purchase payloads are logged before dispatch.
 - `Ekom:Tracking:CookieName` and `Ekom:Tracking:CookieLifetimeDays` control Ekom's own tracking cookie.
-- `Ekom:Tracking:SiteBaseUrl` is used as a fallback base URL when no landing URL can be resolved from the request.
+- `Ekom:Tracking:SiteBaseUrl` is the fallback base URL when no landing URL or store-specific base URL can be resolved.
+- `Ekom:Tracking:Stores` lets you override the fallback base URL per store alias.
 - `Ekom:Tracking:Consent` defines the default consent cookie/header names and fallback values.
 - `Ekom:Tracking:Consent:Stores` lets you override consent handling per store alias.
 - Consent is resolved through a chain of `ITrackingConsentResolver` services.
@@ -249,10 +251,17 @@ Full tracking config example:
 "Tracking": {
   "Enabled": true,
   "CaptureEnabled": true,
+  "LogEventData": false,
   "LogPurchaseEventData": false,
   "CookieName": "EkomTracking",
   "CookieLifetimeDays": 30,
   "SiteBaseUrl": "https://www.example.com",
+  "Stores": [
+    {
+      "Alias": "Store",
+      "SiteBaseUrl": "https://store.example.com"
+    }
+  ],
   "Consent": {
     "FallbackAnalyticsConsent": false,
     "FallbackMarketingConsent": false,
@@ -319,6 +328,11 @@ Notes:
 - `Ga4:Testing` sends events through the GA4 debug endpoint.
 - `Meta:Testing` uses `TestEventCode` when configured for the store.
 - `Dispatching:Capacity` and `Dispatching:MaxConcurrency` control the background queue used for provider dispatching.
+- Meta uses the captured landing URL first, then `Tracking:Stores[*]:SiteBaseUrl`, and finally `Tracking:SiteBaseUrl` for `event_source_url`.
+- GA4 sends VAT-exclusive list unit prices in `items[*]:price`, with per-unit discounts in `items[*]:discount`, and derives event `value` from the discounted item totals. Applied order and line coupons are sent in GA4 coupon fields. Purchase `tax` and shipping are sent separately; payment fees are excluded from the GA4 event value.
+- GA4 monetary values are rounded to the store currency's decimal precision before dispatch.
+- GA4 adds `engagement_time_msec: 1` only when analytics consent and a captured GA session ID are available.
+- GA4 maps captured UTM values to `campaign_source`, `campaign_medium`, `campaign_name`, `campaign_term`, and `campaign_content`.
 
 Default consent config example:
 

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -230,10 +230,17 @@
         "Tracking": {
             "Enabled": true,
             "CaptureEnabled": true,
+            "LogEventData": false,
             "LogPurchaseEventData": false,
             "CookieName": "EkomTracking",
             "CookieLifetimeDays": 30,
             "SiteBaseUrl": "https://localhost:44317",
+            "Stores": [
+                {
+                    "Alias": "Store",
+                    "SiteBaseUrl": "https://localhost:44317"
+                }
+            ],
             "Consent": {
                 "FallbackAnalyticsConsent": false,
                 "FallbackMarketingConsent": false,


### PR DESCRIPTION
## Summary
- add store-specific tracking URL fallbacks for Meta events
- improve GA4 ecommerce, attribution, culture, and engagement payload data
- add separate all-event and purchase-only payload logging controls

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~Ga4TrackingServiceTests"`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~MetaTrackingServiceTests"`