### PR TITLE
perf(import): reduce unnecessary import work

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
@@ -83,7 +83,7 @@ public class ImportMediaService
             lastMediaFolder = CreateMediaFolder("1");
         }
 
-        var mediaItems = _mediaService.GetPagedChildren(lastMediaFolder.Id, 0, int.MaxValue, out var _).Where(x => !x.Trashed && x.ContentType.Alias == MediaTypes.Image || x.ContentType.Alias == MediaTypes.File).ToList();
+        var mediaItems = _mediaService.GetPagedChildren(lastMediaFolder.Id, 0, int.MaxValue, out var _).Where(x => !x.Trashed && (x.ContentType.Alias == MediaTypes.Image || x.ContentType.Alias == MediaTypes.File)).ToList();
 
         mediaCount = mediaItems.Count;
     }

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
@@ -385,9 +385,7 @@ public class ImportService : IImportService
 
         ArgumentNullException.ThrowIfNull(umbracoRootContent);
 
-        var rootUmbracoMediafolder = _importMediaService.GetRootMedia(mediaRootKey);
-
-        var allUmbracoMedia = _importMediaService.GetUmbracoMediaFiles(rootUmbracoMediafolder);
+        _ = _importMediaService.GetRootMedia(mediaRootKey);
 
         var allEkomNodes = GetAllEkomNodes();
 
@@ -1807,7 +1805,7 @@ public class ImportService : IImportService
         else
         {
             umbracoRootContent = _contentService
-                .GetPagedOfType(catalogContentType.Id, 0, int.MaxValue, out var _, new Query<IContent>(_scopeProvider.SqlContext)
+                .GetPagedOfType(catalogContentType.Id, 0, 1, out var _, new Query<IContent>(_scopeProvider.SqlContext)
                 .Where(x => !x.Trashed)).FirstOrDefault();
         }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -384,9 +384,7 @@ public class ImportService : IImportService
 
         ArgumentNullException.ThrowIfNull(umbracoRootContent);
 
-        var rootUmbracoMediafolder = _importMediaService.GetRootMedia(mediaRootKey);
-
-        var allUmbracoMedia = _importMediaService.GetUmbracoMediaFiles(rootUmbracoMediafolder);
+        _ = _importMediaService.GetRootMedia(mediaRootKey);
 
         var allEkomNodes = GetAllEkomNodes();
 
@@ -673,6 +671,11 @@ public class ImportService : IImportService
                     // Not in import? Delete.
                     if (!importProductIdentifiers.Contains(productIdentifier))
                     {
+                        if (recycleBinNode != null && recycleBinNode.Id == umbracoProduct.ParentId)
+                        {
+                            continue;
+                        }
+
                         _logger.LogInformation($"Product deleted Id: {umbracoProduct.Id} Name: {umbracoProduct.Name} Parent: {umbracoProduct.ParentId} ProductIdentifier: {productIdentifier}");
 
                         if (recycleBinNode != null)
@@ -1791,7 +1794,7 @@ public class ImportService : IImportService
         else
         {
             umbracoRootContent = _contentService
-                .GetPagedOfType(catalogContentType.Id, 0, int.MaxValue, out var _, new Query<IContent>(_scopeProvider.SqlContext)
+                .GetPagedOfType(catalogContentType.Id, 0, 1, out var _, new Query<IContent>(_scopeProvider.SqlContext)
                 .Where(x => !x.Trashed)).FirstOrDefault();
         }
 


### PR DESCRIPTION
## Summary
- avoid loading the complete media tree during product update sync while retaining media-root validation
- skip repeated U17 unpublish and move operations for products already in the recycle bin
- limit fallback catalog lookup to the single record that is used
- exclude trashed files when U10 counts media in the active import folder

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- run product update sync against a large media tree and confirm media-root validation still occurs without loading all descendants
- run U17 sync with products already in the recycle bin and confirm they are not moved again
