### PR TITLE
fix(algolia): handle initial index rebuilds

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaIndexReplacementServiceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaIndexReplacementServiceTests.cs
@@ -1,0 +1,103 @@
+using Algolia.Search.Clients;
+using Algolia.Search.Utils;
+using Ekom.Algolia;
+using Ekom.Algolia.Indexing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaIndexReplacementServiceTests
+{
+    [Fact]
+    public async Task Saves_Records_Directly_When_Index_Does_Not_Exist()
+    {
+        var client = new Mock<ISearchClient>();
+        var records = new[] { new TestRecord() };
+        using var cts = new CancellationTokenSource();
+        client
+            .Setup(x => x.IndexExistsAsync("products", cts.Token))
+            .ReturnsAsync(false);
+        var service = CreateService(client.Object, maxRetries: 800);
+
+        await service.ReplaceAllAsync("products", records, 1000, cts.Token);
+
+        client.Verify(
+            x => x.SaveObjectsAsync(
+                "products",
+                records,
+                true,
+                1000,
+                null,
+                cts.Token,
+                It.Is<ChunkedHelperOptions>(options => options.MaxRetries == 800)),
+            Times.Once);
+        client.Verify(
+            x => x.ReplaceAllObjectsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<TestRecord>>(),
+                It.IsAny<int>(),
+                null,
+                null,
+                It.IsAny<CancellationToken>(),
+                It.IsAny<ChunkedHelperOptions>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Replaces_Existing_Index_With_Configured_Max_Retries()
+    {
+        var client = new Mock<ISearchClient>();
+        var records = new[] { new TestRecord() };
+        using var cts = new CancellationTokenSource();
+        client
+            .Setup(x => x.IndexExistsAsync("products", cts.Token))
+            .ReturnsAsync(true);
+        var service = CreateService(client.Object, maxRetries: 321);
+
+        await service.ReplaceAllAsync("products", records, 500, cts.Token);
+
+        client.Verify(
+            x => x.ReplaceAllObjectsAsync(
+                "products",
+                records,
+                500,
+                null,
+                null,
+                cts.Token,
+                It.Is<ChunkedHelperOptions>(options => options.MaxRetries == 321)),
+            Times.Once);
+        client.Verify(
+            x => x.SaveObjectsAsync(
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<TestRecord>>(),
+                It.IsAny<bool>(),
+                It.IsAny<int>(),
+                null,
+                It.IsAny<CancellationToken>(),
+                It.IsAny<ChunkedHelperOptions>()),
+            Times.Never);
+    }
+
+    private static AlgoliaIndexReplacementService CreateService(ISearchClient client, int maxRetries)
+        => new(
+            client,
+            Options.Create(new AlgoliaOptions
+            {
+                ApplicationId = "app-id",
+                AdminApiKey = "admin-key",
+                SearchApiKey = "search-key",
+                Replacement = new AlgoliaIndexReplacementOptions
+                {
+                    MaxRetries = maxRetries,
+                },
+            }),
+            NullLogger<AlgoliaIndexReplacementService>.Instance);
+
+    private sealed class TestRecord
+    {
+        public string ObjectID { get; init; } = "record-id";
+    }
+}

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -20,6 +20,7 @@ public class AlgoliaSearchTests
                 ["Ekom:Algolia:ApplicationId"] = "app-id",
                 ["Ekom:Algolia:AdminApiKey"] = "admin-key",
                 ["Ekom:Algolia:SearchApiKey"] = "search-key",
+                ["Ekom:Algolia:Replacement:MaxRetries"] = "400",
                 ["Ekom:Algolia:Search:Enabled"] = "true",
                 ["Ekom:Algolia:Search:Products"] = "true",
                 ["Ekom:Algolia:Search:Categories"] = "true",
@@ -48,6 +49,7 @@ public class AlgoliaSearchTests
         var options = provider.GetRequiredService<IOptions<AlgoliaOptions>>().Value;
 
         Assert.Equal("search-key", options.SearchApiKey);
+        Assert.Equal(400, options.Replacement.MaxRetries);
         Assert.True(options.Search.Categories);
         Assert.True(options.Search.QuerySuggestions);
         Assert.True(options.Search.IncludeUserToken);

--- a/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
+++ b/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ public static class AlgoliaServiceCollectionExtensions
         services.AddSingleton<IndexNameBuilder>();
         services.AddSingleton<ContentIndexNameResolver>();
         services.AddSingleton<AlgoliaStoreResolver>();
+        services.AddSingleton<AlgoliaIndexReplacementService>();
         services.AddSingleton<AlgoliaSearchCacheVersionProvider>();
         services.AddSingleton<AlgoliaSearchCacheKeyBuilder>();
         services.AddSingleton<IAlgoliaProductIndexMapper, ProductIndexMapper>();

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -16,10 +16,16 @@ public sealed class AlgoliaOptions
 
     public AlgoliaIndexingOptions Indexing { get; set; } = new();
     public AlgoliaContentIndexingOptions ContentIndexing { get; set; } = new();
+    public AlgoliaIndexReplacementOptions Replacement { get; set; } = new();
     public AlgoliaEventsOptions Events { get; set; } = new();
     public AlgoliaSearchOptions Search { get; set; } = new();
 
     public IReadOnlyCollection<AlgoliaStoreOptions> Stores { get; init; } = [];
+}
+
+public sealed class AlgoliaIndexReplacementOptions
+{
+    public int MaxRetries { get; set; } = 800;
 }
 
 public sealed class AlgoliaIndexingOptions

--- a/Plugins/Ekom.Algolia/Ekom.Algolia.csproj
+++ b/Plugins/Ekom.Algolia/Ekom.Algolia.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Algolia.Search" Version="7.40.0" />
+    <PackageReference Include="Algolia.Search" Version="7.47.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
   </ItemGroup>
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexExecutor.cs
@@ -14,6 +14,7 @@ internal sealed class AlgoliaCategoryIndexExecutor
     private const string CategoriesEntity = "categories";
 
     private readonly ISearchClient _client;
+    private readonly AlgoliaIndexReplacementService _indexReplacementService;
     private readonly AlgoliaOptions _options;
     private readonly AlgoliaStoreResolver _storeResolver;
     private readonly IndexNameBuilder _indexNameBuilder;
@@ -23,6 +24,7 @@ internal sealed class AlgoliaCategoryIndexExecutor
 
     public AlgoliaCategoryIndexExecutor(
         ISearchClient client,
+        AlgoliaIndexReplacementService indexReplacementService,
         IOptions<AlgoliaOptions> options,
         AlgoliaStoreResolver storeResolver,
         IndexNameBuilder indexNameBuilder,
@@ -31,6 +33,7 @@ internal sealed class AlgoliaCategoryIndexExecutor
         ILogger<AlgoliaCategoryIndexExecutor> logger)
     {
         _client = client;
+        _indexReplacementService = indexReplacementService;
         _options = options.Value;
         _storeResolver = storeResolver;
         _indexNameBuilder = indexNameBuilder;
@@ -112,11 +115,7 @@ internal sealed class AlgoliaCategoryIndexExecutor
 
             var batchSize = _options.Indexing.BatchSize <= 0 ? 1000 : _options.Indexing.BatchSize;
 
-            await _client.ReplaceAllObjectsAsync(
-                indexName: indexName,
-                objects: records,
-                batchSize: batchSize,
-                cancellationToken: ct).ConfigureAwait(false);
+            await _indexReplacementService.ReplaceAllAsync(indexName, records, batchSize, ct).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Algolia rebuild store {Store} locale {Locale} -> {IndexName}. Categories={Count}",

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaIndexReplacementService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaIndexReplacementService.cs
@@ -1,0 +1,112 @@
+using Algolia.Search.Clients;
+using Algolia.Search.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Ekom.Algolia.Indexing;
+
+internal sealed class AlgoliaIndexReplacementService
+{
+    private const int DefaultMaxRetries = 800;
+
+    private readonly ISearchClient _client;
+    private readonly AlgoliaOptions _options;
+    private readonly ILogger<AlgoliaIndexReplacementService> _logger;
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _indexLocks = new(StringComparer.Ordinal);
+
+    public AlgoliaIndexReplacementService(
+        ISearchClient client,
+        IOptions<AlgoliaOptions> options,
+        ILogger<AlgoliaIndexReplacementService> logger)
+    {
+        _client = client;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task ReplaceAllAsync<T>(
+        string indexName,
+        IReadOnlyCollection<T> records,
+        int batchSize,
+        CancellationToken ct)
+        where T : class
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(indexName);
+        ArgumentNullException.ThrowIfNull(records);
+
+        var indexLock = _indexLocks.GetOrAdd(indexName, static _ => new SemaphoreSlim(1, 1));
+        await indexLock.WaitAsync(ct).ConfigureAwait(false);
+
+        var stopwatch = Stopwatch.StartNew();
+        var maxRetries = _options.Replacement.MaxRetries > 0
+            ? _options.Replacement.MaxRetries
+            : DefaultMaxRetries;
+        var effectiveBatchSize = batchSize > 0 ? batchSize : 1000;
+        var chunkedOptions = new ChunkedHelperOptions { MaxRetries = maxRetries };
+
+        try
+        {
+            var indexExists = await _client.IndexExistsAsync(indexName, ct).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Algolia {Operation} index {IndexName}. Records={RecordCount} BatchSize={BatchSize} MaxRetries={MaxRetries}",
+                indexExists ? "replacing" : "creating",
+                indexName,
+                records.Count,
+                effectiveBatchSize,
+                maxRetries);
+
+            if (indexExists)
+            {
+                await _client.ReplaceAllObjectsAsync(
+                    indexName: indexName,
+                    objects: records,
+                    batchSize: effectiveBatchSize,
+                    scopes: null,
+                    options: null,
+                    cancellationToken: ct,
+                    chunkedOptions: chunkedOptions).ConfigureAwait(false);
+            }
+            else
+            {
+                await _client.SaveObjectsAsync(
+                    indexName: indexName,
+                    objects: records,
+                    waitForTasks: true,
+                    batchSize: effectiveBatchSize,
+                    options: null,
+                    cancellationToken: ct,
+                    chunkedOptions: chunkedOptions).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation(
+                "Algolia index {IndexName} {Operation} completed in {DurationSeconds:F2} seconds. Records={RecordCount}",
+                indexName,
+                indexExists ? "replacement" : "creation",
+                stopwatch.Elapsed.TotalSeconds,
+                records.Count);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Algolia index operation failed for {IndexName} after {DurationSeconds:F2} seconds. Records={RecordCount} BatchSize={BatchSize} MaxRetries={MaxRetries}",
+                indexName,
+                stopwatch.Elapsed.TotalSeconds,
+                records.Count,
+                effectiveBatchSize,
+                maxRetries);
+            throw;
+        }
+        finally
+        {
+            indexLock.Release();
+        }
+    }
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
@@ -13,6 +13,7 @@ namespace Ekom.Algolia.Indexing;
 internal sealed class AlgoliaProductIndexExecutor
 {
     private readonly ISearchClient _client;
+    private readonly AlgoliaIndexReplacementService _indexReplacementService;
     private readonly AlgoliaOptions _options;
     private readonly AlgoliaStoreResolver _storeResolver;
     private readonly IndexNameBuilder _indexNameBuilder;
@@ -23,6 +24,7 @@ internal sealed class AlgoliaProductIndexExecutor
 
     public AlgoliaProductIndexExecutor(
         ISearchClient client,
+        AlgoliaIndexReplacementService indexReplacementService,
         IOptions<AlgoliaOptions> options,
         AlgoliaStoreResolver storeResolver,
         IndexNameBuilder indexNameBuilder,
@@ -32,6 +34,7 @@ internal sealed class AlgoliaProductIndexExecutor
         ILogger<AlgoliaProductIndexExecutor> logger)
     {
         _client = client;
+        _indexReplacementService = indexReplacementService;
         _options = options.Value;
         _storeResolver = storeResolver;
         _indexNameBuilder = indexNameBuilder;
@@ -129,7 +132,6 @@ internal sealed class AlgoliaProductIndexExecutor
         {
             ct.ThrowIfCancellationRequested();
             var indexName = _indexNameBuilder.BuildPrimary("products", target);
-            await EnsureIndexSettingsAsync(target, indexName, ct).ConfigureAwait(false);
             var records = new List<AlgoliaProductRecord>(products.Count);
 
             var skippedProducts = 0;
@@ -162,12 +164,9 @@ internal sealed class AlgoliaProductIndexExecutor
                 indexName,
                 records.Count);
 
-            await _client.ReplaceAllObjectsAsync(
-                indexName: indexName,
-                objects: records,
-                batchSize: batchSize,
-                cancellationToken: ct).ConfigureAwait(false);
+            await _indexReplacementService.ReplaceAllAsync(indexName, records, batchSize, ct).ConfigureAwait(false);
 
+            await EnsureIndexSettingsAsync(target, indexName, ct).ConfigureAwait(false);
             await EnsureQuerySuggestionsAsync(target, indexName, ct).ConfigureAwait(false);
         }
 

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -77,6 +77,9 @@ public sealed class ProductSearchController
       "InsightsApiKey": "INSIGHTS_API_KEY",
       "AnalyticsRegion": "eu",
       "Environment": "prod",
+      "Replacement": {
+        "MaxRetries": 800
+      },
       "Indexing": {
         "Enabled": true,
         "Products": true,
@@ -173,6 +176,7 @@ public sealed class ProductSearchController
 | `InsightsApiKey` | `string` | `null` | Optional key for Insights events. Falls back to `AdminApiKey` when omitted. |
 | `AnalyticsRegion` | `string` | `null` | Algolia analytics region for query suggestions, usually `us` or `eu`. If omitted, the plugin tries both. |
 | `Environment` | `string` | `prod` | Environment segment used in generated index names. |
+| `Replacement:MaxRetries` | `int` | `800` | Maximum number of status polling retries while atomically replacing an existing index. |
 | `Indexing:Enabled` | `bool` | `true` | Enables indexing features. |
 | `Indexing:Products` | `bool` | `true` | Enables product indexing. |
 | `Indexing:Categories` | `bool` | `true` | Enables category indexing. |

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaContentIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaContentIndexExecutor.cs
@@ -21,6 +21,7 @@ namespace Ekom.Algolia.Indexing;
 internal sealed class AlgoliaContentIndexExecutor
 {
     private readonly ISearchClient _client;
+    private readonly AlgoliaIndexReplacementService _indexReplacementService;
     private readonly AlgoliaOptions _options;
     private readonly IReadOnlyList<IAlgoliaContentEnricher> _enrichers;
     private readonly IReadOnlyList<IAlgoliaContentPropertyValueConverter> _propertyConverters;
@@ -38,6 +39,7 @@ internal sealed class AlgoliaContentIndexExecutor
 
     public AlgoliaContentIndexExecutor(
         ISearchClient client,
+        AlgoliaIndexReplacementService indexReplacementService,
         IOptions<AlgoliaOptions> options,
         IContentService contentService,
         ILocalizationService languageService,
@@ -54,6 +56,7 @@ internal sealed class AlgoliaContentIndexExecutor
         IEnumerable<IAlgoliaContentPropertyValueConverter>? propertyConverters = null)
     {
         _client = client;
+        _indexReplacementService = indexReplacementService;
         _options = options.Value;
         _contentService = contentService;
         _languageService = languageService;
@@ -224,7 +227,7 @@ internal sealed class AlgoliaContentIndexExecutor
         {
             try
             {
-                await _client.ReplaceAllObjectsAsync(indexName, accepted, batchSize, cancellationToken: ct).ConfigureAwait(false);
+                await _indexReplacementService.ReplaceAllAsync(indexName, accepted, batchSize, ct).ConfigureAwait(false);
                 return accepted.Count;
             }
             catch (AlgoliaApiException ex)

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Algolia.Search": {
         "type": "Direct",
-        "requested": "[7.40.0, )",
-        "resolved": "7.40.0",
-        "contentHash": "d6h5GQ+3N668Y2A0qpz1EsRMLV2NxZ30L5W6SEyL7CR92SyislmwyDSxaP5gTCgLu60N1ReYeQSNFJcYp9cTZg==",
+        "requested": "[7.47.0, )",
+        "resolved": "7.47.0",
+        "contentHash": "ERWAbM3Zdioh4//CKMvtTULSzRd3MrvaIJ1PfJneklO0gISkSggBoWaWDIa3O7zjalNBKAqc2RCADDUft2nIKA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "[8.0.0, 11.0.0)",
           "Microsoft.Extensions.Logging.Abstractions": "[8.0.0, 11.0.0)"
@@ -1792,9 +1792,9 @@
     "net8.0": {
       "Algolia.Search": {
         "type": "Direct",
-        "requested": "[7.40.0, )",
-        "resolved": "7.40.0",
-        "contentHash": "d6h5GQ+3N668Y2A0qpz1EsRMLV2NxZ30L5W6SEyL7CR92SyislmwyDSxaP5gTCgLu60N1ReYeQSNFJcYp9cTZg==",
+        "requested": "[7.47.0, )",
+        "resolved": "7.47.0",
+        "contentHash": "ERWAbM3Zdioh4//CKMvtTULSzRd3MrvaIJ1PfJneklO0gISkSggBoWaWDIa3O7zjalNBKAqc2RCADDUft2nIKA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "[8.0.0, 11.0.0)",
           "Microsoft.Extensions.Logging.Abstractions": "[8.0.0, 11.0.0)"


### PR DESCRIPTION
## Summary
- add a shared replacement service that creates missing Algolia indexes directly and atomically replaces existing indexes
- serialize replacement operations per physical index and add structured timing/failure logging
- make replacement polling configurable through `Replacement:MaxRetries`, defaulting to 800
- apply the replacement flow to product, category, and content rebuilds, including oversized-content retries
- upgrade `Algolia.Search` from 7.40.0 to 7.47.0 and update the lock file
- document the new setting and add focused replacement/configuration tests

## Test Plan
- `dotnet build "Ekom.Algolia.csproj" --no-restore` (passes with existing warnings)
- `dotnet test "Ekom.Tests.csproj" --no-restore --filter "FullyQualifiedName~Algolia"` (44 passed)
- `dotnet test "Ekom.Tests.csproj" --no-restore` (377 passed; 3 unrelated existing failures in ConfigurationTests, PriceTests, and OrderInfoTests)
- `git diff --check`
