### PR TITLE
feat(u17): add SKU product picker

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Ekom.Services;
 using Ekom.Tracking;
 using Ekom.Umb.CatalogCollection.Services;
 using Ekom.Umb.Services;
+using Ekom.Umb.SkuProductPicker.Services;
 using Ekom.Umb.VariantApp.Services;
 using EkomCore.Services;
 using Microsoft.AspNetCore.Builder;
@@ -32,6 +33,7 @@ public static class ApplicationBuilderExtensions
         services.AddTransient<IMetafieldService, MetafieldService>();
         services.AddTransient<IUmbracoService, UmbracoService>();
         services.AddTransient<ICatalogCollectionService, CatalogCollectionService>();
+        services.AddTransient<ISkuProductPickerService, SkuProductPickerService>();
         services.AddTransient<IVariantAppService, VariantAppService>();
         services.AddTransient<IUrlService, UrlService>();
         services.AddScoped<BackofficeUserAccessor>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/CatalogCollectionService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/CatalogCollection/Services/CatalogCollectionService.cs
@@ -335,6 +335,8 @@ GROUP BY n.parentId, ct.alias",
     private static CatalogCollectionProduct MapProduct(IContent content)
     {
         var price = GetPrice(content);
+        var pendingChanges = content.Published && content.Edited;
+
         return new CatalogCollectionProduct
         {
             Id = content.Id,
@@ -350,6 +352,9 @@ GROUP BY n.parentId, ct.alias",
             UpdatedDate = content.UpdateDate,
             Available = IsAvailable(content),
             Image = GetFirstImage(GetStringValue(content, "images")),
+            Published = content.Published,
+            PendingChanges = pendingChanges,
+            Status = content.Published ? pendingChanges ? "Pending changes" : "Published" : "Unpublished",
         };
     }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/DataEditors/EkomDataEditors.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/DataEditors/EkomDataEditors.cs
@@ -100,3 +100,12 @@ public sealed class EkomPropertyEditor : DataEditor
     {
     }
 }
+
+[DataEditor("Ekom.SkuProductPicker", ValueType = ValueTypes.Json)]
+public sealed class EkomSkuProductPicker : DataEditor
+{
+    public EkomSkuProductPicker(IDataValueEditorFactory dataValueEditorFactory)
+        : base(dataValueEditorFactory)
+    {
+    }
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
@@ -34,6 +34,7 @@ class EnsureNodesExist : IComponent
     private const string EkomCurrencyEditorUiAlias = "Ekom.PropertyEditorUi.Currency";
     private const string EkomPriceEditorUiAlias = "Ekom.PropertyEditorUi.Price";
     private const string EkomPropertyEditorUiAlias = "Ekom.PropertyEditorUi.Property";
+    private const string EkomSkuProductPickerEditorUiAlias = "Ekom.PropertyEditorUi.SkuProductPicker";
     private const string EkomStockEditorUiAlias = "Ekom.PropertyEditorUi.Stock";
     private const string EkomZoneEditorUiAlias = "Ekom.PropertyEditorUi.Zone";
     private static readonly JsonSerializerOptions ConfigurationSerializerOptions = new()
@@ -1483,6 +1484,8 @@ class EnsureNodesExist : IComponent
                 #endregion
             }
 
+            EnsureSkuProductPickerDataType();
+
             _logger.LogDebug("Done");
         }
 #pragma warning disable CA1031 // Should not kill startup
@@ -1511,6 +1514,33 @@ class EnsureNodesExist : IComponent
         }
 
         return ekmContainer;
+    }
+
+    private void EnsureSkuProductPickerDataType()
+    {
+        if (!_propertyEditorCollection.TryGet("Ekom.SkuProductPicker", out IDataEditor? skuProductPicker)
+            || _contentTypeService.Get("ekmProduct") is not { } productContentType)
+        {
+            return;
+        }
+
+        var dataTypeContainer = EnsureDataTypeContainerExists();
+        var dataType = EnsureDataTypeExists(new DataType(skuProductPicker, _configurationEditorJsonSerializer, dataTypeContainer.Id)
+        {
+            Name = "Ekom SKU Product Picker",
+            EditorUiAlias = EkomSkuProductPickerEditorUiAlias,
+        });
+
+        dataType.ConfigurationData = ToConfigurationData(new MultiNodePickerConfiguration
+        {
+            Filter = BuildContentTypeFilter(productContentType),
+            TreeSource = new MultiNodePickerConfigurationTreeSource
+            {
+                ObjectType = "content",
+            },
+        });
+
+        _dataTypeService.Save(dataType);
     }
 
     private IDataType GetDataType(Guid key)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Controllers/SkuProductPickerController.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Controllers/SkuProductPickerController.cs
@@ -1,0 +1,31 @@
+using Ekom.ActionFilters;
+using Ekom.Authorization;
+using Ekom.Umb.SkuProductPicker.Models;
+using Ekom.Umb.SkuProductPicker.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ekom.Umb.SkuProductPicker.Controllers;
+
+[Route("ekom/backoffice/SkuProductPicker")]
+[CamelCaseJson]
+public sealed class SkuProductPickerController : ControllerBase
+{
+    private readonly ISkuProductPickerService _skuProductPickerService;
+
+    public SkuProductPickerController(ISkuProductPickerService skuProductPickerService)
+    {
+        _skuProductPickerService = skuProductPickerService;
+    }
+
+    [HttpPost("keys")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public IReadOnlyList<SkuProductPickerItem> ResolveKeys([FromBody] SkuProductPickerKeysRequest request)
+        => _skuProductPickerService.ResolveKeys(request.Keys);
+
+    [HttpPost("skus")]
+    [UmbracoUserAuthorize]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
+    public IReadOnlyList<SkuProductPickerItem> ResolveSkus([FromBody] SkuProductPickerSkusRequest request)
+        => _skuProductPickerService.ResolveSkus(request.Skus);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Models/SkuProductPickerItem.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Models/SkuProductPickerItem.cs
@@ -1,0 +1,7 @@
+namespace Ekom.Umb.SkuProductPicker.Models;
+
+public sealed class SkuProductPickerItem
+{
+    public Guid Key { get; init; }
+    public string Sku { get; init; } = string.Empty;
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Models/SkuProductPickerKeysRequest.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Models/SkuProductPickerKeysRequest.cs
@@ -1,0 +1,6 @@
+namespace Ekom.Umb.SkuProductPicker.Models;
+
+public sealed class SkuProductPickerKeysRequest
+{
+    public IReadOnlyList<Guid> Keys { get; init; } = Array.Empty<Guid>();
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Models/SkuProductPickerSkusRequest.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Models/SkuProductPickerSkusRequest.cs
@@ -1,0 +1,6 @@
+namespace Ekom.Umb.SkuProductPicker.Models;
+
+public sealed class SkuProductPickerSkusRequest
+{
+    public IReadOnlyList<string> Skus { get; init; } = Array.Empty<string>();
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Services/ISkuProductPickerService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Services/ISkuProductPickerService.cs
@@ -1,0 +1,9 @@
+using Ekom.Umb.SkuProductPicker.Models;
+
+namespace Ekom.Umb.SkuProductPicker.Services;
+
+public interface ISkuProductPickerService
+{
+    IReadOnlyList<SkuProductPickerItem> ResolveKeys(IReadOnlyList<Guid> keys);
+    IReadOnlyList<SkuProductPickerItem> ResolveSkus(IReadOnlyList<string> skus);
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Services/SkuProductPickerService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/SkuProductPicker/Services/SkuProductPickerService.cs
@@ -1,0 +1,126 @@
+using Ekom.Umb.SkuProductPicker.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace Ekom.Umb.SkuProductPicker.Services;
+
+internal sealed class SkuProductPickerService : ISkuProductPickerService
+{
+    private const string ProductContentTypeAlias = "ekmProduct";
+    private const string SkuPropertyAlias = "sku";
+
+    private readonly IContentService _contentService;
+    private readonly IScopeProvider _scopeProvider;
+
+    public SkuProductPickerService(IContentService contentService, IScopeProvider scopeProvider)
+    {
+        _contentService = contentService;
+        _scopeProvider = scopeProvider;
+    }
+
+    public IReadOnlyList<SkuProductPickerItem> ResolveKeys(IReadOnlyList<Guid> keys)
+    {
+        var productSkus = new List<SkuProductPickerItem>();
+
+        foreach (var key in keys.Distinct())
+        {
+            var content = _contentService.GetById(key);
+            if (content == null
+                || content.Trashed
+                || !content.ContentType.Alias.Equals(ProductContentTypeAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var sku = content.GetValue<string>(SkuPropertyAlias)?.Trim();
+            if (string.IsNullOrWhiteSpace(sku))
+            {
+                continue;
+            }
+
+            productSkus.Add(new SkuProductPickerItem { Key = key, Sku = sku });
+        }
+
+        var productsBySku = GetProductsBySku(productSkus.Select(x => x.Sku));
+        return productSkus
+            .Where(item => productsBySku.TryGetValue(item.Sku, out var matches)
+                && matches.Count == 1
+                && matches[0].Key == item.Key)
+            .ToList();
+    }
+
+    public IReadOnlyList<SkuProductPickerItem> ResolveSkus(IReadOnlyList<string> skus)
+    {
+        var productsBySku = GetProductsBySku(skus);
+        var results = new List<SkuProductPickerItem>();
+
+        foreach (var sku in skus)
+        {
+            var normalizedSku = sku?.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedSku)
+                || !productsBySku.TryGetValue(normalizedSku, out var matches)
+                || matches.Count != 1)
+            {
+                continue;
+            }
+
+            results.Add(matches[0]);
+        }
+
+        return results;
+    }
+
+    private IReadOnlyDictionary<string, List<SkuProductPickerItem>> GetProductsBySku(IEnumerable<string> skus)
+    {
+        var requestedSkus = skus
+            .Select(sku => sku?.Trim())
+            .Where(sku => !string.IsNullOrWhiteSpace(sku))
+            .Distinct(StringComparer.Ordinal)
+            .Cast<string>()
+            .ToList();
+
+        if (requestedSkus.Count == 0)
+        {
+            return new Dictionary<string, List<SkuProductPickerItem>>(StringComparer.Ordinal);
+        }
+
+        using var scope = _scopeProvider.CreateScope(autoComplete: true);
+        var rows = scope.Database.Fetch<SkuProductPickerRow>(
+            @"SELECT n.uniqueId AS [Key], pd.varcharValue AS Sku
+FROM umbracoNode n
+INNER JOIN umbracoContent c ON c.nodeId = n.id
+INNER JOIN cmsContentType ct ON ct.nodeId = c.contentTypeId
+INNER JOIN umbracoContentVersion cv ON cv.nodeId = n.id AND cv.[current] = 1
+INNER JOIN umbracoPropertyData pd ON pd.versionId = cv.id
+INNER JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
+WHERE n.trashed = 0
+  AND ct.alias = @0
+  AND pt.alias = @1
+  AND pd.varcharValue IN (@2)",
+            ProductContentTypeAlias,
+            SkuPropertyAlias,
+            requestedSkus);
+
+        return rows
+            .Where(row => !string.IsNullOrWhiteSpace(row.Sku))
+            .GroupBy(row => row.Sku, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .GroupBy(row => row.Key)
+                    .Select(keyGroup => keyGroup.First())
+                    .Select(row => new SkuProductPickerItem
+                    {
+                        Key = row.Key,
+                        Sku = row.Sku,
+                    })
+                    .ToList(),
+                StringComparer.Ordinal);
+    }
+
+    private sealed class SkuProductPickerRow
+    {
+        public Guid Key { get; init; }
+        public string Sku { get; init; } = string.Empty;
+    }
+}

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/manifests.js
@@ -195,6 +195,27 @@ const e = [
   },
   {
     type: "propertyEditorSchema",
+    alias: "Ekom.SkuProductPicker",
+    name: "Ekom SKU Product Picker",
+    meta: {
+      defaultPropertyEditorUiAlias: "Ekom.PropertyEditorUi.SkuProductPicker"
+    }
+  },
+  {
+    type: "propertyEditorUi",
+    alias: "Ekom.PropertyEditorUi.SkuProductPicker",
+    name: "Ekom SKU Product Picker UI",
+    element: "/App_Plugins/Ekom/dist/sku-product-picker.element.js",
+    meta: {
+      label: "Ekom SKU Product Picker",
+      propertyEditorSchemaAlias: "Ekom.SkuProductPicker",
+      icon: "icon-page-add",
+      group: "Ekom",
+      supportsReadOnly: !0
+    }
+  },
+  {
+    type: "propertyEditorSchema",
     alias: "Ekom.Range",
     name: "Ekom Range Editor",
     meta: {

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/sku-product-picker.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/sku-product-picker.element.js
@@ -1,0 +1,89 @@
+var a = Object.defineProperty;
+var d = (o, n, e) => n in o ? a(o, n, { enumerable: !0, configurable: !0, writable: !0, value: e }) : o[n] = e;
+var r = (o, n, e) => d(o, typeof n != "symbol" ? n + "" : n, e);
+import { UmbChangeEvent as l } from "@umbraco-cms/backoffice/event";
+import { createExtensionElement as u } from "@umbraco-cms/backoffice/extension-api";
+import { umbExtensionsRegistry as c } from "@umbraco-cms/backoffice/extension-registry";
+import { UmbPropertyEditorConfigCollection as h } from "@umbraco-cms/backoffice/property-editor";
+class y extends HTMLElement {
+  constructor() {
+    super(...arguments);
+    r(this, "manifest");
+    r(this, "name");
+    r(this, "dataSourceAlias");
+    r(this, "config");
+    r(this, "mandatory");
+    r(this, "mandatoryMessage");
+    r(this, "nativeEditor");
+    r(this, "skus", []);
+  }
+  get value() {
+    return this.skus;
+  }
+  set value(e) {
+    this.skus = this.normalizeSkus(e), this.syncNativeValue();
+  }
+  get readonly() {
+    return this.hasAttribute("readonly");
+  }
+  set readonly(e) {
+    this.toggleAttribute("readonly", e), this.syncReadOnlyState();
+  }
+  connectedCallback() {
+    this.createNativeEditor();
+  }
+  disconnectedCallback() {
+    var e, t;
+    (t = (e = this.nativeEditor) == null ? void 0 : e.destroy) == null || t.call(e);
+  }
+  async createNativeEditor() {
+    const e = c.getByAlias("Umb.PropertyEditorUi.ContentPicker");
+    if (e == null)
+      throw new Error("Could not find the Umbraco Content Picker property editor UI.");
+    const t = await u(e);
+    if (t == null)
+      throw new Error("Could not create the Umbraco Content Picker property editor UI.");
+    t.manifest = e, t.name = this.name, t.config = this.config ?? new h([]), t.readonly = this.readonly, t.mandatory = this.mandatory, t.mandatoryMessage = this.mandatoryMessage, t.toggleAttribute("readonly", this.readonly), t.addEventListener("change", (i) => this.onNativeEditorChange(i)), t.addEventListener("property-value-change", (i) => this.onNativeEditorChange(i)), this.nativeEditor = t, this.replaceChildren(t), await this.syncNativeValue();
+  }
+  async syncNativeValue() {
+    if (this.nativeEditor == null)
+      return;
+    const e = await this.post("skus", { skus: this.skus });
+    this.nativeEditor.value = e.map((t) => ({
+      type: "document",
+      unique: t.key
+    }));
+  }
+  async onNativeEditorChange(e) {
+    if (e.stopPropagation(), this.nativeEditor == null)
+      return;
+    const t = this.getKeys(this.nativeEditor.value), i = await this.post("keys", { keys: t });
+    this.skus = i.map((s) => s.sku), this.dispatchEvent(new l());
+  }
+  getKeys(e) {
+    return Array.isArray(e) ? e.map((t) => typeof t == "object" && t != null && "unique" in t ? t.unique : void 0).filter((t) => typeof t == "string") : [];
+  }
+  normalizeSkus(e) {
+    return Array.isArray(e) ? e.filter((t) => typeof t == "string").map((t) => t.trim()).filter((t) => t.length > 0) : [];
+  }
+  syncReadOnlyState() {
+    this.nativeEditor != null && (this.nativeEditor.readonly = this.readonly, this.nativeEditor.toggleAttribute("readonly", this.readonly));
+  }
+  async post(e, t) {
+    const i = await fetch(`/ekom/backoffice/SkuProductPicker/${e}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(t)
+    });
+    if (!i.ok)
+      throw new Error(`Could not resolve selected products (${i.status}).`);
+    return i.json();
+  }
+}
+customElements.define("ekom-sku-product-picker", y);
+export {
+  y as EkomSkuProductPickerElement,
+  y as default
+};

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manifests.ts
@@ -195,6 +195,27 @@ export const manifests: Array<UmbExtensionManifest> = [
   },
   {
     type: 'propertyEditorSchema',
+    alias: 'Ekom.SkuProductPicker',
+    name: 'Ekom SKU Product Picker',
+    meta: {
+      defaultPropertyEditorUiAlias: 'Ekom.PropertyEditorUi.SkuProductPicker',
+    },
+  },
+  {
+    type: 'propertyEditorUi',
+    alias: 'Ekom.PropertyEditorUi.SkuProductPicker',
+    name: 'Ekom SKU Product Picker UI',
+    element: '/App_Plugins/Ekom/dist/sku-product-picker.element.js',
+    meta: {
+      label: 'Ekom SKU Product Picker',
+      propertyEditorSchemaAlias: 'Ekom.SkuProductPicker',
+      icon: 'icon-page-add',
+      group: 'Ekom',
+      supportsReadOnly: true,
+    },
+  },
+  {
+    type: 'propertyEditorSchema',
     alias: 'Ekom.Range',
     name: 'Ekom Range Editor',
     meta: {

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/sku-product-picker.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/sku-product-picker.element.ts
@@ -1,0 +1,164 @@
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import {
+  UmbPropertyEditorConfigCollection,
+  type ManifestPropertyEditorUi,
+  type UmbPropertyEditorConfigCollection as UmbPropertyEditorConfigCollectionType,
+  type UmbPropertyEditorUiElement,
+} from '@umbraco-cms/backoffice/property-editor';
+
+type DocumentReference = {
+  type: 'document';
+  unique: string;
+};
+
+type SkuProductPickerItem = {
+  key: string;
+  sku: string;
+};
+
+export class EkomSkuProductPickerElement extends HTMLElement implements UmbPropertyEditorUiElement {
+  manifest?: ManifestPropertyEditorUi;
+  name?: string;
+  dataSourceAlias?: string;
+  config?: UmbPropertyEditorConfigCollectionType;
+  mandatory?: boolean;
+  mandatoryMessage?: string;
+
+  private nativeEditor?: UmbPropertyEditorUiElement;
+  private skus: string[] = [];
+
+  get value(): string[] {
+    return this.skus;
+  }
+
+  set value(value: unknown) {
+    this.skus = this.normalizeSkus(value);
+    void this.syncNativeValue();
+  }
+
+  get readonly(): boolean {
+    return this.hasAttribute('readonly');
+  }
+
+  set readonly(value: boolean) {
+    this.toggleAttribute('readonly', value);
+    this.syncReadOnlyState();
+  }
+
+  override connectedCallback(): void {
+    void this.createNativeEditor();
+  }
+
+  override disconnectedCallback(): void {
+    this.nativeEditor?.destroy?.();
+  }
+
+  private async createNativeEditor(): Promise<void> {
+    const manifest = umbExtensionsRegistry.getByAlias<ManifestPropertyEditorUi>('Umb.PropertyEditorUi.ContentPicker');
+    if (manifest == null) {
+      throw new Error('Could not find the Umbraco Content Picker property editor UI.');
+    }
+
+    const editor = await createExtensionElement<UmbPropertyEditorUiElement>(manifest);
+    if (editor == null) {
+      throw new Error('Could not create the Umbraco Content Picker property editor UI.');
+    }
+
+    editor.manifest = manifest;
+    editor.name = this.name;
+    editor.config = this.config ?? new UmbPropertyEditorConfigCollection([]);
+    editor.readonly = this.readonly;
+    editor.mandatory = this.mandatory;
+    editor.mandatoryMessage = this.mandatoryMessage;
+    editor.toggleAttribute('readonly', this.readonly);
+    editor.addEventListener('change', event => this.onNativeEditorChange(event));
+    editor.addEventListener('property-value-change', event => this.onNativeEditorChange(event));
+
+    this.nativeEditor = editor;
+    this.replaceChildren(editor);
+    await this.syncNativeValue();
+  }
+
+  private async syncNativeValue(): Promise<void> {
+    if (this.nativeEditor == null) {
+      return;
+    }
+
+    const items = await this.post<SkuProductPickerItem[]>('skus', { skus: this.skus });
+    this.nativeEditor.value = items.map(item => ({
+      type: 'document',
+      unique: item.key,
+    } satisfies DocumentReference));
+  }
+
+  private async onNativeEditorChange(event: Event): Promise<void> {
+    event.stopPropagation();
+
+    if (this.nativeEditor == null) {
+      return;
+    }
+
+    const keys = this.getKeys(this.nativeEditor.value);
+    const items = await this.post<SkuProductPickerItem[]>('keys', { keys });
+    this.skus = items.map(item => item.sku);
+    this.dispatchEvent(new UmbChangeEvent());
+  }
+
+  private getKeys(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .map(item => typeof item === 'object' && item != null && 'unique' in item ? item.unique : undefined)
+      .filter((key): key is string => typeof key === 'string');
+  }
+
+  private normalizeSkus(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .filter((sku): sku is string => typeof sku === 'string')
+      .map(sku => sku.trim())
+      .filter(sku => sku.length > 0);
+  }
+
+  private syncReadOnlyState(): void {
+    if (this.nativeEditor == null) {
+      return;
+    }
+
+    this.nativeEditor.readonly = this.readonly;
+    this.nativeEditor.toggleAttribute('readonly', this.readonly);
+  }
+
+  private async post<T>(route: string, body: unknown): Promise<T> {
+    const response = await fetch(`/ekom/backoffice/SkuProductPicker/${route}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Could not resolve selected products (${response.status}).`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+}
+
+customElements.define('ekom-sku-product-picker', EkomSkuProductPickerElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ekom-sku-product-picker': EkomSkuProductPickerElement;
+  }
+}
+
+export default EkomSkuProductPickerElement;

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         'price-editor.element': 'src/property-editors/price-editor.element.ts',
         'property-editor.element': 'src/property-editors/property-editor.element.ts',
         'range-editor.element': 'src/property-editors/range-editor.element.ts',
+        'sku-product-picker.element': 'src/property-editors/sku-product-picker.element.ts',
         'stock-editor.element': 'src/property-editors/stock-editor.element.ts',
         'variant-count-workspace-footer-app.element': 'src/variants/variant-count-workspace-footer-app.element.ts',
         'variants-workspace-view.element': 'src/variants/variants-workspace-view.element.ts',


### PR DESCRIPTION
## Summary
- add an Ekom SKU Product Picker that persists selected product SKUs as a JSON array
- reuse the U17 Content Picker experience for published and unpublished ekmProduct documents
- omit products with missing or ambiguous SKUs and restore selections through current content-version lookup
- restore written product publish status beside its status dot in catalog cards

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- `npm run typecheck` and `npm run build` in `Ekom/Ekom.Web/Ekom.Web.U17/Client`
- manually select published and unpublished products and verify SKU persistence, missing/duplicate SKU omission, and catalog product status text