### PR TITLE
fix(catalog): use node names in collection

### DIFF
--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/catalog-collection-view.element.js
@@ -1,6 +1,6 @@
 var P = Object.defineProperty;
-var C = (r, c, e) => c in r ? P(r, c, { enumerable: !0, configurable: !0, writable: !0, value: e }) : r[c] = e;
-var l = (r, c, e) => C(r, typeof c != "symbol" ? c + "" : c, e);
+var C = (r, d, e) => d in r ? P(r, d, { enumerable: !0, configurable: !0, writable: !0, value: e }) : r[d] = e;
+var l = (r, d, e) => C(r, typeof d != "symbol" ? d + "" : d, e);
 import { UMB_COLLECTION_CONTEXT as E } from "@umbraco-cms/backoffice/collection";
 import { UmbElementMixin as T } from "@umbraco-cms/backoffice/element-api";
 import "@umbraco-cms/backoffice/imaging";
@@ -234,9 +234,9 @@ class O extends T(HTMLElement) {
   }
   renderBreadcrumbs(e) {
     return `<nav class="breadcrumbs">${e.breadcrumbs.map((t, i) => {
-      const o = i === e.breadcrumbs.length - 1, a = p(t.title || t.name), s = t.siblings.filter((d) => d.key !== t.key), h = t.contentTypeAlias === "ekmCategory" && s.length > 0 ? `<div class="breadcrumb-category"><a class="breadcrumb-link" href="${this.getDocumentHref(t.key)}" data-breadcrumb-link-key="${p(t.key)}" ${o ? 'aria-current="page"' : ""}>${a}</a><details class="breadcrumb-menu"><summary aria-label="Show sibling categories for ${a}"><span aria-hidden="true"></span></summary><div class="breadcrumb-menu-list" role="menu">${s.map((d) => {
-        const u = p(d.title || d.name);
-        return `<button type="button" data-breadcrumb-category-key="${p(d.key)}" role="menuitem">${u}</button>`;
+      const o = i === e.breadcrumbs.length - 1, a = p(t.name), s = t.siblings.filter((c) => c.key !== t.key), h = t.contentTypeAlias === "ekmCategory" && s.length > 0 ? `<div class="breadcrumb-category"><a class="breadcrumb-link" href="${this.getDocumentHref(t.key)}" data-breadcrumb-link-key="${p(t.key)}" ${o ? 'aria-current="page"' : ""}>${a}</a><details class="breadcrumb-menu"><summary aria-label="Show sibling categories for ${a}"><span aria-hidden="true"></span></summary><div class="breadcrumb-menu-list" role="menu">${s.map((c) => {
+        const u = p(c.name);
+        return `<button type="button" data-breadcrumb-category-key="${p(c.key)}" role="menuitem">${u}</button>`;
       }).join("")}</div></details></div>` : o ? `<span aria-current="page">${a}</span>` : `<a href="${this.getDocumentHref(t.key)}">${a}</a>`;
       return `${i > 0 ? '<span class="sep">/</span>' : ""}${h}`;
     }).join("")}</nav>`;
@@ -246,7 +246,7 @@ class O extends T(HTMLElement) {
       <header class="catalog-header">
         <button type="button" class="back" data-action="back" ${e.parent == null ? "disabled" : ""}>←</button>
         <div>
-          <h1>${p(e.current.title || e.current.name)}</h1>
+          <h1>${p(e.current.name)}</h1>
           <p>${e.productCount} products · ${e.subcategoryCount} subcategories</p>
         </div>
       </header>
@@ -282,7 +282,7 @@ class O extends T(HTMLElement) {
         <h2>Subcategories</h2>
         <div class="chips">${e.map((t) => `
           <a class="chip" href="${this.getDocumentHref(t.key)}">
-            <span class="tile">▦</span><span class="chip-text"><strong>${p(t.title || t.name)}<span class="chip-status ${k(t.status)}" title="${t.status}" aria-label="${t.status}"></span></strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
+            <span class="tile">▦</span><span class="chip-text"><strong>${p(t.name)}<span class="chip-status ${k(t.status)}" title="${t.status}" aria-label="${t.status}"></span></strong><small>${t.productCount} products · ${t.subcategoryCount} subcategories</small></span><span>›</span>
           </a>
         `).join("")}</div>
       </section>
@@ -313,9 +313,9 @@ class O extends T(HTMLElement) {
     return `
       <article class="card ${t ? "selected" : ""}">
         <button type="button" class="checkbox ${t ? "checked" : ""}" data-product-key="${e.key}">${t ? "✓" : ""}</button>
-        <a class="image ${e.published ? "" : "dimmed"}" href="${i}">${e.image ? `<umb-imaging-thumbnail unique="${p(e.image)}" width="320" height="160" alt="${p(e.title || e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
+        <a class="image ${e.published ? "" : "dimmed"}" href="${i}">${e.image ? `<umb-imaging-thumbnail unique="${p(e.image)}" width="320" height="160" alt="${p(e.name)}"></umb-imaging-thumbnail>` : "<span>Product image</span>"}</a>
         <div class="card-body">
-          <a class="title" href="${i}">${p(e.title || e.name)}</a>
+          <a class="title" href="${i}">${p(e.name)}</a>
           <div class="meta"><span>${e.sku ? `SKU ${p(e.sku)}` : "No SKU"}</span><strong>${p(e.price)}</strong></div>
           <div class="status-row"><span class="pill ${k(e.status)}"><i></i>${e.status}</span><strong class="availability ${e.available ? "ok" : "bad"}">${e.available ? "✓ Available" : "✕ Unavailable"}</strong></div>
         </div>
@@ -356,8 +356,8 @@ class O extends T(HTMLElement) {
       s.addEventListener("click", (n) => {
         var u;
         n.preventDefault();
-        const h = s.dataset.productKey, d = (u = this.data) == null ? void 0 : u.products.find((g) => g.key === h);
-        d != null && this.toggleProduct(d);
+        const h = s.dataset.productKey, c = (u = this.data) == null ? void 0 : u.products.find((g) => g.key === h);
+        c != null && this.toggleProduct(c);
       });
     }), this.querySelectorAll("[data-page]").forEach((s) => {
       s.addEventListener("click", () => this.setPage(Number(s.dataset.page)));
@@ -365,13 +365,13 @@ class O extends T(HTMLElement) {
       s.addEventListener("click", (n) => {
         var u;
         n.preventDefault();
-        const h = s.dataset.breadcrumbLinkKey, d = (u = this.data) == null ? void 0 : u.breadcrumbs.find((g) => g.key === h);
-        d != null && this.drillTo(d);
+        const h = s.dataset.breadcrumbLinkKey, c = (u = this.data) == null ? void 0 : u.breadcrumbs.find((g) => g.key === h);
+        c != null && this.drillTo(c);
       });
     }), this.querySelectorAll("[data-breadcrumb-category-key]").forEach((s) => {
       s.addEventListener("click", () => {
-        var d;
-        const n = s.dataset.breadcrumbCategoryKey, h = (d = this.data) == null ? void 0 : d.breadcrumbs.flatMap((u) => u.siblings).find((u) => u.key === n);
+        var c;
+        const n = s.dataset.breadcrumbCategoryKey, h = (c = this.data) == null ? void 0 : c.breadcrumbs.flatMap((u) => u.siblings).find((u) => u.key === n);
         h != null && this.drillTo(h);
       });
     }), this.querySelectorAll(".breadcrumb-menu").forEach((s) => {
@@ -408,12 +408,12 @@ class O extends T(HTMLElement) {
   }
 }
 class x extends Error {
-  constructor(c, e) {
-    super(c), this.status = e;
+  constructor(d, e) {
+    super(d), this.status = e;
   }
 }
 function p(r) {
-  return r.replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c] ?? c);
+  return r.replace(/[&<>"]/g, (d) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[d] ?? d);
 }
 function k(r) {
   return r === "Published" ? "published" : r === "Pending changes" ? "pending" : "unpublished";

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/catalog/catalog-collection-view.element.ts
@@ -486,12 +486,12 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
   private renderBreadcrumbs(data: CatalogResponse): string {
     return `<nav class="breadcrumbs">${data.breadcrumbs.map((item, index) => {
       const isCurrent = index === data.breadcrumbs.length - 1;
-      const label = escapeHtml(item.title || item.name);
+      const label = escapeHtml(item.name);
       const siblings = item.siblings.filter(sibling => sibling.key !== item.key);
       const hasSiblings = item.contentTypeAlias === 'ekmCategory' && siblings.length > 0;
       const breadcrumb = hasSiblings
         ? `<div class="breadcrumb-category"><a class="breadcrumb-link" href="${this.getDocumentHref(item.key)}" data-breadcrumb-link-key="${escapeHtml(item.key)}" ${isCurrent ? 'aria-current="page"' : ''}>${label}</a><details class="breadcrumb-menu"><summary aria-label="Show sibling categories for ${label}"><span aria-hidden="true"></span></summary><div class="breadcrumb-menu-list" role="menu">${siblings.map(sibling => {
-          const siblingLabel = escapeHtml(sibling.title || sibling.name);
+          const siblingLabel = escapeHtml(sibling.name);
           return `<button type="button" data-breadcrumb-category-key="${escapeHtml(sibling.key)}" role="menuitem">${siblingLabel}</button>`;
         }).join('')}</div></details></div>`
         : isCurrent ? `<span aria-current="page">${label}</span>` : `<a href="${this.getDocumentHref(item.key)}">${label}</a>`;
@@ -504,7 +504,7 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
       <header class="catalog-header">
         <button type="button" class="back" data-action="back" ${data.parent == null ? 'disabled' : ''}>←</button>
         <div>
-          <h1>${escapeHtml(data.current.title || data.current.name)}</h1>
+          <h1>${escapeHtml(data.current.name)}</h1>
           <p>${data.productCount} products · ${data.subcategoryCount} subcategories</p>
         </div>
       </header>
@@ -541,7 +541,7 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
         <h2>Subcategories</h2>
         <div class="chips">${subcategories.map(category => `
           <a class="chip" href="${this.getDocumentHref(category.key)}">
-            <span class="tile">▦</span><span class="chip-text"><strong>${escapeHtml(category.title || category.name)}<span class="chip-status ${statusClass(category.status)}" title="${category.status}" aria-label="${category.status}"></span></strong><small>${category.productCount} products · ${category.subcategoryCount} subcategories</small></span><span>›</span>
+            <span class="tile">▦</span><span class="chip-text"><strong>${escapeHtml(category.name)}<span class="chip-status ${statusClass(category.status)}" title="${category.status}" aria-label="${category.status}"></span></strong><small>${category.productCount} products · ${category.subcategoryCount} subcategories</small></span><span>›</span>
           </a>
         `).join('')}</div>
       </section>
@@ -577,9 +577,9 @@ class EkomCatalogCollectionViewElement extends UmbElementMixin(HTMLElement) {
     return `
       <article class="card ${selected ? 'selected' : ''}">
         <button type="button" class="checkbox ${selected ? 'checked' : ''}" data-product-key="${product.key}">${selected ? '✓' : ''}</button>
-        <a class="image ${!product.published ? 'dimmed' : ''}" href="${href}">${product.image ? `<umb-imaging-thumbnail unique="${escapeHtml(product.image)}" width="320" height="160" alt="${escapeHtml(product.title || product.name)}"></umb-imaging-thumbnail>` : '<span>Product image</span>'}</a>
+        <a class="image ${!product.published ? 'dimmed' : ''}" href="${href}">${product.image ? `<umb-imaging-thumbnail unique="${escapeHtml(product.image)}" width="320" height="160" alt="${escapeHtml(product.name)}"></umb-imaging-thumbnail>` : '<span>Product image</span>'}</a>
         <div class="card-body">
-          <a class="title" href="${href}">${escapeHtml(product.title || product.name)}</a>
+          <a class="title" href="${href}">${escapeHtml(product.name)}</a>
           <div class="meta"><span>${product.sku ? `SKU ${escapeHtml(product.sku)}` : 'No SKU'}</span><strong>${escapeHtml(product.price)}</strong></div>
           <div class="status-row"><span class="pill ${statusClass(product.status)}"><i></i>${product.status}</span><strong class="availability ${product.available ? 'ok' : 'bad'}">${product.available ? '✓ Available' : '✕ Unavailable'}</strong></div>
         </div>


### PR DESCRIPTION
## Summary
- display Umbraco node names instead of title properties throughout the catalog collection
- update breadcrumbs, sibling navigation, catalog headers, category cards, and product card image labels

## Test Plan
- `npm run typecheck` in `Ekom/Ekom.Web/Ekom.Web.U17/Client`
- `npm run build` in `Ekom/Ekom.Web/Ekom.Web.U17/Client`
- verify catalog collection labels match document node names