### PR TITLE
fix(algolia): handle oversized content records

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaContentRecordSizeInspectorTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaContentRecordSizeInspectorTests.cs
@@ -1,0 +1,75 @@
+using Ekom.Algolia;
+using Ekom.Algolia.Indexing;
+using Ekom.Algolia.Models.Indexing;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaContentRecordSizeInspectorTests
+{
+    [Fact]
+    public void Measures_Serialized_Utf8_Record_Size()
+    {
+        var record = CreateRecord();
+        record.Data["body"] = "Halló 🌋";
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        var result = AlgoliaContentRecordSizeInspector.Inspect(record);
+
+        Assert.Equal(JsonSerializer.SerializeToUtf8Bytes(record, options).Length, result.SizeBytes);
+    }
+
+    [Fact]
+    public void Reports_Largest_Fields_Without_Field_Values()
+    {
+        var record = CreateRecord();
+        var body = new string('x', 1_000);
+        record.Data["body"] = body;
+        record.Data["summary"] = "Short";
+
+        var result = AlgoliaContentRecordSizeInspector.Inspect(record);
+
+        var largestField = Assert.Single(result.LargestFields, field => field.Name == "body");
+        Assert.True(largestField.SizeBytes > 1_000);
+        Assert.DoesNotContain(result.LargestFields, field => field.Name == body);
+    }
+
+    [Theory]
+    [InlineData("{\"message\":\"Record is too big\",\"objectID\":\"record-key\",\"status\":400}", true, "record-key")]
+    [InlineData("{\"message\":\"Record at the position 7 objectID=record-key is too big size=102824/100000 bytes.\",\"status\":400}", true, "record-key")]
+    [InlineData("{\"message\":\"Record is too big\",\"status\":400}", false, null)]
+    [InlineData("not-json", false, null)]
+    public void Extracts_ObjectId_From_Algolia_Error(string message, bool expectedResult, string? expectedObjectId)
+    {
+        var result = AlgoliaContentRecordSizeInspector.TryGetObjectId(message, out var objectId);
+
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedObjectId, objectId);
+    }
+
+    [Fact]
+    public void Oversized_Record_Options_Default_To_Fail_At_Algolia_Limit()
+    {
+        var options = new AlgoliaContentIndexingOptions();
+
+        Assert.Equal(AlgoliaOversizedRecordBehavior.Fail, options.OversizedRecords.Behavior);
+        Assert.Equal(100_000, options.OversizedRecords.MaxSizeBytes);
+    }
+
+    private static AlgoliaContentRecord CreateRecord()
+        => new()
+        {
+            ObjectID = "record-key",
+            NodeId = 42,
+            ContentTypeAlias = "article",
+            Url = "/articles/example/",
+            Name = "Example article",
+            UpdateDate = new DateTime(2026, 8, 18, 12, 0, 0, DateTimeKind.Utc),
+            CreateDate = new DateTime(2026, 8, 17, 12, 0, 0, DateTimeKind.Utc)
+        };
+}

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -32,6 +32,8 @@ public class AlgoliaSearchTests
                 ["Ekom:Algolia:Search:Cache:DurationMinutes"] = "15",
                 ["Ekom:Algolia:Search:Cache:CacheEmptyResults"] = "false",
                 ["Ekom:Algolia:ContentIndexing:Enabled"] = "true",
+                ["Ekom:Algolia:ContentIndexing:OversizedRecords:Behavior"] = "Skip",
+                ["Ekom:Algolia:ContentIndexing:OversizedRecords:MaxSizeBytes"] = "90000",
                 ["Ekom:Algolia:ContentIndexing:Indexes:0:IndexName"] = "SearchIndex",
                 ["Ekom:Algolia:ContentIndexing:Indexes:0:ContentTypes:0:Alias"] = "article",
                 ["Ekom:Algolia:ContentIndexing:Indexes:0:ContentTypes:0:Properties:0"] = "title",
@@ -55,6 +57,8 @@ public class AlgoliaSearchTests
         Assert.Equal(15, options.Search.Cache.DurationMinutes);
         Assert.False(options.Search.Cache.CacheEmptyResults);
         Assert.True(options.ContentIndexing.Enabled);
+        Assert.Equal(AlgoliaOversizedRecordBehavior.Skip, options.ContentIndexing.OversizedRecords.Behavior);
+        Assert.Equal(90_000, options.ContentIndexing.OversizedRecords.MaxSizeBytes);
         Assert.Equal("SearchIndex", options.ContentIndexing.Indexes.Single().IndexName);
         Assert.Equal("article", options.ContentIndexing.Indexes.Single().ContentTypes.Single().Alias);
         Assert.Equal(["title", "publishedAt|unix"], options.ContentIndexing.Indexes.Single().ContentTypes.Single().Properties);

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -43,7 +43,20 @@ public sealed class AlgoliaContentIndexingOptions
     public bool EnforcePublisherOnly { get; set; } = true;
     public int BatchSize { get; set; } = 1000;
     public AlgoliaDispatcherOptions Dispatching { get; init; } = new();
+    public AlgoliaOversizedRecordOptions OversizedRecords { get; init; } = new();
     public IReadOnlyCollection<AlgoliaContentIndexOptions> Indexes { get; init; } = [];
+}
+
+public sealed class AlgoliaOversizedRecordOptions
+{
+    public AlgoliaOversizedRecordBehavior Behavior { get; init; } = AlgoliaOversizedRecordBehavior.Fail;
+    public int MaxSizeBytes { get; init; } = 100_000;
+}
+
+public enum AlgoliaOversizedRecordBehavior
+{
+    Fail,
+    Skip
 }
 
 public sealed class AlgoliaContentIndexOptions

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentRecordSizeInspector.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentRecordSizeInspector.cs
@@ -1,0 +1,113 @@
+using Ekom.Algolia.Models.Indexing;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Ekom.Algolia.Indexing;
+
+internal static class AlgoliaContentRecordSizeInspector
+{
+    private const int ReportedFieldCount = 5;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static int GetSizeBytes(AlgoliaContentRecord record)
+        => JsonSerializer.SerializeToUtf8Bytes(record, JsonOptions).Length;
+
+    public static AlgoliaContentRecordSizeInfo Inspect(AlgoliaContentRecord record)
+    {
+        var sizeBytes = GetSizeBytes(record);
+        var fieldSizes = GetFields(record)
+            .Select(field => new AlgoliaContentFieldSize(field.Key, GetFieldSize(field.Key, field.Value)))
+            .OrderByDescending(field => field.SizeBytes)
+            .ThenBy(field => field.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(ReportedFieldCount)
+            .ToList();
+
+        return new AlgoliaContentRecordSizeInfo(record, sizeBytes, fieldSizes);
+    }
+
+    public static bool TryGetObjectId(string message, out string? objectId)
+    {
+        objectId = null;
+
+        if (string.IsNullOrWhiteSpace(message))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(message);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                return false;
+
+            if (document.RootElement.TryGetProperty("objectID", out var objectIdElement) && objectIdElement.ValueKind == JsonValueKind.String)
+            {
+                objectId = objectIdElement.GetString();
+                return !string.IsNullOrWhiteSpace(objectId);
+            }
+
+            if (!document.RootElement.TryGetProperty("message", out var messageElement) || messageElement.ValueKind != JsonValueKind.String)
+                return false;
+
+            objectId = ExtractObjectId(messageElement.GetString());
+            return !string.IsNullOrWhiteSpace(objectId);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string? ExtractObjectId(string? message)
+    {
+        const string marker = "objectID=";
+        const string suffix = " is too big";
+
+        if (string.IsNullOrWhiteSpace(message))
+            return null;
+
+        var startIndex = message.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (startIndex < 0)
+            return null;
+
+        startIndex += marker.Length;
+        var endIndex = message.IndexOf(suffix, startIndex, StringComparison.OrdinalIgnoreCase);
+        if (endIndex < 0)
+            endIndex = message.Length;
+
+        var value = message[startIndex..endIndex].Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static IEnumerable<KeyValuePair<string, object?>> GetFields(AlgoliaContentRecord record)
+    {
+        yield return new("objectID", record.ObjectID);
+        yield return new("nodeId", record.NodeId);
+        yield return new("contentTypeAlias", record.ContentTypeAlias);
+        yield return new("url", record.Url);
+        yield return new("name", record.Name);
+        yield return new("updateDate", record.UpdateDate);
+        yield return new("updateDateUnixSecond", record.UpdateDateUnixSecond);
+        yield return new("createDate", record.CreateDate);
+        yield return new("createDateUnixSecond", record.CreateDateUnixSecond);
+
+        foreach (var field in record.Data)
+            yield return new(field.Key, field.Value);
+    }
+
+    private static int GetFieldSize(string fieldName, object? value)
+    {
+        var nameSize = Encoding.UTF8.GetByteCount(JsonSerializer.Serialize(fieldName, JsonOptions));
+        var valueSize = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions).Length;
+        return nameSize + valueSize + 1;
+    }
+}
+
+internal sealed record AlgoliaContentRecordSizeInfo(
+    AlgoliaContentRecord Record,
+    int SizeBytes,
+    IReadOnlyList<AlgoliaContentFieldSize> LargestFields);
+
+internal sealed record AlgoliaContentFieldSize(string Name, int SizeBytes);

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -84,11 +84,8 @@ public sealed class ProductSearchController
         "Variants": false,
         "BatchSize": 1000,
         "ProductProperties": [
-          "title",
-          "summary",
-          "description",
           "channels|array",
-          "stockCount|int",
+          "packageCount|int",
           "weight|decimal",
           "publishedAt|unix"
         ],
@@ -103,6 +100,10 @@ public sealed class ProductSearchController
         "Enabled": true,
         "EnforcePublisherOnly": true,
         "BatchSize": 1000,
+        "OversizedRecords": {
+          "Behavior": "Fail",
+          "MaxSizeBytes": 100000
+        },
         "Indexes": [
           {
             "IndexName": "SearchIndex",
@@ -185,6 +186,8 @@ public sealed class ProductSearchController
 | `Indexing:Dispatching:MaxConcurrency` | `int` | `2` | Maximum indexing worker concurrency. |
 | `ContentIndexing:Enabled` | `bool` | `false` | Enables standard Umbraco content indexing. |
 | `ContentIndexing:BatchSize` | `int` | `1000` | Batch size for content index rebuild operations. |
+| `ContentIndexing:OversizedRecords:Behavior` | `Fail` or `Skip` | `Fail` | Fails content indexing or skips records that exceed the configured size limit. |
+| `ContentIndexing:OversizedRecords:MaxSizeBytes` | `int` | `100000` | Maximum serialized UTF-8 size of one content record. |
 | `ContentIndexing:Indexes` | `object[]` | `[]` | Content indexes to maintain. Index names resolve as `{IndexName}.{Environment}.{Culture}`. |
 | `ContentIndexing:Indexes[*]:ContentTypes[*]:Alias` | `string` | required | Umbraco content type alias to include in the content index. |
 | `ContentIndexing:Indexes[*]:ContentTypes[*]:Properties` | `string[]` | `[]` | Property aliases to index. Use `|unix` or `|unixms` to add numeric date fields. |
@@ -249,6 +252,31 @@ When `Search:QuerySuggestions` is enabled, the plugin provisions the separate `q
     }
   }
 }
+```
+
+### Oversized content records
+
+Standard content records are measured before they are sent to Algolia. The default `ContentIndexing:OversizedRecords:Behavior` is `Fail`, which stops the operation and logs enough Umbraco context to identify the node. Set it to `Skip` to exclude oversized records and continue indexing:
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "ContentIndexing": {
+        "OversizedRecords": {
+          "Behavior": "Skip",
+          "MaxSizeBytes": 100000
+        }
+      }
+    }
+  }
+}
+```
+
+Diagnostics include the index name, record size, `NodeId`, `objectID`, node name, content type alias, URL, and the five largest field names with their approximate byte sizes. Field values are not logged. When `Skip` is used during incremental indexing, any previous record for that node is deleted from Algolia to prevent stale content.
+
+```text
+Algolia content record is too large for index SearchIndex.prod.en-US: size 102824/100000 bytes, NodeId 1234, ObjectID f0446822-c9cd-4bd9-8351-2e582153ce43, Name Example article, ContentTypeAlias article, Url /articles/example/, LargestFields body=101542, summary=640. Behavior: Fail.
 ```
 
 ### Index naming and store context
@@ -343,7 +371,19 @@ Search cache keys include the resolved index name and serialized Algolia query p
 
 ### Product records and ranking fields
 
-Product records always include `Title` as a top-level field. `NodeName` contains the Umbraco node name.
+Product records provide the following fields without requiring any `Indexing:ProductProperties` configuration:
+
+- Identity: `objectID`, `Sku`, `ProductId`, and `IsVariant`.
+- Content: `NodeName`, `Title`, `Summary`, `Description`, and `Url`.
+- Images: `image_url` and `ImageUrls`.
+- Pricing: `Price`, `PriceWithVat`, `PriceWithoutVat`, and `Currency`.
+- Availability and ranking: `Available`, `ProductRanking`, and `CategoryRanking`.
+- Store context and dates: `StoreAlias`, `Locale`, `CreatedAt`, and `UpdatedAt`.
+- Categories: `hierarchical_categories.lvl0`, additional hierarchy levels when present, and `category_paths`.
+
+Optional fields are omitted when no value is available. `Stock` is included only when `Stores[*]:IncludeStock` is enabled. Variant-specific fields are included when variant indexing is enabled, as described below.
+
+`Title` is a required top-level field. `NodeName` contains the Umbraco node name.
 
 `Available` is indexed as a numeric value so it can be used for ranking:
 
@@ -417,7 +457,7 @@ Product indexes are configured with `AttributeForDistinct = ProductId`. `Search:
 
 ### Additional product properties and metafields
 
-`Indexing:ProductProperties` adds extra product properties and metafields to product records. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
+`Indexing:ProductProperties` is only for adding extra product properties and metafields that are not part of the default product record fields listed above. Do not add built-in fields such as `title`, `summary`, or `description` here. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
 
 ```json
 {
@@ -426,7 +466,7 @@ Product indexes are configured with `AttributeForDistinct = ProductId`. `Search:
       "Indexing": {
         "ProductProperties": [
           "channels|array",
-          "stockCount|int",
+          "packageCount|int",
           "weight|decimal",
           "publishedAt|unix"
         ]
@@ -468,11 +508,11 @@ Use the backoffice endpoints to rebuild Algolia indexes manually. Both endpoints
 Rebuild all configured store indexes:
 
 ```http
-POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildIndexes
+POST /umbraco/backoffice/api/EkomAlgoliaBackoffice/RebuildIndexes
 ```
 
 Rebuild one store:
 
 ```http
-POST /umbraco/backoffice/api/Ekom/AlgoliaBackoffice/RebuildStoreIndexes?storeAlias=Store
+POST /umbraco/backoffice/api/EkomAlgoliaBackoffice/RebuildStoreIndexes?storeAlias=Store
 ```

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaContentIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaContentIndexExecutor.cs
@@ -1,4 +1,5 @@
 using Algolia.Search.Clients;
+using Algolia.Search.Exceptions;
 using Ekom.Algolia.Mappers;
 using Ekom.Algolia.Models.Indexing;
 using Ekom.Algolia.Services;
@@ -142,8 +143,8 @@ internal sealed class AlgoliaContentIndexExecutor
         {
             ct.ThrowIfCancellationRequested();
             var batchSize = _options.ContentIndexing.BatchSize <= 0 ? 1000 : _options.ContentIndexing.BatchSize;
-            await _client.ReplaceAllObjectsAsync(resolvedIndexName, documents, batchSize, cancellationToken: ct).ConfigureAwait(false);
-            _logger.LogInformation("Rebuilt Algolia content index {IndexName} with {Count} documents.", resolvedIndexName, documents.Count);
+            var indexedCount = await ReplaceAllObjectsAsync(resolvedIndexName, documents, batchSize, ct).ConfigureAwait(false);
+            _logger.LogInformation("Rebuilt Algolia content index {IndexName} with {Count} documents.", resolvedIndexName, indexedCount);
         }
 
         _searchCacheVersions.InvalidateStore("content");
@@ -174,7 +175,7 @@ internal sealed class AlgoliaContentIndexExecutor
                     continue;
 
                 var indexName = _indexNameResolver.Resolve(index.IndexName, culture);
-                await _client.SaveObjectsAsync(indexName, documents, batchSize: 1000, waitForTasks: true, cancellationToken: ct).ConfigureAwait(false);
+                await SaveObjectsAsync(indexName, documents, ct).ConfigureAwait(false);
             }
 
             foreach (var (culture, keys) in deletesByCulture)
@@ -210,6 +211,165 @@ internal sealed class AlgoliaContentIndexExecutor
         var indexName = _indexNameResolver.Resolve(index.IndexName, culture);
         await _client.DeleteObjectsAsync(indexName, ids, batchSize: 1000, waitForTasks: false, cancellationToken: ct).ConfigureAwait(false);
     }
+
+    private async Task<int> ReplaceAllObjectsAsync(
+        string indexName,
+        IReadOnlyCollection<AlgoliaContentRecord> documents,
+        int batchSize,
+        CancellationToken ct)
+    {
+        var accepted = PrepareDocuments(indexName, documents, out _);
+
+        while (true)
+        {
+            try
+            {
+                await _client.ReplaceAllObjectsAsync(indexName, accepted, batchSize, cancellationToken: ct).ConfigureAwait(false);
+                return accepted.Count;
+            }
+            catch (AlgoliaApiException ex)
+            {
+                var oversized = ResolveOversizedRecord(ex, accepted);
+                if (oversized is null)
+                    throw;
+
+                LogOversizedRecord(indexName, oversized, ex);
+                if (_options.ContentIndexing.OversizedRecords.Behavior == AlgoliaOversizedRecordBehavior.Fail)
+                    throw;
+
+                accepted.Remove(oversized.Record);
+            }
+        }
+    }
+
+    private async Task SaveObjectsAsync(
+        string indexName,
+        IReadOnlyCollection<AlgoliaContentRecord> documents,
+        CancellationToken ct)
+    {
+        var accepted = PrepareDocuments(indexName, documents, out var skippedObjectIds);
+
+        while (accepted.Count > 0)
+        {
+            try
+            {
+                await _client.SaveObjectsAsync(indexName, accepted, batchSize: 1000, waitForTasks: true, cancellationToken: ct).ConfigureAwait(false);
+                break;
+            }
+            catch (AlgoliaApiException ex)
+            {
+                var oversized = ResolveOversizedRecord(ex, accepted);
+                if (oversized is null)
+                    throw;
+
+                LogOversizedRecord(indexName, oversized, ex);
+                if (_options.ContentIndexing.OversizedRecords.Behavior == AlgoliaOversizedRecordBehavior.Fail)
+                    throw;
+
+                accepted.Remove(oversized.Record);
+                skippedObjectIds.Add(oversized.Record.ObjectID);
+            }
+        }
+
+        if (skippedObjectIds.Count > 0)
+        {
+            await _client.DeleteObjectsAsync(
+                indexName,
+                skippedObjectIds,
+                batchSize: 1000,
+                waitForTasks: true,
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+    }
+
+    private List<AlgoliaContentRecord> PrepareDocuments(
+        string indexName,
+        IReadOnlyCollection<AlgoliaContentRecord> documents,
+        out HashSet<string> skippedObjectIds)
+    {
+        var maxSizeBytes = _options.ContentIndexing.OversizedRecords.MaxSizeBytes <= 0
+            ? 100_000
+            : _options.ContentIndexing.OversizedRecords.MaxSizeBytes;
+        var accepted = new List<AlgoliaContentRecord>(documents.Count);
+        skippedObjectIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var document in documents)
+        {
+            if (AlgoliaContentRecordSizeInspector.GetSizeBytes(document) <= maxSizeBytes)
+            {
+                accepted.Add(document);
+                continue;
+            }
+
+            var sizeInfo = AlgoliaContentRecordSizeInspector.Inspect(document);
+            LogOversizedRecord(indexName, sizeInfo);
+            if (_options.ContentIndexing.OversizedRecords.Behavior == AlgoliaOversizedRecordBehavior.Fail)
+                throw new InvalidOperationException(BuildOversizedRecordMessage(indexName, sizeInfo, maxSizeBytes));
+
+            skippedObjectIds.Add(document.ObjectID);
+        }
+
+        return accepted;
+    }
+
+    private AlgoliaContentRecordSizeInfo? ResolveOversizedRecord(
+        AlgoliaApiException exception,
+        IReadOnlyCollection<AlgoliaContentRecord> documents)
+    {
+        if (exception.HttpErrorCode != 400 ||
+            !exception.Message.Contains("too big", StringComparison.OrdinalIgnoreCase) ||
+            !AlgoliaContentRecordSizeInspector.TryGetObjectId(exception.Message, out var objectId))
+        {
+            return null;
+        }
+
+        var record = documents.FirstOrDefault(document => document.ObjectID.Equals(objectId, StringComparison.OrdinalIgnoreCase));
+        return record is null ? null : AlgoliaContentRecordSizeInspector.Inspect(record);
+    }
+
+    private void LogOversizedRecord(string indexName, AlgoliaContentRecordSizeInfo sizeInfo, Exception? exception = null)
+    {
+        var maxSizeBytes = _options.ContentIndexing.OversizedRecords.MaxSizeBytes <= 0
+            ? 100_000
+            : _options.ContentIndexing.OversizedRecords.MaxSizeBytes;
+        var largestFields = string.Join(", ", sizeInfo.LargestFields.Select(field => $"{field.Name}={field.SizeBytes}"));
+        var message = "Algolia content record is too large for index {IndexName}: size {RecordSizeBytes}/{MaxSizeBytes} bytes, NodeId {NodeId}, ObjectID {ObjectID}, Name {Name}, ContentTypeAlias {ContentTypeAlias}, Url {Url}, LargestFields {LargestFields}. Behavior: {Behavior}.";
+
+        if (_options.ContentIndexing.OversizedRecords.Behavior == AlgoliaOversizedRecordBehavior.Skip)
+        {
+            _logger.LogWarning(
+                exception,
+                message,
+                indexName,
+                sizeInfo.SizeBytes,
+                maxSizeBytes,
+                sizeInfo.Record.NodeId,
+                sizeInfo.Record.ObjectID,
+                sizeInfo.Record.Name,
+                sizeInfo.Record.ContentTypeAlias,
+                sizeInfo.Record.Url,
+                largestFields,
+                _options.ContentIndexing.OversizedRecords.Behavior);
+            return;
+        }
+
+        _logger.LogError(
+            exception,
+            message,
+            indexName,
+            sizeInfo.SizeBytes,
+            maxSizeBytes,
+            sizeInfo.Record.NodeId,
+            sizeInfo.Record.ObjectID,
+            sizeInfo.Record.Name,
+            sizeInfo.Record.ContentTypeAlias,
+            sizeInfo.Record.Url,
+            largestFields,
+            _options.ContentIndexing.OversizedRecords.Behavior);
+    }
+
+    private static string BuildOversizedRecordMessage(string indexName, AlgoliaContentRecordSizeInfo sizeInfo, int maxSizeBytes)
+        => $"Algolia content record '{sizeInfo.Record.Name}' (NodeId {sizeInfo.Record.NodeId}, ObjectID {sizeInfo.Record.ObjectID}, ContentTypeAlias {sizeInfo.Record.ContentTypeAlias}, Url {sizeInfo.Record.Url}) is too large for index '{indexName}': {sizeInfo.SizeBytes}/{maxSizeBytes} bytes.";
 
     private List<IContent> GetAllOfType(int contentTypeId)
     {

--- a/Plugins/Ekom.Algolia/Umbraco/U17/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U17/AlgoliaBackofficeController.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core;
 namespace Ekom.Algolia.Controllers;
 
 [Authorize(AuthenticationSchemes = Constants.Security.BackOfficeAuthenticationType)]
-[Route("umbraco/backoffice/api/Ekom/AlgoliaBackoffice")]
+[Route("umbraco/backoffice/api/EkomAlgoliaBackoffice")]
 public class EkomAlgoliaBackofficeController : ControllerBase
 {
     private readonly IAlgoliaProductIndexService _algoliaProductIndexService;


### PR DESCRIPTION
## Summary
- detect oversized standard content records before sending them to Algolia and log the Umbraco node ID, name, content type, URL, and largest fields
- add configurable `Fail` or `Skip` handling, including removal of stale incremental records when oversized content is skipped
- handle Algolia-reported oversized records and retry eligible batches in skip mode
- document default product fields and clarify that `ProductProperties` is only for additional data
- align the Umbraco 17 rebuild route with the existing Umbraco 10 endpoint

## Test Plan
- `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" --no-restore`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --no-restore --filter "FullyQualifiedName~Algolia"` (42 passed)
- `git diff --check`

The complete test project was also run: 370 tests passed and three unrelated existing tests failed (`OrderInfoTests.OrderedPaymentProvider_SerializesOnlyActivePrice`, `ConfigurationTests.Reads_From_InMemory_Appsettings_And_Overrides`, and `PriceTests.ISK_PerUnit_VatIncluded_LineLevelVat_1538x4_24pct`). The configuration test passed on a focused rerun; the OrderInfo and Price failures remained reproducible.
