### PR TITLE
fix: validate variants and guard import syncs

### DIFF
--- a/Ekom/Ekom.Core/Ekom/API/Order.cs
+++ b/Ekom/Ekom.Core/Ekom/API/Order.cs
@@ -365,6 +365,7 @@ public partial class Order
     /// <exception cref="ArgumentException">storeAlias</exception>
     /// <exception cref="OrderLineNegativeException">Can indicate a request to modify lines to negative values f.x. </exception>
     /// <exception cref="ProductNotFoundException"></exception>
+    /// <exception cref="VariantRequiredException"></exception>
     /// <exception cref="VariantNotFoundException"></exception>
     /// <exception cref="NotEnoughStockException"></exception>
     public async Task<IOrderInfo> AddOrderLineAsync(

--- a/Ekom/Ekom.Core/Ekom/Exceptions/VariantRequiredException.cs
+++ b/Ekom/Ekom.Core/Ekom/Exceptions/VariantRequiredException.cs
@@ -1,0 +1,31 @@
+namespace Ekom.Exceptions;
+
+/// <summary>
+/// The product has variants but no variant was selected for the order line.
+/// </summary>
+public class VariantRequiredException : EkomException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VariantRequiredException"/> class.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    public VariantRequiredException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VariantRequiredException"/> class.
+    /// </summary>
+    public VariantRequiredException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VariantRequiredException"/> class.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public VariantRequiredException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Services/OrderDiscountCalculationService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderDiscountCalculationService.cs
@@ -191,6 +191,7 @@ public sealed class OrderDiscountCalculationService : IOrderDiscountCalculationS
             }
 
             var variant = await ResolveVariantAsync(requestLine, product, store.Alias, ct).ConfigureAwait(false);
+            OrderLineVariantValidator.Validate(product, variant);
 
             orderInfo.orderLines.Add(new OrderLine(
                 product,

--- a/Ekom/Ekom.Core/Ekom/Services/OrderLineVariantValidator.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderLineVariantValidator.cs
@@ -1,0 +1,16 @@
+using Ekom.Exceptions;
+using Ekom.Models;
+
+namespace Ekom.Services;
+
+internal static class OrderLineVariantValidator
+{
+    public static void Validate(IProduct product, IVariant? variant)
+    {
+        if (variant is null)
+        {
+            if (product.AllVariants.Any())
+                throw new VariantRequiredException($"A variant is required for product '{product.Key}'.");
+        }
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -649,6 +649,7 @@ partial class OrderService
     /// <exception cref="ArgumentException">productKey</exception>
     /// <exception cref="OrderLineNegativeException">Can indicate a request to modify lines to negative values f.x. </exception>
     /// <exception cref="ProductNotFoundException"></exception>
+    /// <exception cref="VariantRequiredException"></exception>
     /// <exception cref="VariantNotFoundException"></exception>
     /// <exception cref="NotEnoughStockException"></exception>
     public async Task<OrderInfo> AddOrderLineAsync(
@@ -687,6 +688,8 @@ partial class OrderService
             }
         }
 
+        OrderLineVariantValidator.Validate(product, variant);
+
         IStore? store = _storeSvc.GetStoreByAlias(storeAlias);
 
         return await AddOrderLineAsync(
@@ -705,6 +708,7 @@ partial class OrderService
     /// </summary>
     /// <exception cref="ArgumentException"></exception>
     /// <exception cref="OrderLineNegativeException">Can indicate a request to modify lines to negative values f.x. </exception>
+    /// <exception cref="VariantRequiredException"></exception>
     public async Task<OrderInfo> AddOrderLineAsync(
         IProduct product,
         decimal quantity,
@@ -1124,6 +1128,10 @@ partial class OrderService
         variant = addingOrderlineEventArgs.Variant;
         settings = addingOrderlineEventArgs.Settings;
         action = addingOrderlineEventArgs.Action;
+
+        OrderLineVariantValidator.Validate(product, variant);
+        if (variant != null && variant.ProductKey != product.Key)
+            throw new EkomException("Mismatch between product and variant. Ensure chosen variant is a child of given Product");
 
         if (quantity == 0)
         {

--- a/Ekom/Ekom.Core/Ekom/Utilities/ExceptionHandler.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/ExceptionHandler.cs
@@ -29,6 +29,7 @@ static class ExceptionHandler
             OrderLineNegativeException => new StatusCodeResult((int)HttpStatusCode.BadRequest),
             OrderLineNotFoundException => new NotFoundResult(),
             ProductNotFoundException => new NotFoundResult(),
+            VariantRequiredException requiredEx => new BadRequestObjectResult(new { message = requiredEx.Message }),
             VariantNotFoundException => new NotFoundResult(),
             NotEnoughStockException => new StatusCodeResult((int)HttpStatusCode.Conflict),
             DiscountNotFoundException => new NotFoundResult(),

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
@@ -53,7 +53,7 @@ public class ImportService : IImportService
     private int variantGroupDeleted = 0;
 
     private static readonly object _syncLock = new object();
-    private static bool _isFullSyncRunning = false;
+    private static bool _isSyncRunning = false;
 
     public ImportService(
         IUmbracoContextFactory umbracoContextFactory,
@@ -81,16 +81,7 @@ public class ImportService : IImportService
     {
         _logger.LogInformation($"Full Sync running. ParentKey: {(parentKey.HasValue ? parentKey.Value.ToString() : "None")}, SyncUser: {syncUser}, Categories: {(data.Categories != null ?  (data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()) : 0)} Products: {data.Products.Count}");
 
-        lock (_syncLock)
-        {
-            if (_isFullSyncRunning)
-            {
-                _logger.LogError("Full Sync is already in progress.");
-                throw new InvalidOperationException("Sync is already in progress.");
-            }
-
-            _isFullSyncRunning = true;
-        }
+        BeginSync("Full Sync");
 
         try
         {
@@ -167,10 +158,7 @@ public class ImportService : IImportService
         }
         finally
         {
-            lock (_syncLock)
-            {
-                _isFullSyncRunning = false;
-            }
+            EndSync();
         }
     }
 
@@ -178,16 +166,7 @@ public class ImportService : IImportService
     {
         _logger.LogInformation($"Move Sync running. ParentKey: {(parentKey.HasValue ? parentKey.Value.ToString() : "None")}, SyncUser: {syncUser}, Categories: {(data.Categories != null ? (data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()) : 0)} Products: {data.Products.Count}");
 
-        lock (_syncLock)
-        {
-            if (_isFullSyncRunning)
-            {
-                _logger.LogError("Full Sync is already in progress.");
-                throw new InvalidOperationException("Sync is already in progress.");
-            }
-
-            _isFullSyncRunning = true;
-        }
+        BeginSync("Move Sync");
 
         try
         {
@@ -232,14 +211,25 @@ public class ImportService : IImportService
         }
         finally
         {
-            lock (_syncLock)
-            {
-                _isFullSyncRunning = false;
-            }
+            EndSync();
         }
     }
 
     public void CategorySync(ImportData data, Guid parentKey, int syncUser = -1)
+    {
+        BeginSync("Category Sync");
+
+        try
+        {
+            CategorySyncCore(data, parentKey, syncUser);
+        }
+        finally
+        {
+            EndSync();
+        }
+    }
+
+    private void CategorySyncCore(ImportData data, Guid parentKey, int syncUser)
     {
         _logger.LogInformation($"Category Sync running. ParentKey: {parentKey}, SyncUser: {syncUser}, Categories: {data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()} Products: {data.Products.Count}");
 
@@ -279,6 +269,28 @@ public class ImportService : IImportService
         _logger.LogInformation(
             "Category Sync took {Duration} seconds. Parent {parentKey} Categories Saved: {categoriesCount} Products Saved: {productsCount} Products With Error: {productsErrorCount} Variants Saved: {variantsCount} VariantsGroups Saved: {variantGroupsCount} Categories Deleted: {categoriesDeleted} Products Deleted: {productDeleted} Variants Deleted: {variantDeleted} VariantsGroups Deleted: {variantGroupDeleted}",
             (stopwatch.ElapsedMilliseconds / 1000.0).ToString("F2"), parentKey, categoriesSaved.Count, productsSaved.Where(x => x.Exception == null).Count(), productsSaved.Where(x => x.Exception != null).Count(), variantsSaved.Count, variantGroupsSaved.Count, categoriesDeleted, productDeleted, variantDeleted, variantGroupDeleted);
+    }
+
+    private void BeginSync(string syncName)
+    {
+        lock (_syncLock)
+        {
+            if (_isSyncRunning)
+            {
+                _logger.LogError("{SyncName} cannot start because another import sync is already in progress.", syncName);
+                throw new InvalidOperationException("Sync is already in progress.");
+            }
+
+            _isSyncRunning = true;
+        }
+    }
+
+    private static void EndSync()
+    {
+        lock (_syncLock)
+        {
+            _isSyncRunning = false;
+        }
     }
 
     public void ProductSync(ImportProduct importProduct, Guid? parentKey, Guid mediaRootKey, int syncUser = -1, bool forceUpdate = false)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -52,7 +52,7 @@ public class ImportService : IImportService
     private int variantGroupDeleted = 0;
 
     private static readonly object _syncLock = new object();
-    private static bool _isFullSyncRunning = false;
+    private static bool _isSyncRunning = false;
 
     public ImportService(
         IUmbracoContextFactory umbracoContextFactory,
@@ -80,16 +80,7 @@ public class ImportService : IImportService
     {
         _logger.LogInformation($"Full Sync running. ParentKey: {(parentKey.HasValue ? parentKey.Value.ToString() : "None")}, SyncUser: {syncUser}, Categories: {(data.Categories != null ?  (data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()) : 0)} Products: {data.Products.Count}");
 
-        lock (_syncLock)
-        {
-            if (_isFullSyncRunning)
-            {
-                _logger.LogError("Full Sync is already in progress.");
-                throw new InvalidOperationException("Sync is already in progress.");
-            }
-
-            _isFullSyncRunning = true;
-        }
+        BeginSync("Full Sync");
 
         try
         {
@@ -166,10 +157,7 @@ public class ImportService : IImportService
         }
         finally
         {
-            lock (_syncLock)
-            {
-                _isFullSyncRunning = false;
-            }
+            EndSync();
         }
     }
 
@@ -177,16 +165,7 @@ public class ImportService : IImportService
     {
         _logger.LogInformation($"Move Sync running. ParentKey: {(parentKey.HasValue ? parentKey.Value.ToString() : "None")}, SyncUser: {syncUser}, Categories: {(data.Categories != null ? (data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()) : 0)} Products: {data.Products.Count}");
 
-        lock (_syncLock)
-        {
-            if (_isFullSyncRunning)
-            {
-                _logger.LogError("Full Sync is already in progress.");
-                throw new InvalidOperationException("Sync is already in progress.");
-            }
-
-            _isFullSyncRunning = true;
-        }
+        BeginSync("Move Sync");
 
         try
         {
@@ -231,14 +210,25 @@ public class ImportService : IImportService
         }
         finally
         {
-            lock (_syncLock)
-            {
-                _isFullSyncRunning = false;
-            }
+            EndSync();
         }
     }
 
     public void CategorySync(ImportData data, Guid parentKey, int syncUser = -1)
+    {
+        BeginSync("Category Sync");
+
+        try
+        {
+            CategorySyncCore(data, parentKey, syncUser);
+        }
+        finally
+        {
+            EndSync();
+        }
+    }
+
+    private void CategorySyncCore(ImportData data, Guid parentKey, int syncUser)
     {
         _logger.LogInformation($"Category Sync running. ParentKey: {parentKey}, SyncUser: {syncUser}, Categories: {data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()} Products: {data.Products.Count}");
 
@@ -278,6 +268,28 @@ public class ImportService : IImportService
         _logger.LogInformation(
             "Category Sync took {Duration} seconds. Parent {parentKey} Categories Saved: {categoriesCount} Products Saved: {productsCount} Products With Error: {productsErrorCount} Variants Saved: {variantsCount} VariantsGroups Saved: {variantGroupsCount} Categories Deleted: {categoriesDeleted} Products Deleted: {productDeleted} Variants Deleted: {variantDeleted} VariantsGroups Deleted: {variantGroupDeleted}",
             (stopwatch.ElapsedMilliseconds / 1000.0).ToString("F2"), parentKey, categoriesSaved.Count, productsSaved.Where(x => x.Exception == null).Count(), productsSaved.Where(x => x.Exception != null).Count(), variantsSaved.Count, variantGroupsSaved.Count, categoriesDeleted, productDeleted, variantDeleted, variantGroupDeleted);
+    }
+
+    private void BeginSync(string syncName)
+    {
+        lock (_syncLock)
+        {
+            if (_isSyncRunning)
+            {
+                _logger.LogError("{SyncName} cannot start because another import sync is already in progress.", syncName);
+                throw new InvalidOperationException("Sync is already in progress.");
+            }
+
+            _isSyncRunning = true;
+        }
+    }
+
+    private static void EndSync()
+    {
+        lock (_syncLock)
+        {
+            _isSyncRunning = false;
+        }
     }
 
     public void ProductSync(ImportProduct importProduct, Guid? parentKey, Guid mediaRootKey, int syncUser = -1, bool forceUpdate = false)

--- a/Ekom/Tests/Ekom.Tests/Tests/OrderLineVariantValidatorTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/OrderLineVariantValidatorTests.cs
@@ -1,0 +1,72 @@
+using Ekom.Exceptions;
+using Ekom.Models;
+using Ekom.Services;
+using Ekom.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Text.Json;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class OrderLineVariantValidatorTests
+{
+    [Fact]
+    public void Requires_Variant_When_Product_Has_Variants()
+    {
+        var product = CreateProduct([Mock.Of<IVariant>()]);
+
+        var exception = Assert.Throws<VariantRequiredException>(() =>
+            OrderLineVariantValidator.Validate(product.Object, null));
+
+        Assert.Contains(product.Object.Key.ToString(), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Allows_Missing_Variant_When_Product_Has_No_Variants()
+    {
+        var product = CreateProduct([]);
+
+        OrderLineVariantValidator.Validate(product.Object, null);
+    }
+
+    [Fact]
+    public void Allows_Missing_Variant_When_Product_Has_Only_Empty_Variant_Groups()
+    {
+        var product = CreateProduct([]);
+        product.SetupGet(x => x.VariantGroups).Returns([Mock.Of<IVariantGroup>()]);
+
+        OrderLineVariantValidator.Validate(product.Object, null);
+    }
+
+    [Fact]
+    public void Allows_Selected_Variant_When_Product_Has_Variants()
+    {
+        var variant = Mock.Of<IVariant>();
+        var product = CreateProduct([variant]);
+
+        OrderLineVariantValidator.Validate(product.Object, variant);
+    }
+
+    [Fact]
+    public void Variant_Required_Exception_Maps_To_Bad_Request()
+    {
+        const string message = "A variant is required for product 'product-key'.";
+
+        var result = ExceptionHandler.Handle(new VariantRequiredException(message));
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(400, badRequest.StatusCode);
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(badRequest.Value));
+        Assert.Equal(message, document.RootElement.GetProperty("message").GetString());
+    }
+
+    private static Mock<IProduct> CreateProduct(IReadOnlyCollection<IVariant> variants)
+    {
+        var product = new Mock<IProduct>();
+        product.SetupGet(x => x.Key).Returns(Guid.NewGuid());
+        product.SetupGet(x => x.AllVariants).Returns(variants);
+        product.SetupGet(x => x.VariantGroups).Returns([]);
+        return product;
+    }
+}

--- a/Samples/U10/Ekom.Site/Views/Product.cshtml
+++ b/Samples/U10/Ekom.Site/Views/Product.cshtml
@@ -309,6 +309,12 @@
     </main>
 
     <script>
+        function escapeHtml(value) {
+            const element = document.createElement('div');
+            element.textContent = value;
+            return element.innerHTML;
+        }
+
         function postCart(formData) {
 
             var formElement = document.getElementsByClassName("product__add-form")[0];
@@ -335,7 +341,7 @@
                         },
                         body: JSON.stringify(formData)
                     })
-                    .then((response) => {
+                    .then(async (response) => {
 
                         if (response.status === 409) {
                             this.message = `
@@ -354,18 +360,45 @@
                                     </div>
                                     </div>
                                 </div>`;
-                        } else {
-                            return response.json().then((order) => {
+                            return;
+                        }
 
-                                let cartQuantityElement = document.querySelector('[data-cart-quantity]');
+                        const payload = await response.json();
 
-                                if (cartQuantityElement) {
-                                    cartQuantityElement.innerText = order.totalQuantity;
-                                }
+                        if (!response.ok) {
+                            const errorMessage = payload && payload.message
+                                ? payload.message
+                                : 'Unable to add the product to your cart.';
+                            this.message = `
+                                <div class="rounded-md mt-5 bg-red-50 p-4 cartMessage">
+                                    <div class="flex">
+                                    <div class="flex-shrink-0">
+                                        <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+                                        </svg>
+                                    </div>
+                                    <div class="ml-3">
+                                        <h3 class="text-sm font-medium text-red-800">Unable to add product</h3>
+                                        <div class="mt-2 text-sm text-red-700">
+                                            <p>${escapeHtml(errorMessage)}</p>
+                                        </div>
+                                    </div>
+                                    </div>
+                                </div>`;
+                            return;
+                        }
 
-                                if (formElement) {
+                        const order = payload;
 
-                                    this.message = `
+                        let cartQuantityElement = document.querySelector('[data-cart-quantity]');
+
+                        if (cartQuantityElement) {
+                            cartQuantityElement.innerText = order.totalQuantity;
+                        }
+
+                        if (formElement) {
+
+                            this.message = `
                                         <div class="rounded-md mt-5 bg-green-50 p-4 cartMessage">
                                             <div class="flex">
                                             <div class="flex-shrink-0">
@@ -386,11 +419,7 @@
                                             </div>
                                             </div>
                                         </div>`;
-                                } 
-                            });
                         }
-
-
                     })
                     .catch((ex) => {
                             this.message = `

--- a/Samples/U17/Ekom.Site.U17/Views/Product.cshtml
+++ b/Samples/U17/Ekom.Site.U17/Views/Product.cshtml
@@ -178,6 +178,12 @@
     </main>
 
     <script>
+        function escapeHtml(value) {
+            const element = document.createElement('div');
+            element.textContent = value;
+            return element.innerHTML;
+        }
+
         function postCart(formData) {
             var formElement = document.getElementsByClassName("product__add-form")[0];
 
@@ -204,7 +210,7 @@
                         },
                         body: JSON.stringify(formData)
                     })
-                    .then((response) => {
+                    .then(async (response) => {
                         if (response.status === 409) {
                             this.message = `
                                 <div class="rounded-md mt-5 bg-red-50 p-4 cartMessage">
@@ -222,15 +228,42 @@
                                         </div>
                                     </div>
                                 </div>`;
-                        } else {
-                            return response.json().then((order) => {
-                                let cartQuantityElement = document.querySelector('[data-cart-quantity]');
+                            return;
+                        }
 
-                                if (cartQuantityElement) {
-                                    cartQuantityElement.innerText = order.totalQuantity;
-                                }
+                        const payload = await response.json();
 
-                                this.message = `
+                        if (!response.ok) {
+                            const errorMessage = payload && payload.message
+                                ? payload.message
+                                : 'Unable to add the product to your cart.';
+                            this.message = `
+                                <div class="rounded-md mt-5 bg-red-50 p-4 cartMessage">
+                                    <div class="flex">
+                                        <div class="flex-shrink-0">
+                                            <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+                                            </svg>
+                                        </div>
+                                        <div class="ml-3">
+                                            <h3 class="text-sm font-medium text-red-800">Unable to add product</h3>
+                                            <div class="mt-2 text-sm text-red-700">
+                                                <p>${escapeHtml(errorMessage)}</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>`;
+                            return;
+                        }
+
+                        const order = payload;
+                        let cartQuantityElement = document.querySelector('[data-cart-quantity]');
+
+                        if (cartQuantityElement) {
+                            cartQuantityElement.innerText = order.totalQuantity;
+                        }
+
+                        this.message = `
                                     <div class="rounded-md mt-5 bg-green-50 p-4 cartMessage">
                                         <div class="flex">
                                             <div class="flex-shrink-0">
@@ -251,8 +284,6 @@
                                             </div>
                                         </div>
                                     </div>`;
-                            });
-                        }
                     })
                     .catch(() => {
                         this.message = `


### PR DESCRIPTION
## Summary
- serialize full, move, and category imports through the same process-level sync guard in U10 and U17
- require a variant when adding products that have actual variants to persisted order lines, replayed orders, and discount previews
- return a clear HTTP 400 response when the required variant is missing
- update the U10 and U17 sample product templates to display API validation errors instead of showing add-to-cart success
- keep product/variant ownership checks and existing out-of-stock handling intact

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --no-restore --filter "FullyQualifiedName~OrderLineVariantValidatorTests"` (5 passed)
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- `dotnet build "Samples/U10/Ekom.Site/Ekom.Site.csproj" --no-restore`
- `dotnet build "Samples/U17/Ekom.Site.U17/Ekom.Site.U17.csproj" --no-restore`
- `git diff --check`

The complete test project was also run: 374 tests passed and four unrelated tests failed because shared configuration/provider state was unavailable (`ConfigurationTests.Reads_From_InMemory_Appsettings_And_Overrides`, two `PriceTests` cases, and `StoreCurrencyTests.Currency_UsesCurrencyCookieBeforeRequestCulture`).
