### PR TITLE
feat: add Algolia transforms and optimize imports

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Services/IImportService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/IImportService.cs
@@ -13,6 +13,13 @@ public interface IImportService
     /// <param name="syncUser">The user ID initiating the sync operation. Defaults to -1 to represent a system or anonymous user.</param>
     public void FullSync(ImportData data, Guid? parentKey = null, int syncUser = -1);
 
+    /// <summary>
+    /// Reconciles the category hierarchy by moving categories to the parents specified in the import data.
+    /// Use this when category parent relationships have changed and products do not need to be synchronized.
+    /// </summary>
+    /// <param name="data">The import data containing the category hierarchy to reconcile.</param>
+    /// <param name="parentKey">Optional GUID of the parent category under which the hierarchy is processed. If null, processing starts at the root level.</param>
+    /// <param name="syncUser">The user ID initiating the sync operation. Defaults to -1 to represent a system or anonymous user.</param>
     public void MoveSync(ImportData data, Guid? parentKey = null, int syncUser = -1);
 
 
@@ -25,9 +32,10 @@ public interface IImportService
     public void CategorySync(ImportData data, Guid categoryKey, int syncUser = -1);
 
     /// <summary>
-    /// Synchronizes a single product, ensuring it is updated or integrated into the catalog according to the provided data. This method is targeted at product-level operations.
+    /// Creates or updates a product and synchronizes its related product tree, including variants and variant groups.
+    /// Use this when receiving a complete product payload, including media and child entities, and the product may not already exist.
     /// </summary>
-    /// <param name="productData">The product data to be synchronized, including any variants and associated information.</param>
+    /// <param name="productData">The complete product data to synchronize, including media, variants, and variant groups.</param>
     /// <param name="parentKey">Optional GUID of the parent category under which the data should be synchronized. If null, synchronization is performed at the root level.</param>
     /// <param name="mediaRootKey">The GUID key identifying the media root folder in the CMS.</param>
     /// <param name="syncUser">The user ID initiating the sync operation. Defaults to -1 to represent a system or anonymous user.</param>
@@ -35,7 +43,8 @@ public interface IImportService
     public void ProductSync(ImportProduct productData, Guid? parentKey, Guid mediaRootKey, int syncUser = -1, bool forceUpdate = false);
 
     /// <summary>
-    /// Updates a single product, ensuring the product data is modified or synchronized in the catalog.
+    /// Updates an existing product's own data without synchronizing its media, variants, or variant groups.
+    /// Use this for a product-only update when the product is known to already exist; an exception is thrown if it cannot be found by identifier.
     /// </summary>
     /// <param name="importProduct">The product data to be updated.</param>
     /// <param name="parentKey">Optional GUID of the parent category under which the data should be updated. If null, the product is updated at the root level.</param>

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
@@ -3,10 +3,11 @@ using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Persistence.Querying;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
 using MediaTypes = Umbraco.Cms.Core.Constants.Conventions.MediaTypes;
 
@@ -20,6 +21,7 @@ public class ImportMediaService
     private readonly MediaUrlGeneratorCollection _mediaUrlGenerators;
     private readonly IShortStringHelper _shortStringHelper;
     private readonly ILogger<ImportMediaService> _logger;
+    private readonly IScopeProvider _scopeProvider;
 
     private int mediaCount = 0;
     private int mediaFolderPageSize = 400;
@@ -33,7 +35,8 @@ public class ImportMediaService
         MediaFileManager mediaFileManager,
         MediaUrlGeneratorCollection mediaUrlGenerators,
         IShortStringHelper shortStringHelper,
-        ILogger<ImportMediaService> logger)
+        ILogger<ImportMediaService> logger,
+        IScopeProvider scopeProvider)
     {
         _mediaService = mediaService;
         _httpClientFactory = httpClientFactory;
@@ -42,6 +45,7 @@ public class ImportMediaService
         _mediaUrlGenerators = mediaUrlGenerators;
         _shortStringHelper = shortStringHelper;
         _logger = logger;
+        _scopeProvider = scopeProvider;
     }
 
     public IMedia GetRootMedia(Guid rootMediaKey)
@@ -123,6 +127,70 @@ public class ImportMediaService
         while (pageIndex * pageSize < total);
 
         return results;
+    }
+
+    public List<IMedia> GetUmbracoMediaFiles(
+        IMedia rootMedia,
+        IReadOnlyCollection<string> identifiers,
+        IReadOnlyCollection<string> comparers,
+        IReadOnlyCollection<Guid> keys)
+    {
+        if (identifiers.Count == 0 && comparers.Count == 0 && keys.Count == 0)
+        {
+            return new List<IMedia>();
+        }
+
+        var conditions = new List<string>();
+        var parameters = new List<object> { $"%,{rootMedia.Id},%", MediaTypes.Image, MediaTypes.File };
+
+        if (keys.Count > 0)
+        {
+            conditions.Add($"n.uniqueId IN (@{parameters.Count})");
+            parameters.Add(keys);
+        }
+
+        if (identifiers.Count > 0)
+        {
+            conditions.Add($"(pt.alias = 'ekmIdentifier' AND pd.varcharValue IN (@{parameters.Count}))");
+            parameters.Add(identifiers);
+        }
+
+        if (comparers.Count > 0)
+        {
+            conditions.Add($"(pt.alias = 'comparer' AND pd.varcharValue IN (@{parameters.Count}))");
+            parameters.Add(comparers);
+        }
+
+        using var scope = _scopeProvider.CreateScope(autoComplete: true);
+        var mediaIds = scope.Database.Fetch<int>(
+            $@"SELECT DISTINCT n.id
+FROM umbracoNode n
+INNER JOIN umbracoContent c ON c.nodeId = n.id
+INNER JOIN cmsContentType ct ON ct.nodeId = c.contentTypeId
+INNER JOIN umbracoContentVersion cv ON cv.nodeId = n.id AND cv.[current] = 1
+LEFT JOIN umbracoPropertyData pd ON pd.versionId = cv.id
+LEFT JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
+WHERE n.trashed = 0
+  AND n.path LIKE @0
+  AND ct.alias IN (@1, @2)
+  AND ({string.Join(" OR ", conditions)})
+ORDER BY n.id",
+            parameters.ToArray());
+
+        var matchingMedia = _mediaService.GetPagedDescendants(
+                rootMedia.Id,
+                0,
+                int.MaxValue,
+                out _,
+                new Query<IMedia>(_scopeProvider.SqlContext).Where(media => mediaIds.Contains(media.Id)))
+            .Where(media => !media.Trashed
+                && (media.ContentType.Alias == MediaTypes.Image || media.ContentType.Alias == MediaTypes.File))
+            .ToDictionary(media => media.Id);
+
+        return mediaIds
+            .Where(matchingMedia.ContainsKey)
+            .Select(mediaId => matchingMedia[mediaId])
+            .ToList();
     }
 
     public IMedia? ImportMediaFromExternalUrl(ImportMediaFromExternalUrl image, string comparer, ImportMediaTypes mediaType, string? identifier, int? syncUser = -1)

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
@@ -311,14 +311,19 @@ public class ImportService : IImportService
 
         ArgumentNullException.ThrowIfNull(umbracoRootContent);
 
-        var allEkomNodes = GetAllEkomNodes();
-
-        var allUmbracoCategories = allEkomNodes.Where(x => x.ContentType.Alias == "ekmCategory").ToList();
-        var allUmbracoProducts = allEkomNodes.Where(x => x.ContentType.Alias == "ekmProduct").ToList();
+        var allUmbracoCategories = GetContentByIdentifiers(categoryContentType, importProduct.Categories);
+        var primaryCategory = importProduct.Categories
+            .Select(identifier => allUmbracoCategories.FirstOrDefault(category => category.GetValue<string>(Configuration.ImportAliasIdentifier) == identifier))
+            .FirstOrDefault(category => category != null);
+        var allUmbracoProducts = primaryCategory == null
+            ? new List<IContent>()
+            : GetContentByIdentifiers(productContentType, new[] { importProduct.Identifier }, primaryCategory.Id);
+        var existingProduct = allUmbracoProducts.FirstOrDefault();
+        var allEkomNodes = GetProductSyncNodes(allUmbracoCategories, existingProduct);
 
         var rootUmbracoMediafolder = _importMediaService.GetRootMedia(mediaRootKey);
 
-        var allUmbracoMedia = _importMediaService.GetUmbracoMediaFiles(rootUmbracoMediafolder);
+        var allUmbracoMedia = GetProductSyncMedia(rootUmbracoMediafolder, importProduct);
         var mediaIndex = new ImportMediaIndex(allUmbracoMedia);
 
         IterateProductTree(new List<ImportProduct> { importProduct }, allEkomNodes, allUmbracoProducts, allUmbracoCategories, allUmbracoMedia, mediaIndex, syncUser, false, forceUpdate: forceUpdate);
@@ -387,11 +392,9 @@ public class ImportService : IImportService
 
         _ = _importMediaService.GetRootMedia(mediaRootKey);
 
-        var allEkomNodes = GetAllEkomNodes();
+        var allUmbracoCategories = GetContentByIdentifiers(categoryContentType, importProduct.Categories);
 
-        var allUmbracoCategories = allEkomNodes.Where(x => x.ContentType.Alias == "ekmCategory").ToList();
-
-        var product = allEkomNodes.FirstOrDefault(x => x.ContentType.Alias == "ekmProduct" && x.GetValue<string>(Configuration.ImportAliasIdentifier) == importProduct.Identifier);
+        var product = GetContentByIdentifiers(productContentType, new[] { importProduct.Identifier }).FirstOrDefault();
 
         if (product == null)
         {
@@ -2010,6 +2013,177 @@ public class ImportService : IImportService
         }
 
         return all;
+    }
+
+    private List<IContent> GetProductSyncNodes(List<IContent> categories, IContent? product)
+    {
+        var nodes = new List<IContent>(categories.Count);
+        nodes.AddRange(categories);
+
+        if (product == null)
+        {
+            return nodes;
+        }
+
+        var variantGroups = GetSyncEnabledChildren(product.Id);
+        nodes.AddRange(variantGroups);
+
+        foreach (var variantGroup in variantGroups)
+        {
+            nodes.AddRange(GetSyncEnabledChildren(variantGroup.Id));
+        }
+
+        return nodes;
+    }
+
+    private List<IContent> GetSyncEnabledChildren(int parentId)
+    {
+        return _contentService.GetPagedChildren(parentId, 0, int.MaxValue, out _, new Query<IContent>(_scopeProvider.SqlContext)
+                .Where(x => !x.Trashed))
+            .Where(x => !x.GetValue<bool>("ekmDisableSync"))
+            .ToList();
+    }
+
+    private List<IContent> GetContentByIdentifiers(IContentType? contentType, IEnumerable<string>? identifiers, int? parentId = null)
+    {
+        ArgumentNullException.ThrowIfNull(contentType);
+        ArgumentNullException.ThrowIfNull(umbracoRootContent);
+
+        var requestedIdentifiers = identifiers?
+            .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
+            .Distinct(StringComparer.Ordinal)
+            .ToList() ?? new List<string>();
+
+        if (requestedIdentifiers.Count == 0)
+        {
+            return new List<IContent>();
+        }
+
+        var contentByIdentifier = new Dictionary<string, IContent>(StringComparer.Ordinal);
+        var root = umbracoRootContent;
+        if (!parentId.HasValue
+            && !root.Trashed
+            && root.ContentType.Id == contentType.Id
+            && !root.GetValue<bool>("ekmDisableSync")
+            && root.GetValue<string>(Configuration.ImportAliasIdentifier) is { } rootIdentifier
+            && requestedIdentifiers.Contains(rootIdentifier, StringComparer.Ordinal))
+        {
+            contentByIdentifier.TryAdd(rootIdentifier, root);
+        }
+
+        using var scope = _scopeProvider.CreateScope(autoComplete: true);
+        var parentFilter = parentId.HasValue ? "\n  AND n.parentId = @4" : string.Empty;
+        var query = $@"SELECT n.id
+FROM umbracoNode n
+INNER JOIN umbracoContent c ON c.nodeId = n.id
+INNER JOIN umbracoContentVersion cv ON cv.nodeId = n.id AND cv.[current] = 1
+INNER JOIN umbracoPropertyData pd ON pd.versionId = cv.id
+INNER JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
+WHERE n.trashed = 0
+  AND n.path LIKE @0
+  AND c.contentTypeId = @1
+  AND pt.alias = @2
+  AND pd.varcharValue IN (@3){parentFilter}";
+        object[] queryParameters = parentId.HasValue
+            ? [$"%,{root.Id},%", contentType.Id, Configuration.ImportAliasIdentifier, requestedIdentifiers, parentId.Value]
+            : [$"%,{root.Id},%", contentType.Id, Configuration.ImportAliasIdentifier, requestedIdentifiers];
+        var contentIds = scope.Database.Fetch<int>(query, queryParameters);
+
+        foreach (var contentId in contentIds)
+        {
+            var content = _contentService.GetById(contentId);
+            if (content == null
+                || content.Trashed
+                || content.GetValue<bool>("ekmDisableSync")
+                || content.GetValue<string>(Configuration.ImportAliasIdentifier) is not { } identifier
+                || !requestedIdentifiers.Contains(identifier, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            contentByIdentifier.TryAdd(identifier, content);
+        }
+
+        return contentByIdentifier.Values.ToList();
+    }
+
+    private List<IMedia> GetProductSyncMedia(IMedia rootMedia, ImportProduct importProduct)
+    {
+        var identifiers = new HashSet<string>(StringComparer.Ordinal);
+        var comparers = new HashSet<string>(StringComparer.Ordinal);
+        var keys = new HashSet<Guid>();
+
+        AddMediaReferences(importProduct.Images, identifiers, comparers, keys);
+        AddMediaReferences(importProduct.Files, identifiers, comparers, keys);
+
+        foreach (var variantGroup in importProduct.VariantGroups)
+        {
+            AddMediaReferences(variantGroup.Images, identifiers, comparers, keys);
+
+            foreach (var variant in variantGroup.Variants)
+            {
+                AddMediaReferences(variant.Images, identifiers, comparers, keys);
+                AddMediaReferences(variant.Files, identifiers, comparers, keys);
+            }
+        }
+
+        return _importMediaService.GetUmbracoMediaFiles(rootMedia, identifiers, comparers, keys);
+    }
+
+    private void AddMediaReferences(
+        IEnumerable<IImportMedia> importMedias,
+        ISet<string> identifiers,
+        ISet<string> comparers,
+        ISet<Guid> keys)
+    {
+        foreach (var importMedia in importMedias)
+        {
+            switch (importMedia)
+            {
+                case ImportMediaFromUdi udiMedia:
+                    const string mediaUdiPrefix = "umb://media/";
+                    if (udiMedia.Udi.StartsWith(mediaUdiPrefix, StringComparison.OrdinalIgnoreCase)
+                        && Guid.TryParse(udiMedia.Udi[mediaUdiPrefix.Length..], out var key))
+                    {
+                        keys.Add(key);
+                    }
+                    break;
+                case ImportMediaFromExternalUrl externalUrlMedia:
+                    AddMediaReference(
+                        externalUrlMedia.Identifier,
+                        externalUrlMedia.Comparer ?? ComputeSha256Hash(externalUrlMedia, new[] { "Action", "SortOrder" }),
+                        identifiers,
+                        comparers);
+                    break;
+                case ImportMediaFromBytes bytesMedia:
+                    AddMediaReference(
+                        bytesMedia.Identifier,
+                        bytesMedia.Comparer ?? ComputeSha256Hash(bytesMedia, new[] { "Bytes", "SortOrder" }),
+                        identifiers,
+                        comparers);
+                    break;
+                case ImportMediaFromBase64 base64Media:
+                    AddMediaReference(
+                        base64Media.Identifier,
+                        base64Media.Comparer ?? ComputeSha256Hash(base64Media, new[] { "Base64", "SortOrder" }),
+                        identifiers,
+                        comparers);
+                    break;
+            }
+        }
+    }
+
+    private static void AddMediaReference(string? identifier, string comparer, ISet<string> identifiers, ISet<string> comparers)
+    {
+        if (!string.IsNullOrEmpty(identifier))
+        {
+            identifiers.Add(identifier);
+        }
+
+        if (!string.IsNullOrEmpty(comparer))
+        {
+            comparers.Add(comparer);
+        }
     }
 
     private sealed class ImportMediaIndex

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportMediaService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportMediaService.cs
@@ -6,6 +6,8 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Persistence.Querying;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
 using MediaTypes = Umbraco.Cms.Core.Constants.Conventions.MediaTypes;
 
@@ -20,6 +22,7 @@ public class ImportMediaService
     private readonly MediaUrlGeneratorCollection _mediaUrlGenerators;
     private readonly IShortStringHelper _shortStringHelper;
     private readonly ILogger<ImportMediaService> _logger;
+    private readonly IScopeProvider _scopeProvider;
 
     private readonly int _mediaFolderPageSize = 400;
     private int _mediaCount;
@@ -33,7 +36,8 @@ public class ImportMediaService
         MediaFileManager mediaFileManager,
         MediaUrlGeneratorCollection mediaUrlGenerators,
         IShortStringHelper shortStringHelper,
-        ILogger<ImportMediaService> logger)
+        ILogger<ImportMediaService> logger,
+        IScopeProvider scopeProvider)
     {
         _mediaService = mediaService;
         _httpClientFactory = httpClientFactory;
@@ -42,6 +46,7 @@ public class ImportMediaService
         _mediaUrlGenerators = mediaUrlGenerators;
         _shortStringHelper = shortStringHelper;
         _logger = logger;
+        _scopeProvider = scopeProvider;
     }
 
     public IMedia GetRootMedia(Guid rootMediaKey)
@@ -102,6 +107,70 @@ public class ImportMediaService
         while (true);
 
         return results;
+    }
+
+    public List<IMedia> GetUmbracoMediaFiles(
+        IMedia rootMedia,
+        IReadOnlyCollection<string> identifiers,
+        IReadOnlyCollection<string> comparers,
+        IReadOnlyCollection<Guid> keys)
+    {
+        if (identifiers.Count == 0 && comparers.Count == 0 && keys.Count == 0)
+        {
+            return new List<IMedia>();
+        }
+
+        var conditions = new List<string>();
+        var parameters = new List<object> { $"%,{rootMedia.Id},%", MediaTypes.Image, MediaTypes.File };
+
+        if (keys.Count > 0)
+        {
+            conditions.Add($"n.uniqueId IN (@{parameters.Count})");
+            parameters.Add(keys);
+        }
+
+        if (identifiers.Count > 0)
+        {
+            conditions.Add($"(pt.alias = 'ekmIdentifier' AND pd.varcharValue IN (@{parameters.Count}))");
+            parameters.Add(identifiers);
+        }
+
+        if (comparers.Count > 0)
+        {
+            conditions.Add($"(pt.alias = 'comparer' AND pd.varcharValue IN (@{parameters.Count}))");
+            parameters.Add(comparers);
+        }
+
+        using var scope = _scopeProvider.CreateScope(autoComplete: true);
+        var mediaIds = scope.Database.Fetch<int>(
+            $@"SELECT DISTINCT n.id
+FROM umbracoNode n
+INNER JOIN umbracoContent c ON c.nodeId = n.id
+INNER JOIN cmsContentType ct ON ct.nodeId = c.contentTypeId
+INNER JOIN umbracoContentVersion cv ON cv.nodeId = n.id AND cv.[current] = 1
+LEFT JOIN umbracoPropertyData pd ON pd.versionId = cv.id
+LEFT JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
+WHERE n.trashed = 0
+  AND n.path LIKE @0
+  AND ct.alias IN (@1, @2)
+  AND ({string.Join(" OR ", conditions)})
+ORDER BY n.id",
+            parameters.ToArray());
+
+        var matchingMedia = _mediaService.GetPagedDescendants(
+                rootMedia.Id,
+                0,
+                int.MaxValue,
+                out _,
+                new Query<IMedia>(_scopeProvider.SqlContext).Where(media => mediaIds.Contains(media.Id)))
+            .Where(media => !media.Trashed
+                && (media.ContentType.Alias == MediaTypes.Image || media.ContentType.Alias == MediaTypes.File))
+            .ToDictionary(media => media.Id);
+
+        return mediaIds
+            .Where(matchingMedia.ContainsKey)
+            .Select(mediaId => matchingMedia[mediaId])
+            .ToList();
     }
 
     public IMedia? ImportMediaFromExternalUrl(

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -310,14 +310,19 @@ public class ImportService : IImportService
 
         ArgumentNullException.ThrowIfNull(umbracoRootContent);
 
-        var allEkomNodes = GetAllEkomNodes();
-
-        var allUmbracoCategories = allEkomNodes.Where(x => x.ContentType.Alias == "ekmCategory").ToList();
-        var allUmbracoProducts = allEkomNodes.Where(x => x.ContentType.Alias == "ekmProduct").ToList();
+        var allUmbracoCategories = GetContentByIdentifiers(categoryContentType, importProduct.Categories);
+        var primaryCategory = importProduct.Categories
+            .Select(identifier => allUmbracoCategories.FirstOrDefault(category => category.GetValue<string>(Configuration.ImportAliasIdentifier) == identifier))
+            .FirstOrDefault(category => category != null);
+        var allUmbracoProducts = primaryCategory == null
+            ? new List<IContent>()
+            : GetContentByIdentifiers(productContentType, new[] { importProduct.Identifier }, primaryCategory.Id);
+        var existingProduct = allUmbracoProducts.FirstOrDefault();
+        var allEkomNodes = GetProductSyncNodes(allUmbracoCategories, existingProduct);
 
         var rootUmbracoMediafolder = _importMediaService.GetRootMedia(mediaRootKey);
 
-        var allUmbracoMedia = _importMediaService.GetUmbracoMediaFiles(rootUmbracoMediafolder);
+        var allUmbracoMedia = GetProductSyncMedia(rootUmbracoMediafolder, importProduct);
         var mediaIndex = new ImportMediaIndex(allUmbracoMedia);
 
         IterateProductTree(new List<ImportProduct> { importProduct }, allEkomNodes, allUmbracoProducts, allUmbracoCategories, allUmbracoMedia, mediaIndex, syncUser, false, forceUpdate: forceUpdate);
@@ -386,11 +391,9 @@ public class ImportService : IImportService
 
         _ = _importMediaService.GetRootMedia(mediaRootKey);
 
-        var allEkomNodes = GetAllEkomNodes();
+        var allUmbracoCategories = GetContentByIdentifiers(categoryContentType, importProduct.Categories);
 
-        var allUmbracoCategories = allEkomNodes.Where(x => x.ContentType.Alias == "ekmCategory").ToList();
-
-        var product = allEkomNodes.FirstOrDefault(x => x.ContentType.Alias == "ekmProduct" && x.GetValue<string>(Configuration.ImportAliasIdentifier) == importProduct.Identifier);
+        var product = GetContentByIdentifiers(productContentType, new[] { importProduct.Identifier }).FirstOrDefault();
 
         if (product == null)
         {
@@ -1999,6 +2002,177 @@ public class ImportService : IImportService
         }
 
         return all;
+    }
+
+    private List<IContent> GetProductSyncNodes(List<IContent> categories, IContent? product)
+    {
+        var nodes = new List<IContent>(categories.Count);
+        nodes.AddRange(categories);
+
+        if (product == null)
+        {
+            return nodes;
+        }
+
+        var variantGroups = GetSyncEnabledChildren(product.Id);
+        nodes.AddRange(variantGroups);
+
+        foreach (var variantGroup in variantGroups)
+        {
+            nodes.AddRange(GetSyncEnabledChildren(variantGroup.Id));
+        }
+
+        return nodes;
+    }
+
+    private List<IContent> GetSyncEnabledChildren(int parentId)
+    {
+        return _contentService.GetPagedChildren(parentId, 0, int.MaxValue, out _, new Query<IContent>(_scopeProvider.SqlContext)
+                .Where(x => !x.Trashed))
+            .Where(x => !x.GetValue<bool>("ekmDisableSync"))
+            .ToList();
+    }
+
+    private List<IContent> GetContentByIdentifiers(IContentType? contentType, IEnumerable<string>? identifiers, int? parentId = null)
+    {
+        ArgumentNullException.ThrowIfNull(contentType);
+        ArgumentNullException.ThrowIfNull(umbracoRootContent);
+
+        var requestedIdentifiers = identifiers?
+            .Where(identifier => !string.IsNullOrWhiteSpace(identifier))
+            .Distinct(StringComparer.Ordinal)
+            .ToList() ?? new List<string>();
+
+        if (requestedIdentifiers.Count == 0)
+        {
+            return new List<IContent>();
+        }
+
+        var contentByIdentifier = new Dictionary<string, IContent>(StringComparer.Ordinal);
+        var root = umbracoRootContent;
+        if (!parentId.HasValue
+            && !root.Trashed
+            && root.ContentType.Id == contentType.Id
+            && !root.GetValue<bool>("ekmDisableSync")
+            && root.GetValue<string>(Configuration.ImportAliasIdentifier) is { } rootIdentifier
+            && requestedIdentifiers.Contains(rootIdentifier, StringComparer.Ordinal))
+        {
+            contentByIdentifier.TryAdd(rootIdentifier, root);
+        }
+
+        using var scope = _scopeProvider.CreateScope(autoComplete: true);
+        var parentFilter = parentId.HasValue ? "\n  AND n.parentId = @4" : string.Empty;
+        var query = $@"SELECT n.id
+FROM umbracoNode n
+INNER JOIN umbracoContent c ON c.nodeId = n.id
+INNER JOIN umbracoContentVersion cv ON cv.nodeId = n.id AND cv.[current] = 1
+INNER JOIN umbracoPropertyData pd ON pd.versionId = cv.id
+INNER JOIN cmsPropertyType pt ON pt.id = pd.propertyTypeId
+WHERE n.trashed = 0
+  AND n.path LIKE @0
+  AND c.contentTypeId = @1
+  AND pt.alias = @2
+  AND pd.varcharValue IN (@3){parentFilter}";
+        object[] queryParameters = parentId.HasValue
+            ? [$"%,{root.Id},%", contentType.Id, Configuration.ImportAliasIdentifier, requestedIdentifiers, parentId.Value]
+            : [$"%,{root.Id},%", contentType.Id, Configuration.ImportAliasIdentifier, requestedIdentifiers];
+        var contentIds = scope.Database.Fetch<int>(query, queryParameters);
+
+        foreach (var contentId in contentIds)
+        {
+            var content = _contentService.GetById(contentId);
+            if (content == null
+                || content.Trashed
+                || content.GetValue<bool>("ekmDisableSync")
+                || content.GetValue<string>(Configuration.ImportAliasIdentifier) is not { } identifier
+                || !requestedIdentifiers.Contains(identifier, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            contentByIdentifier.TryAdd(identifier, content);
+        }
+
+        return contentByIdentifier.Values.ToList();
+    }
+
+    private List<IMedia> GetProductSyncMedia(IMedia rootMedia, ImportProduct importProduct)
+    {
+        var identifiers = new HashSet<string>(StringComparer.Ordinal);
+        var comparers = new HashSet<string>(StringComparer.Ordinal);
+        var keys = new HashSet<Guid>();
+
+        AddMediaReferences(importProduct.Images, identifiers, comparers, keys);
+        AddMediaReferences(importProduct.Files, identifiers, comparers, keys);
+
+        foreach (var variantGroup in importProduct.VariantGroups)
+        {
+            AddMediaReferences(variantGroup.Images, identifiers, comparers, keys);
+
+            foreach (var variant in variantGroup.Variants)
+            {
+                AddMediaReferences(variant.Images, identifiers, comparers, keys);
+                AddMediaReferences(variant.Files, identifiers, comparers, keys);
+            }
+        }
+
+        return _importMediaService.GetUmbracoMediaFiles(rootMedia, identifiers, comparers, keys);
+    }
+
+    private void AddMediaReferences(
+        IEnumerable<IImportMedia> importMedias,
+        ISet<string> identifiers,
+        ISet<string> comparers,
+        ISet<Guid> keys)
+    {
+        foreach (var importMedia in importMedias)
+        {
+            switch (importMedia)
+            {
+                case ImportMediaFromUdi udiMedia:
+                    const string mediaUdiPrefix = "umb://media/";
+                    if (udiMedia.Udi.StartsWith(mediaUdiPrefix, StringComparison.OrdinalIgnoreCase)
+                        && Guid.TryParse(udiMedia.Udi[mediaUdiPrefix.Length..], out var key))
+                    {
+                        keys.Add(key);
+                    }
+                    break;
+                case ImportMediaFromExternalUrl externalUrlMedia:
+                    AddMediaReference(
+                        externalUrlMedia.Identifier,
+                        externalUrlMedia.Comparer ?? ComputeSha256Hash(externalUrlMedia, new[] { "Action", "SortOrder" }),
+                        identifiers,
+                        comparers);
+                    break;
+                case ImportMediaFromBytes bytesMedia:
+                    AddMediaReference(
+                        bytesMedia.Identifier,
+                        bytesMedia.Comparer ?? ComputeSha256Hash(bytesMedia, new[] { "Bytes", "SortOrder" }),
+                        identifiers,
+                        comparers);
+                    break;
+                case ImportMediaFromBase64 base64Media:
+                    AddMediaReference(
+                        base64Media.Identifier,
+                        base64Media.Comparer ?? ComputeSha256Hash(base64Media, new[] { "Base64", "SortOrder" }),
+                        identifiers,
+                        comparers);
+                    break;
+            }
+        }
+    }
+
+    private static void AddMediaReference(string? identifier, string comparer, ISet<string> identifiers, ISet<string> comparers)
+    {
+        if (!string.IsNullOrEmpty(identifier))
+        {
+            identifiers.Add(identifier);
+        }
+
+        if (!string.IsNullOrEmpty(comparer))
+        {
+            comparers.Add(comparer);
+        }
     }
 
     private sealed class ImportMediaIndex

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaHtmlTextConverterTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaHtmlTextConverterTests.cs
@@ -1,0 +1,79 @@
+using Ekom.Algolia;
+using Ekom.Algolia.Indexing;
+using Ekom.Algolia.Mappers;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaHtmlTextConverterTests
+{
+    [Fact]
+    public void Parses_StripHtml_Content_Field_Transform()
+    {
+        var field = AlgoliaContentIndexExecutor.ParseConfiguredField("body|STRIPHTML");
+
+        Assert.Equal("body", field.Alias);
+        Assert.Equal(AlgoliaContentFieldTransform.StripHtml, field.Transform);
+    }
+
+    [Fact]
+    public void Applies_StripHtml_Content_Field_Transform()
+    {
+        var result = AlgoliaContentIndexExecutor.ApplyConfiguredTransform(
+            "{\"markup\":\"<p>Content <strong>body</strong></p>\"}",
+            AlgoliaContentFieldTransform.StripHtml);
+
+        Assert.Equal("Content body", result);
+    }
+
+    [Fact]
+    public void Converts_Html_To_Normalized_Plain_Text()
+    {
+        const string html = "<p>Hello&nbsp;<strong>world</strong></p><p>Next<br>line</p><script>alert('ignored')</script>";
+
+        var result = AlgoliaHtmlTextConverter.ConvertToText(html);
+
+        Assert.Equal("Hello world Next line", result);
+    }
+
+    [Fact]
+    public void Converts_Rich_Text_Json_Markup()
+    {
+        const string value = "{\"markup\":\"<div>Halló &amp; heimur</div>\"}";
+
+        var result = AlgoliaHtmlTextConverter.ConvertToText(value);
+
+        Assert.Equal("Halló & heimur", result);
+    }
+
+    [Fact]
+    public void Tolerates_Malformed_Html_And_Removes_Non_Content_Nodes()
+    {
+        const string html = "<p>First <strong>second<p>Third<style>.hidden { display: none; }</style><!-- ignored -->";
+
+        var result = AlgoliaHtmlTextConverter.ConvertToText(html);
+
+        Assert.Equal("First second Third", result);
+    }
+
+    [Fact]
+    public void Leaves_Non_String_Values_Unchanged()
+    {
+        var value = new object();
+
+        var result = AlgoliaHtmlTextConverter.Convert(value);
+
+        Assert.Same(value, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("<script>alert('ignored')</script>")]
+    public void Returns_Empty_Text_When_No_Indexable_Content_Remains(string value)
+    {
+        var result = AlgoliaHtmlTextConverter.ConvertToText(value);
+
+        Assert.Equal(string.Empty, result);
+    }
+}

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -110,6 +110,59 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Fact]
+    public void Strips_Html_From_Configured_Product_Property()
+    {
+        var mapper = CreateMapper(productProperties: ["body|striphtml"]);
+        var product = CreateProduct(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["body"] = "<p>Hello&nbsp;<strong>world</strong></p><p>Next</p>"
+        });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal("Hello world Next", Assert.IsType<string>(record!.Data["body"]));
+    }
+
+    [Fact]
+    public void Strips_Html_From_Built_In_Product_Text_Fields()
+    {
+        var mapper = CreateMapper(productProperties: ["TITLE|STRIPHTML", "summary|striphtml", "description|striphtml"]);
+        var product = CreateProduct(
+            title: "<p>Product <strong>title</strong></p>",
+            summary: "<div>Product&nbsp;summary</div>",
+            description: "{\"markup\":\"<p>Product description</p>\"}");
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal("Product title", record!.Title);
+        Assert.Equal("Product summary", record.Summary);
+        Assert.Equal("Product description", record.Description);
+        Assert.DoesNotContain(record.Data.Keys, key => key.Equals("title", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(record.Data.Keys, key => key.Equals("summary", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(record.Data.Keys, key => key.Equals("description", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Omits_Configured_Values_That_Are_Empty_After_Stripping_Html()
+    {
+        var mapper = CreateMapper(productProperties: ["body|striphtml", "summary|striphtml"]);
+        var product = CreateProduct(
+            summary: "<script>alert('ignored')</script>",
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["body"] = "<style>.hidden { display: none; }</style>"
+            });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Null(record!.Summary);
+        Assert.DoesNotContain("body", record.Data.Keys);
+    }
+
+    [Fact]
     public void Maps_Array_Product_Properties_From_Configured_Modifier()
     {
         var mapper = CreateMapper(productProperties: ["channels|array"]);
@@ -244,6 +297,20 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Fact]
+    public void MapRecords_Strips_Html_From_Variant_Description()
+    {
+        var mapper = CreateMapper(productProperties: ["description|striphtml"], indexVariants: true);
+        var variant = CreateVariant(description: "<p>Variant <strong>description</strong></p>");
+        var product = CreateProduct(variants: [variant.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        var variantRecord = records.Single(x => x.IsVariant);
+        Assert.Equal("Variant description", variantRecord.Description);
+        Assert.Equal("Variant description", Assert.IsType<string>(variantRecord.Data["variantDescription"]));
+    }
+
+    [Fact]
     public void Keeps_Relative_Urls_And_Image_Urls_As_Is()
     {
         var mapper = CreateMapper();
@@ -276,6 +343,21 @@ public class AlgoliaProductIndexMapperTests
 
         Assert.NotNull(record);
         Assert.Equal("Cotton", Assert.IsType<string>(record!.Data["material"]));
+    }
+
+    [Fact]
+    public void Strips_Html_From_Configured_Metafield()
+    {
+        var mapper = CreateMapper(productProperties: ["metafield:longDescription|striphtml"]);
+        var product = CreateProduct(metafields:
+        [
+            CreateMetafield("longDescription", [CreateMetafieldValue(("is-IS", "{\"markup\":\"<p>Halló <strong>heimur</strong></p>\"}"))])
+        ]);
+
+        var record = mapper.Map(product.Object, CreateStore(locale: "is-IS"), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal("Halló heimur", Assert.IsType<string>(record!.Data["longDescription"]));
     }
 
     [Fact]

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -81,7 +81,8 @@ public enum AlgoliaContentFieldTransform
 {
     None,
     UnixSeconds,
-    UnixMilliseconds
+    UnixMilliseconds,
+    StripHtml,
 }
 
 public sealed class AlgoliaEventsOptions

--- a/Plugins/Ekom.Algolia/Ekom.Algolia.csproj
+++ b/Plugins/Ekom.Algolia/Ekom.Algolia.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.74" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
@@ -58,6 +59,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />

--- a/Plugins/Ekom.Algolia/Mappers/AlgoliaHtmlTextConverter.cs
+++ b/Plugins/Ekom.Algolia/Mappers/AlgoliaHtmlTextConverter.cs
@@ -1,0 +1,115 @@
+using HtmlAgilityPack;
+using System.Text;
+using System.Text.Json;
+
+namespace Ekom.Algolia.Mappers;
+
+internal static class AlgoliaHtmlTextConverter
+{
+    private static readonly HashSet<string> BlockElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "address", "article", "aside", "blockquote", "dd", "div", "dl", "dt", "figcaption", "figure",
+        "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "li", "main", "nav",
+        "ol", "p", "pre", "section", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "ul",
+    };
+
+    public static object? Convert(object? value)
+        => value is string text ? ConvertToText(text) : value;
+
+    public static string ConvertToText(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return string.Empty;
+
+        var markup = TryGetMarkup(value) ?? value;
+        var document = new HtmlDocument
+        {
+            OptionFixNestedTags = true,
+        };
+        document.LoadHtml(markup);
+
+        var nonContentNodes = document.DocumentNode.SelectNodes("//script|//style|//noscript|//template");
+        if (nonContentNodes is not null)
+        {
+            foreach (var node in nonContentNodes)
+                node.Remove();
+        }
+
+        var text = new StringBuilder(markup.Length);
+        AppendText(document.DocumentNode, text);
+
+        return NormalizeWhitespace(HtmlEntity.DeEntitize(text.ToString()));
+    }
+
+    private static void AppendText(HtmlNode node, StringBuilder text)
+    {
+        if (node.NodeType == HtmlNodeType.Comment)
+            return;
+
+        if (node.NodeType == HtmlNodeType.Text)
+        {
+            text.Append(node.InnerText);
+            return;
+        }
+
+        var isSeparator = node.Name.Equals("br", StringComparison.OrdinalIgnoreCase)
+            || BlockElements.Contains(node.Name);
+
+        if (isSeparator)
+            text.Append(' ');
+
+        foreach (var child in node.ChildNodes)
+            AppendText(child, text);
+
+        if (isSeparator)
+            text.Append(' ');
+    }
+
+    private static string? TryGetMarkup(string value)
+    {
+        var trimmed = value.TrimStart();
+        if (!trimmed.StartsWith('{'))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(trimmed);
+            if (document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty("markup", out var markup)
+                && markup.ValueKind == JsonValueKind.String)
+            {
+                return markup.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return null;
+    }
+
+    private static string NormalizeWhitespace(string value)
+    {
+        var normalized = new StringBuilder(value.Length);
+        var pendingSpace = false;
+
+        foreach (var character in value)
+        {
+            if (char.IsWhiteSpace(character) || character == '\u00a0')
+            {
+                pendingSpace = normalized.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                normalized.Append(' ');
+                pendingSpace = false;
+            }
+
+            normalized.Append(character);
+        }
+
+        return normalized.ToString();
+    }
+}

--- a/Plugins/Ekom.Algolia/Mappers/AlgoliaProductMappingContracts.cs
+++ b/Plugins/Ekom.Algolia/Mappers/AlgoliaProductMappingContracts.cs
@@ -42,5 +42,6 @@ public enum AlgoliaFieldTransform
 {
     None,
     UnixSeconds,
-    UnixMilliseconds
+    UnixMilliseconds,
+    StripHtml,
 }

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -38,7 +38,27 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         var locale = store.Locale;
         var categoryLevels = BuildCategoryLevels(product, locale);
         var nodeName = GetNodeName(product);
-        var title = GetLocalizedValue(product, "title", product.Title, locale);
+        var title = ApplyBuiltInTextTransform(
+            "title",
+            GetLocalizedValue(product, "title", product.Title, locale),
+            allowedProps,
+            product,
+            store,
+            baseIndexName);
+        var summary = ApplyBuiltInTextTransform(
+            "summary",
+            GetLocalizedValue(product, "summary", product.Summary, locale),
+            allowedProps,
+            product,
+            store,
+            baseIndexName);
+        var description = ApplyBuiltInTextTransform(
+            "description",
+            GetLocalizedValue(product, "description", product.Description, locale),
+            allowedProps,
+            product,
+            store,
+            baseIndexName);
 
         var images = product.Images
             .Select(i => i?.Url)
@@ -73,8 +93,8 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             ProductId = product.Key.ToString(),
             NodeName = NullIfWhiteSpace(nodeName),
             Title = title,
-            Summary = NullIfWhiteSpace(GetLocalizedValue(product, "summary", product.Summary, locale)),
-            Description = NullIfWhiteSpace(GetLocalizedValue(product, "description", product.Description, locale)),
+            Summary = NullIfWhiteSpace(summary),
+            Description = NullIfWhiteSpace(description),
             Url = NullIfWhiteSpace(urls.FirstOrDefault() ?? product.Url),
             ImageUrl = NullIfWhiteSpace(images.FirstOrDefault()),
             ImageUrls = images.Count > 0 ? images : null,
@@ -101,7 +121,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         if (categoryPaths.Count > 0)
             record.Data["category_paths"] = categoryPaths;
 
-        foreach (var kvp in allowedProps)
+        foreach (var kvp in allowedProps.Where(x => !IsBuiltInTextStripHtmlField(x.Value)))
         {
             var alias = kvp.Key;
             var configuredField = kvp.Value;
@@ -109,6 +129,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             object? converted = ResolveConfiguredValue(product, store, configuredField);
             var ctx = new AlgoliaProductFieldContext(product, store, alias, baseIndexName);
             converted = ConvertProperty(ctx, converted);
+            converted = ApplyTransform(converted, configuredField.Transform);
 
             if (converted is null)
                 continue;
@@ -151,10 +172,11 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             return [productRecord];
 
         var records = new List<AlgoliaProductRecord> { productRecord };
+        var configuredFields = BuildAllowedProperties(product, store);
 
         foreach (var variant in product.AllVariants)
         {
-            var record = MapVariant(product, variant, productRecord, store);
+            var record = MapVariant(product, variant, productRecord, store, baseIndexName, configuredFields);
             if (record is not null)
                 records.Add(record);
         }
@@ -162,11 +184,13 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         return records;
     }
 
-    private static AlgoliaProductRecord? MapVariant(
+    private AlgoliaProductRecord? MapVariant(
         IProduct product,
         IVariant variant,
         AlgoliaProductRecord productRecord,
-        AlgoliaResolvedStore store)
+        AlgoliaResolvedStore store,
+        string baseIndexName,
+        IReadOnlyDictionary<string, ConfiguredField> configuredFields)
     {
         if (string.IsNullOrWhiteSpace(variant.SKU))
             return null;
@@ -179,11 +203,12 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             .ToList();
 
         var price = ResolvePrice(variant, store);
+        var variantDescription = ResolveVariantDescription(product, variant, store, baseIndexName, configuredFields);
         var data = new Dictionary<string, object?>(productRecord.Data, StringComparer.OrdinalIgnoreCase)
         {
             ["variantSku"] = variant.SKU,
             ["variantTitle"] = NullIfWhiteSpace(variant.Title),
-            ["variantDescription"] = NullIfWhiteSpace(variant.Description),
+            ["variantDescription"] = variantDescription,
             ["variantAvailable"] = variant.Available ? 1 : 0,
             ["variantStock"] = store.IncludeStock ? variant.Stock : null
         };
@@ -202,7 +227,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             NodeName = productRecord.NodeName,
             Title = productRecord.Title,
             Summary = productRecord.Summary,
-            Description = NullIfWhiteSpace(variant.Description) ?? productRecord.Description,
+            Description = variantDescription ?? productRecord.Description,
             Url = productRecord.Url,
             ImageUrl = NullIfWhiteSpace(images.FirstOrDefault()) ?? productRecord.ImageUrl,
             ImageUrls = images.Count > 0 ? images : productRecord.ImageUrls,
@@ -220,6 +245,23 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             UpdatedAt = ToUnixTimeSeconds(variant.UpdateDate),
             Data = data
         };
+    }
+
+    private string? ResolveVariantDescription(
+        IProduct product,
+        IVariant variant,
+        AlgoliaResolvedStore store,
+        string baseIndexName,
+        IReadOnlyDictionary<string, ConfiguredField> configuredFields)
+    {
+        if (!configuredFields.TryGetValue("description", out var field) || !IsBuiltInTextStripHtmlField(field))
+            return NullIfWhiteSpace(variant.Description);
+
+        var context = new AlgoliaProductFieldContext(product, store, "description", baseIndexName);
+        var converted = ConvertProperty(context, variant.Description);
+        converted = ApplyTransform(converted, field.Transform);
+
+        return NullIfWhiteSpace(converted?.ToString());
     }
 
     private Dictionary<string, ConfiguredField> BuildAllowedProperties(IProduct product, AlgoliaResolvedStore store)
@@ -244,6 +286,36 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
         return value;
     }
+
+    private static object? ApplyTransform(object? value, AlgoliaFieldTransform transform)
+        => transform == AlgoliaFieldTransform.StripHtml
+            ? AlgoliaHtmlTextConverter.Convert(value)
+            : value;
+
+    private string ApplyBuiltInTextTransform(
+        string alias,
+        string value,
+        IReadOnlyDictionary<string, ConfiguredField> configuredFields,
+        IProduct product,
+        AlgoliaResolvedStore store,
+        string baseIndexName)
+    {
+        if (!configuredFields.TryGetValue(alias, out var field) || !IsBuiltInTextStripHtmlField(field))
+            return value;
+
+        var context = new AlgoliaProductFieldContext(product, store, alias, baseIndexName);
+        var converted = ConvertProperty(context, value);
+        converted = ApplyTransform(converted, field.Transform);
+
+        return converted?.ToString() ?? string.Empty;
+    }
+
+    private static bool IsBuiltInTextStripHtmlField(ConfiguredField field)
+        => field.Source == AlgoliaFieldSource.Property
+            && field.Transform == AlgoliaFieldTransform.StripHtml
+            && (field.Alias.Equals("title", StringComparison.OrdinalIgnoreCase)
+                || field.Alias.Equals("summary", StringComparison.OrdinalIgnoreCase)
+                || field.Alias.Equals("description", StringComparison.OrdinalIgnoreCase));
 
     private static object? ResolveConfiguredValue(IProduct product, AlgoliaResolvedStore store, ConfiguredField configuredField)
     {
@@ -608,6 +680,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
                 "array" => new ConfiguredField(alias, source, AlgoliaFieldValueType.Array, AlgoliaFieldTransform.None),
                 "unix" => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixSeconds),
                 "unixms" => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.UnixMilliseconds),
+                "striphtml" => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.StripHtml),
                 _ => new ConfiguredField(alias, source, AlgoliaFieldValueType.None, AlgoliaFieldTransform.None)
             };
         }

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -90,7 +90,8 @@ public sealed class ProductSearchController
           "channels|array",
           "packageCount|int",
           "weight|decimal",
-          "publishedAt|unix"
+          "publishedAt|unix",
+          "description|striphtml"
         ],
         "Dispatching": {
           "MaxBatchSize": 100,
@@ -115,7 +116,7 @@ public sealed class ProductSearchController
                 "Alias": "article",
                 "Properties": [
                   "title",
-                  "summary",
+                  "summary|striphtml",
                   "publishedAt|unix"
                 ]
               }
@@ -194,7 +195,7 @@ public sealed class ProductSearchController
 | `ContentIndexing:OversizedRecords:MaxSizeBytes` | `int` | `100000` | Maximum serialized UTF-8 size of one content record. |
 | `ContentIndexing:Indexes` | `object[]` | `[]` | Content indexes to maintain. Index names resolve as `{IndexName}.{Environment}.{Culture}`. |
 | `ContentIndexing:Indexes[*]:ContentTypes[*]:Alias` | `string` | required | Umbraco content type alias to include in the content index. |
-| `ContentIndexing:Indexes[*]:ContentTypes[*]:Properties` | `string[]` | `[]` | Property aliases to index. Use `|unix` or `|unixms` to add numeric date fields. |
+| `ContentIndexing:Indexes[*]:ContentTypes[*]:Properties` | `string[]` | `[]` | Property aliases to index. Use `|unix` or `|unixms` for numeric dates, or `|striphtml` for searchable plain text from rich-text values. |
 | `Search:Enabled` | `bool` | `true` | Enables Algolia search services. |
 | `Search:Products` | `bool` | `true` | Enables product search. |
 | `Search:Categories` | `bool` | `true` | Enables category search. |
@@ -461,7 +462,7 @@ Product indexes are configured with `AttributeForDistinct = ProductId`. `Search:
 
 ### Additional product properties and metafields
 
-`Indexing:ProductProperties` is only for adding extra product properties and metafields that are not part of the default product record fields listed above. Do not add built-in fields such as `title`, `summary`, or `description` here. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, or `|unixms`.
+`Indexing:ProductProperties` adds extra product properties and metafields that are not part of the default product record fields listed above. The built-in `title`, `summary`, and `description` aliases may also be configured with `|striphtml` to transform their top-level record fields. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, `|unixms`, or `|striphtml`.
 
 ```json
 {
@@ -472,7 +473,8 @@ Product indexes are configured with `AttributeForDistinct = ProductId`. `Search:
           "channels|array",
           "packageCount|int",
           "weight|decimal",
-          "publishedAt|unix"
+          "publishedAt|unix",
+          "description|striphtml"
         ]
       }
     }
@@ -490,7 +492,8 @@ Metafields can be indexed explicitly with `metafield:<alias>`:
         "ProductProperties": [
           "metafield:material",
           "metafield:color|array",
-          "metafield:releaseDate|unix"
+          "metafield:releaseDate|unix",
+          "metafield:longDescription|striphtml"
         ]
       }
     }
@@ -502,8 +505,10 @@ Modifier behavior:
 
 - `|array` parses JSON arrays such as `["Web","Store"]` into Algolia string arrays.
 - `|decimal` accepts comma or dot decimal separators, such as `0,1` and `0.0`.
+- `|striphtml` converts direct HTML or rich-text JSON with a `markup` property to plain text. It removes script and style content, decodes HTML entities, and normalizes tags and whitespace to single spaces.
 - Multi-value metafields are skipped unless `|array` is configured.
 - Invalid `|array`, `|int`, and `|decimal` values are skipped instead of being indexed as strings.
+- Only one modifier is supported for each configured field.
 
 ### Manual reindexing
 

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaContentIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaContentIndexExecutor.cs
@@ -465,6 +465,8 @@ internal sealed class AlgoliaContentIndexExecutor
             var value = ReadPropertyValue(property, propertyCulture, availableCultures, contentTypes);
             var converted = ConvertProperty(new AlgoliaContentPropertyContext(content, property, propertyCulture, culture, baseIndexName), value);
 
+            converted = ApplyConfiguredTransform(converted, transform);
+
             if (!HasIndexableValue(converted))
                 continue;
 
@@ -624,7 +626,7 @@ internal sealed class AlgoliaContentIndexExecutor
             _ => true
         };
 
-    private static (string Alias, AlgoliaContentFieldTransform Transform) ParseConfiguredField(string raw)
+    internal static (string Alias, AlgoliaContentFieldTransform Transform) ParseConfiguredField(string raw)
     {
         var parts = raw.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (parts.Length == 0)
@@ -636,11 +638,17 @@ internal sealed class AlgoliaContentIndexExecutor
             {
                 "unix" => AlgoliaContentFieldTransform.UnixSeconds,
                 "unixms" => AlgoliaContentFieldTransform.UnixMilliseconds,
+                "striphtml" => AlgoliaContentFieldTransform.StripHtml,
                 _ => AlgoliaContentFieldTransform.None
             };
 
         return (parts[0], transform);
     }
+
+    internal static object? ApplyConfiguredTransform(object? value, AlgoliaContentFieldTransform transform)
+        => transform == AlgoliaContentFieldTransform.StripHtml
+            ? AlgoliaHtmlTextConverter.Convert(value)
+            : value;
 
     private static object? TryToUnix(object? value, bool unixMilliseconds)
     {

--- a/Plugins/Ekom.Algolia/packages.lock.json
+++ b/Plugins/Ekom.Algolia/packages.lock.json
@@ -12,6 +12,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "[8.0.0, 11.0.0)"
         }
       },
+      "HtmlAgilityPack": {
+        "type": "Direct",
+        "requested": "[1.12.4, )",
+        "resolved": "1.12.4",
+        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
+      },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Direct",
         "requested": "[10.0.0, )",
@@ -286,11 +292,6 @@
         "dependencies": {
           "Hangfire.Core": "[1.8.18]"
         }
-      },
-      "HtmlAgilityPack": {
-        "type": "Transitive",
-        "resolved": "1.12.4",
-        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
       },
       "Humanizer.Core": {
         "type": "Transitive",
@@ -1800,6 +1801,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "[8.0.0, 11.0.0)"
         }
       },
+      "HtmlAgilityPack": {
+        "type": "Direct",
+        "requested": "[1.11.74, )",
+        "resolved": "1.11.74",
+        "contentHash": "q0wRGbegtr4sZXjCNoV3OeRLTOcTNJQKiO9etNVSKPoTo33unmSK8Ahg36C4jIg/Hd3aw8YnTQjtKpBy+wlOpg=="
+      },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Direct",
         "requested": "[8.0.1, )",
@@ -2062,11 +2069,6 @@
         "dependencies": {
           "Hangfire.Core": "[1.8.18]"
         }
-      },
-      "HtmlAgilityPack": {
-        "type": "Transitive",
-        "resolved": "1.11.74",
-        "contentHash": "q0wRGbegtr4sZXjCNoV3OeRLTOcTNJQKiO9etNVSKPoTo33unmSK8Ahg36C4jIg/Hd3aw8YnTQjtKpBy+wlOpg=="
       },
       "Humanizer.Core": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary
- add configurable HTML stripping transforms for Algolia product indexing
- replace full catalog traversal in product sync and product update sync with targeted lookups
- load only media referenced by a product sync payload and hydrate matching media in bulk
- clarify import service synchronization documentation

## Test Plan
- `dotnet build "Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- `git diff --check`
