### PR TITLE
fix(order): Re-snapshot product when caller supplies its own prices

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -1202,6 +1202,26 @@ partial class OrderService
                 {
                     orderLine.OrderLineInfo.Properties[kvp.Key] = kvp.Value;
                 }
+
+                // Re-snapshot the product when the caller supplies its own prices.
+                // Previously an OrderDynamicRequest was honoured only when the line was
+                // first created and silently dropped on every subsequent update, so a
+                // line kept the prices it was born with for the lifetime of the cart.
+                // Gated on the caller having supplied a request, so callers that pass
+                // none - which is every caller that could observe the old behaviour -
+                // are unaffected. OrderLineSettings is deliberately left alone: Link
+                // identifies existing child lines and must not change under them.
+                if (settings.OrderDynamicRequest != null && orderInfo.orderLines.Contains(orderLine))
+                {
+                    orderLine.Product = new OrderedProduct(
+                        product,
+                        variant,
+                        orderInfo.StoreInfo,
+                        settings.OrderDynamicRequest);
+
+                    orderLine.Discount = orderLine.Variant?.Price.Discount
+                        ?? orderLine.Product.Price.Discount;
+                }
             }
             else
             {


### PR DESCRIPTION
OrderDynamicRequest is applied only when an OrderLine is first constructed. AddOrderLineToOrderInfoAsync fires AddingOrderline on every call, but the existing-line branch updates Quantity and OrderLineInfo and discards the rest — so a line's prices are frozen at creation and nothing in the public API re-resolves them.

On a UserBasket store, where carts are bound to the member and never expire, that meant a customer was quoted a per-customer price the ERP had stopped honouring months earlier. The only workaround was remove-and-re-add, which mints a new line key, moves the line to the end of the cart, and leaves a window with two persisted lines for one product.

The existing-line branch now re-snapshots orderLine.Product from the current catalog product plus the caller's OrderDynamicRequest, and recomputes orderLine.Discount as the constructor does. Callers can re-price in place with OrderAction.Set at the line's existing quantity — same line key, same position, one write.

Not a breaking change: it is gated on the caller supplying an OrderDynamicRequest, which this path previously discarded, so no existing caller can have depended on the old behaviour. The Contains guard covers the AddOrUpdate path where the line may already have been removed at quantity zero.

OrderLineSettings is deliberately left untouched — Link identifies existing child lines and must not change under them.