### PR TITLE
fix(culture): preserve order request culture

### DIFF
--- a/Ekom/Ekom.Core/Ekom/EkomCultureProvider.cs
+++ b/Ekom/Ekom.Core/Ekom/EkomCultureProvider.cs
@@ -2,8 +2,6 @@ using Ekom.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Globalization;
 
@@ -11,88 +9,37 @@ namespace Ekom;
 
 public class EkomCultureRequestLocalizationOptions : IConfigureOptions<RequestLocalizationOptions>
 {
-    private readonly IServiceScopeFactory _serviceScopeFactory;
-    private readonly ILogger<EkomCultureRequestLocalizationOptions> _logger;
-
-    public EkomCultureRequestLocalizationOptions(
-        IServiceScopeFactory serviceScopeFactory,
-        ILogger<EkomCultureRequestLocalizationOptions> logger)
-    {
-        _serviceScopeFactory = serviceScopeFactory;
-        _logger = logger;
-    }
-
     public void Configure(RequestLocalizationOptions options)
     {
-        try
+        if (!options.RequestCultureProviders.OfType<EkomCultureProvider>().Any())
         {
-            using var scope = _serviceScopeFactory.CreateScope();
-
-            if (!IsUmbracoRuntimeReady(scope.ServiceProvider))
-            {
-                return;
-            }
-
-            var umbracoService = scope.ServiceProvider.GetRequiredService<IUmbracoService>();
-
-            var cultures = umbracoService.GetLanguages();
-            var defaultCulture = umbracoService.DefaultLanguage();
-
-            var supportedCultures = cultures.Select(culture => new CultureInfo(culture.IsoCode)).ToList();
-
-            options.DefaultRequestCulture = new RequestCulture(defaultCulture, defaultCulture);
-            options.SupportedCultures = supportedCultures;
-            options.SupportedUICultures = supportedCultures;
-
-            // Insert EkomCultureProvider at the highest priority
-            options.RequestCultureProviders.Insert(0, new EkomCultureProvider(options));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed configuring Ekom localization.");
+            options.RequestCultureProviders.Insert(0, new EkomCultureProvider());
         }
     }
 
-    private static bool IsUmbracoRuntimeReady(IServiceProvider serviceProvider)
+    public static void ConfigureCultures(RequestLocalizationOptions options, IUmbracoService umbracoService)
     {
-        var runtimeStateType = AppDomain.CurrentDomain
-            .GetAssemblies()
-            .Select(assembly => assembly.GetType("Umbraco.Cms.Core.Runtime.IRuntimeState"))
-            .FirstOrDefault(type => type != null);
+        var defaultCulture = umbracoService.DefaultLanguage();
+        var supportedCultures = umbracoService.GetLanguages()
+            .Select(culture => culture.IsoCode)
+            .Append(defaultCulture)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(culture => culture, culture => culture, StringComparer.OrdinalIgnoreCase);
+        var cultures = supportedCultures.Values.Select(culture => new CultureInfo(culture)).ToList();
 
-        if (runtimeStateType == null)
-        {
-            return false;
-        }
+        options.DefaultRequestCulture = new RequestCulture(defaultCulture, defaultCulture);
+        options.SupportedCultures = cultures;
+        options.SupportedUICultures = cultures;
 
-        var runtimeState = serviceProvider.GetService(runtimeStateType);
-
-        if (runtimeState == null)
-        {
-            return false;
-        }
-
-        var level = runtimeStateType.GetProperty("Level")?.GetValue(runtimeState)?.ToString();
-
-        return string.Equals(level, "Run", StringComparison.Ordinal);
+        options.RequestCultureProviders.OfType<EkomCultureProvider>()
+            .FirstOrDefault()
+            ?.SetCultures(defaultCulture, supportedCultures);
     }
-
 }
 
 public class EkomCultureProvider : RequestCultureProvider
 {
-    private readonly RequestLocalizationOptions _localizationOptions;
-    private readonly Dictionary<string, string> _supportedCulturesByName;
-
-    // ctor with reference to the RequestLocalizationOptions
-    public EkomCultureProvider(RequestLocalizationOptions localizationOptions)
-    {
-        _localizationOptions = localizationOptions;
-        _supportedCulturesByName = localizationOptions.SupportedCultures
-            ?.DistinctBy(culture => culture.Name)
-            .ToDictionary(culture => culture.Name, culture => culture.Name, StringComparer.OrdinalIgnoreCase)
-            ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-    }
+    private CultureSettings? _cultureSettings;
 
     public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext context)
     {
@@ -101,17 +48,19 @@ public class EkomCultureProvider : RequestCultureProvider
             return NullProviderCultureResult;
         }
 
+        var cultureSettings = Volatile.Read(ref _cultureSettings);
+        if (cultureSettings == null)
+        {
+            return NullProviderCultureResult;
+        }
+
         var cultureName = context.Request.Query["Culture"].FirstOrDefault()
-                            ?? context.Request.Headers["Culture"].FirstOrDefault()
-                            ?? context.Request.Headers["Accept-Language"].FirstOrDefault();
+            ?? context.Request.Headers["Culture"].FirstOrDefault()
+            ?? context.Request.Headers["Accept-Language"].FirstOrDefault();
 
         if (string.IsNullOrWhiteSpace(cultureName))
         {
-            // No culture specified → use default
-            return Task.FromResult(
-                new ProviderCultureResult(
-                    _localizationOptions.DefaultRequestCulture.Culture.Name,
-                    _localizationOptions.DefaultRequestCulture.UICulture.Name));
+            return Task.FromResult(new ProviderCultureResult(cultureSettings.DefaultCulture, cultureSettings.DefaultCulture));
         }
 
         if (string.IsNullOrEmpty(cultureName) || cultureName == "*")
@@ -121,17 +70,23 @@ public class EkomCultureProvider : RequestCultureProvider
 
         cultureName = ParseAcceptLanguageHeader(cultureName);
 
-        if (_supportedCulturesByName.TryGetValue(cultureName, out string? supportedCulture))
+        if (cultureSettings.SupportedCultures.TryGetValue(cultureName, out var supportedCulture))
         {
-            // Found in supported list
             return Task.FromResult(new ProviderCultureResult(supportedCulture, supportedCulture));
         }
 
-        return Task.FromResult(
-            new ProviderCultureResult(
-                _localizationOptions.DefaultRequestCulture.Culture.Name,
-                _localizationOptions.DefaultRequestCulture.UICulture.Name));
+        return Task.FromResult(new ProviderCultureResult(cultureSettings.DefaultCulture, cultureSettings.DefaultCulture));
     }
+
+    internal void SetCultures(string defaultCulture, IReadOnlyDictionary<string, string> supportedCultures)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultCulture);
+        Volatile.Write(ref _cultureSettings, new CultureSettings(defaultCulture, supportedCultures));
+    }
+
+    private sealed record CultureSettings(
+        string DefaultCulture,
+        IReadOnlyDictionary<string, string> SupportedCultures);
 
     private static string ParseAcceptLanguageHeader(string headerValue)
     {

--- a/Ekom/Ekom.Core/Ekom/Models/OrderInfo.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderInfo.cs
@@ -1,5 +1,8 @@
 using Ekom.Services;
 using Ekom.Utilities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.DependencyInjection;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -83,17 +86,35 @@ public class OrderInfo : IOrderInfo
     {
         get
         {
-            if (string.IsNullOrEmpty(_culture))
+            var contextCulture = GetContextCulture();
+            if (!string.IsNullOrWhiteSpace(contextCulture))
             {
-                this._culture = StoreInfo.Culture;
+                _culture = contextCulture;
+            }
+
+            if (string.IsNullOrWhiteSpace(_culture))
+            {
+                _culture = StoreInfo.Culture;
             }
 
             return _culture;
         }
         set
         {
-            this._culture = value;
+            _culture = value;
         }
+    }
+
+    private static string? GetContextCulture()
+    {
+        var httpContext = Configuration.Resolver?.GetService<IHttpContextAccessor>()?.HttpContext;
+        if (httpContext == null)
+        {
+            return null;
+        }
+
+        return httpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name
+            ?? CultureInfo.CurrentCulture.Name;
     }
 
     /// <summary>

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -1414,12 +1414,6 @@ partial class OrderService
     {
         var store = _storeSvc.GetStoreByAlias(orderInfo.StoreInfo.Alias);
         var storeCultures = store?.Cultures ?? [];
-        var currentCulture = CultureInfo.CurrentCulture.Name;
-
-        if (IsStoreCulture(currentCulture, storeCultures))
-        {
-            return currentCulture;
-        }
 
         if (IsStoreCulture(orderInfo.Culture, storeCultures))
         {

--- a/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
+++ b/Ekom/Ekom.Core/Ekom/Tracking/Ga4TrackingService.cs
@@ -63,9 +63,11 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
     public Ga4PurchaseRequest CreateRemovedFromCartRequest(IOrderInfo orderInfo, IOrderLine orderLine)
     {
+        using var cultureScope = UseCulture(orderInfo.Culture);
+        var currencyDecimalDigits = orderInfo.StoreInfo.Currency.CurrencyDecimalDigits;
         var request = CreateRequest(orderInfo, "remove_from_cart");
-        request.Value = orderLine.Amount.WithoutVat.Value * orderLine.Quantity;
-        request.Items = [CreateItem(orderLine, orderInfo.StoreInfo.Alias)];
+        request.Items = [CreateItem(orderLine, orderInfo, currencyDecimalDigits)];
+        request.Value = CalculateEventValue(request.Items, currencyDecimalDigits);
 
         return request;
     }
@@ -83,20 +85,24 @@ public sealed class Ga4TrackingService : IGa4TrackingService
 
     public Ga4PurchaseRequest CreateAddedShippingInfoRequest(IOrderInfo orderInfo)
     {
+        using var cultureScope = UseCulture(orderInfo.Culture);
+        var currencyDecimalDigits = orderInfo.StoreInfo.Currency.CurrencyDecimalDigits;
         var request = CreateRequest(orderInfo, "add_shipping_info");
-        request.Value = orderInfo.ChargedAmount.Value;
         request.ShippingTier = orderInfo.ShippingProvider?.Title;
-        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
+        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo, currencyDecimalDigits)).ToList();
+        request.Value = CalculateEventValue(request.Items, currencyDecimalDigits);
 
         return request;
     }
 
     public Ga4PurchaseRequest CreateAddedPaymentInfoRequest(IOrderInfo orderInfo)
     {
+        using var cultureScope = UseCulture(orderInfo.Culture);
+        var currencyDecimalDigits = orderInfo.StoreInfo.Currency.CurrencyDecimalDigits;
         var request = CreateRequest(orderInfo, "add_payment_info");
-        request.Value = orderInfo.ChargedAmount.Value;
         request.PaymentType = orderInfo.PaymentProvider?.Title;
-        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo.StoreInfo.Alias)).ToList();
+        request.Items = orderInfo.OrderLines.Select(orderLine => CreateItem(orderLine, orderInfo, currencyDecimalDigits)).ToList();
+        request.Value = CalculateEventValue(request.Items, currencyDecimalDigits);
 
         return request;
     }

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -137,6 +138,7 @@ class EkomStartup : IComponent
     readonly IServiceProvider _factory;
     readonly IMemoryCache _cache;
     readonly IRuntimeState _runtimeState;
+    private readonly IOptions<RequestLocalizationOptions> _requestLocalizationOptions;
 
     /// <summary>
     /// 
@@ -146,13 +148,15 @@ class EkomStartup : IComponent
         ILogger<EkomStartup> logger,
         IServiceProvider factory,
         IMemoryCache cache,
-        IRuntimeState runtimeState)
+        IRuntimeState runtimeState,
+        IOptions<RequestLocalizationOptions> requestLocalizationOptions)
     {
         _config = config;
         _logger = logger;
         _factory = factory;
         _cache = cache;
         _runtimeState = runtimeState;
+        _requestLocalizationOptions = requestLocalizationOptions;
     }
 
     /// <summary>
@@ -172,6 +176,9 @@ class EkomStartup : IComponent
 
             Configuration.Resolver = _factory;
             PriceCache.SetCache(_cache);
+            EkomCultureRequestLocalizationOptions.ConfigureCultures(
+                _requestLocalizationOptions.Value,
+                _factory.GetRequiredService<Ekom.Services.IUmbracoService>());
 
             var orderRepo = _factory.GetService<OrderRepository>();
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomStartup.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomStartup.cs
@@ -4,9 +4,11 @@ using Ekom.Models;
 using Ekom.Payments;
 using Ekom.Repositories;
 using Ekom.Services;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Composing;
 
 namespace Ekom.Umb;
@@ -19,17 +21,20 @@ internal sealed class EkomStartup : IComponent
     private readonly ILogger<EkomStartup> _logger;
     private readonly IServiceProvider _factory;
     private readonly IMemoryCache _cache;
+    private readonly IOptions<RequestLocalizationOptions> _requestLocalizationOptions;
 
     public EkomStartup(
         Configuration config,
         ILogger<EkomStartup> logger,
         IServiceProvider factory,
-        IMemoryCache cache)
+        IMemoryCache cache,
+        IOptions<RequestLocalizationOptions> requestLocalizationOptions)
     {
         _config = config;
         _logger = logger;
         _factory = factory;
         _cache = cache;
+        _requestLocalizationOptions = requestLocalizationOptions;
     }
 
     public void Initialize()
@@ -40,6 +45,9 @@ internal sealed class EkomStartup : IComponent
 
             Configuration.Resolver = _factory;
             PriceCache.SetCache(_cache);
+            EkomCultureRequestLocalizationOptions.ConfigureCultures(
+                _requestLocalizationOptions.Value,
+                _factory.GetRequiredService<Ekom.Services.IUmbracoService>());
 
             var orderRepository = _factory.GetService<OrderRepository>();
             orderRepository?.MigrateOrderTableAsync();

--- a/Ekom/Tests/Ekom.Tests/Tests/EkomCultureProviderTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/EkomCultureProviderTests.cs
@@ -1,0 +1,83 @@
+using Ekom.Models.Umbraco;
+using Ekom.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Globalization;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class EkomCultureProviderTests
+{
+    [Fact]
+    public async Task DetermineProviderCultureResult_UsesCultureHeaderAfterUmbracoStarts()
+    {
+        var umbracoService = new Mock<IUmbracoService>();
+        umbracoService.Setup(x => x.DefaultLanguage()).Returns("en-US");
+        umbracoService.Setup(x => x.GetLanguages()).Returns(
+        [
+            new UmbracoLanguage { IsoCode = "en-US" },
+            new UmbracoLanguage { IsoCode = "is-IS" },
+        ]);
+        var options = new RequestLocalizationOptions();
+        var configurator = new EkomCultureRequestLocalizationOptions();
+        configurator.Configure(options);
+        EkomCultureRequestLocalizationOptions.ConfigureCultures(options, umbracoService.Object);
+        var provider = Assert.IsType<EkomCultureProvider>(options.RequestCultureProviders[0]);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/ekom/order/add";
+        context.Request.Headers["Culture"] = "is-IS";
+
+        ProviderCultureResult? result = await provider.DetermineProviderCultureResult(context);
+
+        Assert.NotNull(result);
+        Assert.Equal("is-IS", result.Cultures[0].Value);
+
+        await provider.DetermineProviderCultureResult(context);
+
+        umbracoService.Verify(x => x.GetLanguages(), Times.Once);
+    }
+
+    [Fact]
+    public void Configure_RegistersProviderBeforeUmbracoStarts()
+    {
+        var options = new RequestLocalizationOptions();
+        var configurator = new EkomCultureRequestLocalizationOptions();
+
+        configurator.Configure(options);
+
+        Assert.IsType<EkomCultureProvider>(options.RequestCultureProviders[0]);
+    }
+
+    [Fact]
+    public async Task RequestLocalizationMiddleware_SetsCultureFromEkomHeader()
+    {
+        var umbracoService = new Mock<IUmbracoService>();
+        umbracoService.Setup(x => x.DefaultLanguage()).Returns("en-US");
+        umbracoService.Setup(x => x.GetLanguages()).Returns(
+        [
+            new UmbracoLanguage { IsoCode = "en-US" },
+            new UmbracoLanguage { IsoCode = "is-IS" },
+        ]);
+        var options = new RequestLocalizationOptions();
+        new EkomCultureRequestLocalizationOptions().Configure(options);
+        EkomCultureRequestLocalizationOptions.ConfigureCultures(options, umbracoService.Object);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/ekom/order/add";
+        context.Request.Headers["Culture"] = "is-IS";
+        var middleware = new RequestLocalizationMiddleware(
+            _ =>
+            {
+                Assert.Equal("is-IS", CultureInfo.CurrentCulture.Name);
+                return Task.CompletedTask;
+            },
+            Options.Create(options),
+            NullLoggerFactory.Instance);
+
+        await middleware.Invoke(context);
+    }
+}

--- a/Ekom/Tests/Ekom.Tests/Tests/OrderInfoTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/OrderInfoTests.cs
@@ -1,5 +1,10 @@
 using Ekom.Models;
+using Ekom.Tests.Objects;
 using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -7,6 +12,29 @@ namespace Ekom.Tests.Tests;
 
 public class OrderInfoTests
 {
+    [Fact]
+    public void Culture_UsesRequestCultureAndRetainsItWithoutARequest()
+    {
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+        httpContextAccessor.HttpContext.Features.Set<IRequestCultureFeature>(
+            new RequestCultureFeature(new RequestCulture("da-DK"), null));
+
+        using var configurationScope = new ConfigurationScope(addServices: services =>
+            services.AddSingleton<IHttpContextAccessor>(httpContextAccessor));
+        var store = new Mock<IStore>();
+        store.SetupGet(x => x.Culture).Returns(new CultureInfoDto { Name = "en-US" });
+        var orderInfo = new OrderInfo(new OrderData(), store.Object);
+
+        Assert.Equal("da-DK", orderInfo.Culture);
+
+        httpContextAccessor.HttpContext = null;
+
+        Assert.Equal("da-DK", orderInfo.Culture);
+    }
+
     [Fact]
     public void Constructor_PreservesLegacyTopLevelDiscountObjectAmountValue()
     {

--- a/Samples/U10/Ekom.Site/Views/Product.cshtml
+++ b/Samples/U10/Ekom.Site/Views/Product.cshtml
@@ -1,3 +1,4 @@
+@using System.Globalization
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
     Layout = "Master.cshtml";
@@ -7,6 +8,7 @@
     var product = await _catalog.GetProductAsync();
 
     var checkoutNode = rootNode.FirstChildOfType("checkout");
+    var culture = CultureInfo.CurrentCulture.Name;
 
     var primaryVariantGroup = product.PrimaryVariantGroup;
     var primaryVariant = product.PrimaryVariant;
@@ -327,7 +329,10 @@
 
                     fetch('/ekom/order/add', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Culture': '@culture'
+                        },
                         body: JSON.stringify(formData)
                     })
                     .then((response) => {

--- a/Samples/U10/Ekom.Site/appsettings.json
+++ b/Samples/U10/Ekom.Site/appsettings.json
@@ -230,8 +230,8 @@
         "Tracking": {
             "Enabled": true,
             "CaptureEnabled": true,
-            "LogEventData": false,
-            "LogPurchaseEventData": false,
+            "LogEventData": true,
+            "LogPurchaseEventData": true,
             "CookieName": "EkomTracking",
             "CookieLifetimeDays": 30,
             "SiteBaseUrl": "https://localhost:44317",
@@ -259,6 +259,15 @@
             "Ga4": {
                 "Enabled": true,
                 "Testing": true,
+                "UseDebugEndpoint": true,
+                "DebugMode": true,
+                "Events": {
+                    "AddedToCart": true,
+                    "RemovedFromCart": true,
+                    "StartedCheckout": true,
+                    "AddedShippingInfo": true,
+                    "AddedPaymentInfo": true
+                },
                 "Dispatching": {
                     "Capacity": 1000,
                     "MaxConcurrency": 2
@@ -266,8 +275,8 @@
                 "Stores": [
                     {
                         "Alias": "Store",
-                        "MeasurementId": "G-XXXXXXXXXX",
-                        "ApiSecret": "ga4-api-secret"
+                        "MeasurementId": "xxx",
+                        "ApiSecret": "xxx"
                     }
                 ]
             },

--- a/Samples/U17/Ekom.Site.U17/Views/Product.cshtml
+++ b/Samples/U17/Ekom.Site.U17/Views/Product.cshtml
@@ -1,10 +1,12 @@
-﻿@inherits UmbracoViewPage
+﻿@using System.Globalization
+@inherits UmbracoViewPage
 
 @{
     Layout = "Master.cshtml";
     
     var rootNode = Model.GetSite();
     var checkoutNode = rootNode.FirstChildOfType("checkout");
+    var culture = CultureInfo.CurrentCulture.Name;
     var product = await _catalog.GetProductAsync();
 
     if (product == null)
@@ -196,7 +198,10 @@
 
                     fetch('/ekom/order/add', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Culture': '@culture'
+                        },
                         body: JSON.stringify(formData)
                     })
                     .then((response) => {


### PR DESCRIPTION
## Summary
- initialize Ekom request cultures once after Umbraco reaches its runtime lifecycle
- preserve the active request culture on orders and forward page culture in sample add-to-cart requests
- align GA4 cart event item/value construction with currency-aware mappings

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --no-build --filter "FullyQualifiedName~EkomCultureProviderTests"`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`