### PR TITLE
fix(u17): resolve startup service in scope

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomStartup.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomStartup.cs
@@ -45,9 +45,10 @@ internal sealed class EkomStartup : IComponent
 
             Configuration.Resolver = _factory;
             PriceCache.SetCache(_cache);
+            using var scope = _factory.CreateScope();
             EkomCultureRequestLocalizationOptions.ConfigureCultures(
                 _requestLocalizationOptions.Value,
-                _factory.GetRequiredService<Ekom.Services.IUmbracoService>());
+                scope.ServiceProvider.GetRequiredService<Ekom.Services.IUmbracoService>());
 
             var orderRepository = _factory.GetService<OrderRepository>();
             orderRepository?.MigrateOrderTableAsync();


### PR DESCRIPTION
## Summary
- Resolve the U17 culture service from a startup DI scope.
- Prevent root-provider resolution from constructing services that depend on scoped Umbraco dependencies.

## Test Plan
- dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore