### PR TITLE
fix(import): handle null categories in category sync

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
@@ -231,7 +231,14 @@ public class ImportService : IImportService
 
     private void CategorySyncCore(ImportData data, Guid parentKey, int syncUser)
     {
-        _logger.LogInformation($"Category Sync running. ParentKey: {parentKey}, SyncUser: {syncUser}, Categories: {data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()} Products: {data.Products.Count}");
+        var categoryCount = GetAllCategories(data)?.Count ?? 0;
+        var productCount = data.Products?.Count ?? 0;
+        _logger.LogInformation(
+            "Category Sync running. ParentKey: {ParentKey}, SyncUser: {SyncUser}, Categories: {CategoryCount} Products: {ProductCount}",
+            parentKey,
+            syncUser,
+            categoryCount,
+            productCount);
 
         var stopwatch = Stopwatch.StartNew();
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -230,7 +230,14 @@ public class ImportService : IImportService
 
     private void CategorySyncCore(ImportData data, Guid parentKey, int syncUser)
     {
-        _logger.LogInformation($"Category Sync running. ParentKey: {parentKey}, SyncUser: {syncUser}, Categories: {data.Categories.Count + data.Categories.SelectMany(x => x.SubCategories).Count()} Products: {data.Products.Count}");
+        var categoryCount = GetAllCategories(data)?.Count ?? 0;
+        var productCount = data.Products?.Count ?? 0;
+        _logger.LogInformation(
+            "Category Sync running. ParentKey: {ParentKey}, SyncUser: {SyncUser}, Categories: {CategoryCount} Products: {ProductCount}",
+            parentKey,
+            syncUser,
+            categoryCount,
+            productCount);
 
         var stopwatch = Stopwatch.StartNew();
 


### PR DESCRIPTION
## Summary
- handle `Categories = null` when logging category sync startup
- calculate category totals through the existing null-safe recursive flattener
- use structured logging and guard the product count defensively
- apply the fix consistently to the Umbraco 10 and Umbraco 17 import services

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- call `CategorySync` with `ImportData.Categories` set to null and confirm it logs zero categories without throwing
