### PR TITLE
fix(import): support nested media root folders

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
@@ -46,9 +46,24 @@ public class ImportMediaService
 
     public IMedia GetRootMedia(Guid rootMediaKey)
     {
-        rootMediaFolder = _mediaService.GetRootMedia().FirstOrDefault(x => x.Key == rootMediaKey);
+        var media = _mediaService.GetById(rootMediaKey);
 
-        ArgumentNullException.ThrowIfNull(rootMediaFolder);
+        if (media == null)
+        {
+            throw new ArgumentException($"No media exists with key '{rootMediaKey}'.", nameof(rootMediaKey));
+        }
+
+        if (media.Trashed)
+        {
+            throw new InvalidOperationException($"Media '{rootMediaKey}' is in the recycle bin.");
+        }
+
+        if (media.ContentType.Alias != MediaTypes.Folder)
+        {
+            throw new InvalidOperationException($"Media '{rootMediaKey}' is not a media folder.");
+        }
+
+        rootMediaFolder = media;
 
         GetRootMediaLastChildrenFolder(rootMediaFolder);
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportMediaService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportMediaService.cs
@@ -46,9 +46,24 @@ public class ImportMediaService
 
     public IMedia GetRootMedia(Guid rootMediaKey)
     {
-        _rootMediaFolder = _mediaService.GetRootMedia().FirstOrDefault(x => x.Key == rootMediaKey);
+        var media = _mediaService.GetById(rootMediaKey);
 
-        ArgumentNullException.ThrowIfNull(_rootMediaFolder);
+        if (media == null)
+        {
+            throw new ArgumentException($"No media exists with key '{rootMediaKey}'.", nameof(rootMediaKey));
+        }
+
+        if (media.Trashed)
+        {
+            throw new InvalidOperationException($"Media '{rootMediaKey}' is in the recycle bin.");
+        }
+
+        if (media.ContentType.Alias != MediaTypes.Folder)
+        {
+            throw new InvalidOperationException($"Media '{rootMediaKey}' is not a media folder.");
+        }
+
+        _rootMediaFolder = media;
 
         GetRootMediaLastChildrenFolder(_rootMediaFolder);
 


### PR DESCRIPTION
## Summary
- resolve import media roots directly by GUID instead of enumerating top-level media
- support media root folders located at any depth in the media tree
- reject missing, trashed, and non-folder media roots with clear errors
- apply the same behavior to the Umbraco 10 and Umbraco 17 import services

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- configure `MediaRootKey` with a nested media folder key and verify imports create/use numbered folders beneath it
- verify missing, trashed, and non-folder keys are rejected
