### PR TITLE
fix(umbraco): improve metafield editor behavior

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Services/MetafieldService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/MetafieldService.cs
@@ -26,7 +26,7 @@ internal class MetafieldService : IMetafieldService
             return cachedResponse;
         }
 
-        IEnumerable<UmbracoContent> metafieldNodes = _nodeService.NodesByTypes("ekmMetaField");
+        IEnumerable<UmbracoContent> metafieldNodes = _nodeService.NodesByTypes("ekmMetafield");
 
         IEnumerable<Metafield> result = metafieldNodes.Select(x => new Metafield(x));
 

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EnsureNodesExist.cs
@@ -1349,15 +1349,14 @@ class EnsureNodesExist : IComponent
                                 },
                                 new PropertyType(_shortStringHelper, textstringDt, "description")
                                 {
-                                    Name = "Description",
-                                    Mandatory = true
+                                    Name = "Description"
                                 },
-                                new PropertyType(_shortStringHelper, booleanDt, "enableMultipleChoice")
+                                new PropertyType(_shortStringHelper, booleanDt, "filterable")
                                 {
                                     Name = "Filterable",
                                     Description = "When checked, the metafield will be visible in the filter."
                                 },
-                                new PropertyType(_shortStringHelper, booleanDt, "filterable")
+                                new PropertyType(_shortStringHelper, booleanDt, "enableMultipleChoice")
                                 {
                                     Name = "Enable Multiple Choice",
                                     Description  = "When checked, the dropdown will be a select multiple / combo box style dropdown."
@@ -1367,11 +1366,11 @@ class EnsureNodesExist : IComponent
                                     Name = "Values",
                                     Description  = "If no values are set then an textstring input is used."
                                 },
-                                new PropertyType(_shortStringHelper, booleanDt, "enableMultipleChoice")
+                                new PropertyType(_shortStringHelper, booleanDt, "required")
                                 {
                                     Name = "Required"
                                 },
-                                new PropertyType(_shortStringHelper, booleanDt, "enableMultipleChoice")
+                                new PropertyType(_shortStringHelper, booleanDt, "readOnly")
                                 {
                                     Name = "Read Only",
                                     Description = "When checked, the field will be read-only. This is good for metafields that data are for example synced to."

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
@@ -1379,14 +1379,13 @@ class EnsureNodesExist : IComponent
                                 new PropertyType(_shortStringHelper, textstringDt, "description")
                                 {
                                     Name = "Description",
-                                    Mandatory = true
                                 },
-                                new PropertyType(_shortStringHelper, booleanDt, "enableMultipleChoice")
+                                new PropertyType(_shortStringHelper, booleanDt, "filterable")
                                 {
                                     Name = "Filterable",
                                     Description = "When checked, the metafield will be visible in the filter."
                                 },
-                                new PropertyType(_shortStringHelper, booleanDt, "filterable")
+                                new PropertyType(_shortStringHelper, booleanDt, "enableMultipleChoice")
                                 {
                                     Name = "Enable Multiple Choice",
                                     Description  = "When checked, the dropdown will be a select multiple / combo box style dropdown."
@@ -1464,6 +1463,7 @@ class EnsureNodesExist : IComponent
                     CreateContentTypeSort(paymentProvidersCt, 4),
                     CreateContentTypeSort(zonesCt, 5),
                     CreateContentTypeSort(discountsCt, 6),
+                    CreateContentTypeSort(metafieldsCt, 7),
                 },
                     Icon = "icon-box color-green",
                 });

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -147,7 +147,7 @@ public class ImportService : IImportService
 
             _logger.LogInformation(
                 "Full Sync took {Duration} seconds. Categories Saved: {categoriesCount} Products Saved: {productsCount} Products With Error: {productsErrorCount} Variants Saved: {variantsCount} VariantsGroups Saved: {variantGroupsCount} Categories Deleted: {categoriesDeleted} Products Deleted: {productDeleted} Variants Deleted: {variantDeleted} VariantsGroups Deleted: {variantGroupDeleted}",
-                (stopwatch.ElapsedMilliseconds / 1000.0).ToString("F2"), categoriesSaved.Count, productsSaved.Where(x => x.Exception == null).Count(), productsSaved.Where(x => x.Exception != null).Count(), variantsSaved.Count, variantGroupsSaved.Count, categoriesDeleted, productDeleted, variantDeleted, variantGroupDeleted);
+                (stopwatch.ElapsedMilliseconds / 1000.0).ToString("F2"), categoriesSaved.Count, productsSaved.Count(x => x.Exception == null), productsSaved.Count(x => x.Exception != null), variantsSaved.Count, variantGroupsSaved.Count, categoriesDeleted, productDeleted, variantDeleted, variantGroupDeleted);
 
         }
         catch (Exception ex)
@@ -274,7 +274,8 @@ public class ImportService : IImportService
 
         _logger.LogInformation(
             "Category Sync took {Duration} seconds. Parent {parentKey} Categories Saved: {categoriesCount} Products Saved: {productsCount} Products With Error: {productsErrorCount} Variants Saved: {variantsCount} VariantsGroups Saved: {variantGroupsCount} Categories Deleted: {categoriesDeleted} Products Deleted: {productDeleted} Variants Deleted: {variantDeleted} VariantsGroups Deleted: {variantGroupDeleted}",
-            (stopwatch.ElapsedMilliseconds / 1000.0).ToString("F2"), parentKey, categoriesSaved.Count, productsSaved.Where(x => x.Exception == null).Count(), productsSaved.Where(x => x.Exception != null).Count(), variantsSaved.Count, variantGroupsSaved.Count, categoriesDeleted, productDeleted, variantDeleted, variantGroupDeleted);
+            (stopwatch.ElapsedMilliseconds / 1000.0).ToString("F2"), parentKey, categoriesSaved.Count, productsSaved.Count(x => x.Exception == null), productsSaved.Count(x => x.Exception != null), variantsSaved.Count, variantGroupsSaved.Count, categoriesDeleted, productDeleted, variantDeleted, variantGroupDeleted);
+
     }
 
     private void BeginSync(string syncName)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
@@ -99,6 +99,8 @@ internal sealed class UmbracoEventListeners :
                 continue;
             }
 
+            ClearMemoryCache(node);
+
             var cacheEntry = FindMatchingCache(node.ContentType.Alias);
             var parentNode = _nodeService.NodeById(node.ParentId);
 
@@ -398,7 +400,7 @@ internal sealed class UmbracoEventListeners :
             _cache.Remove($"{content.Id}_SerializeMetafields");
         }
 
-        if (content.ContentType.Alias == "ekmMetaField")
+        if (content.ContentType.Alias.Equals("ekmMetafield", StringComparison.OrdinalIgnoreCase))
         {
             _cache.Remove("GetMetafields");
         }

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/metafield-picker.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/metafield-picker.element.js
@@ -1,21 +1,25 @@
-var c = Object.defineProperty;
-var p = (o, l, e) => l in o ? c(o, l, { enumerable: !0, configurable: !0, writable: !0, value: e }) : o[l] = e;
-var r = (o, l, e) => p(o, typeof l != "symbol" ? l + "" : l, e);
-import { UmbChangeEvent as h } from "@umbraco-cms/backoffice/event";
-class m extends HTMLElement {
+var v = Object.defineProperty;
+var k = (b, m, e) => m in b ? v(b, m, { enumerable: !0, configurable: !0, writable: !0, value: e }) : b[m] = e;
+var p = (b, m, e) => k(b, typeof m != "symbol" ? m + "" : m, e);
+import { UmbChangeEvent as w } from "@umbraco-cms/backoffice/event";
+class S extends HTMLElement {
   constructor() {
     super(...arguments);
-    r(this, "manifest");
-    r(this, "name");
-    r(this, "dataSourceAlias");
-    r(this, "config");
-    r(this, "mandatory");
-    r(this, "mandatoryMessage");
-    r(this, "editor");
-    r(this, "status");
-    r(this, "languages", []);
-    r(this, "fields", []);
-    r(this, "items", []);
+    p(this, "manifest");
+    p(this, "name");
+    p(this, "dataSourceAlias");
+    p(this, "config");
+    p(this, "mandatory");
+    p(this, "mandatoryMessage");
+    p(this, "editor");
+    p(this, "status");
+    p(this, "languages", []);
+    p(this, "fields", []);
+    p(this, "items", []);
+    p(this, "handleDocumentClick", (e) => {
+      const t = e.composedPath().find((o) => o instanceof Element && o.classList.contains("combobox"));
+      (!(t instanceof Element) || !this.contains(t)) && this.closeDropdowns();
+    });
   }
   get value() {
     return this.items;
@@ -30,7 +34,10 @@ class m extends HTMLElement {
     this.toggleAttribute("readonly", e), this.syncDisabledState();
   }
   connectedCallback() {
-    this.renderShell(), this.loadData();
+    this.renderShell(), document.addEventListener("click", this.handleDocumentClick), this.loadData();
+  }
+  disconnectedCallback() {
+    document.removeEventListener("click", this.handleDocumentClick);
   }
   async loadData() {
     this.setStatus("Loading metafields...");
@@ -54,10 +61,27 @@ class m extends HTMLElement {
         .label-row { display: flex; align-items: start; justify-content: space-between; gap: var(--uui-size-space-4, 16px); }
         label { display: grid; gap: var(--uui-size-space-1, 4px); font-weight: 700; }
         small { display: block; color: var(--uui-color-text-alt, #515054); font-weight: 400; }
-        input, select { box-sizing: border-box; width: 100%; min-height: 32px; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); color: var(--uui-color-text, #1b264f); font: inherit; }
-        select[multiple] { min-height: 130px; }
-        button { border: 0; border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px) var(--uui-size-space-3, 12px); background: var(--uui-color-surface-alt, #f3f3f5); color: var(--uui-color-text, #1b264f); border: 1px solid var(--uui-color-border, #d8d7d9); cursor: pointer; font: inherit; font-weight: 600; white-space: nowrap; }
-        button:disabled, input:disabled, select:disabled { cursor: not-allowed; opacity: 0.55; }
+        input { box-sizing: border-box; width: 100%; min-height: 32px; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); color: var(--uui-color-text, #1b264f); font: inherit; }
+        .combobox { position: relative; }
+        .combobox-control { display: flex; align-items: center; gap: var(--uui-size-space-2, 8px); box-sizing: border-box; width: 100%; min-height: 40px; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-1, 4px) var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); color: var(--uui-color-text, #1b264f); cursor: pointer; }
+        .combobox-control:focus { outline: 2px solid var(--uui-color-focus, #3544b1); outline-offset: 1px; }
+        .combobox-control[aria-disabled='true'] { cursor: not-allowed; opacity: 0.55; }
+        .combobox-value { display: flex; flex: 1; flex-wrap: wrap; gap: var(--uui-size-space-1, 4px); min-width: 0; }
+        .placeholder { color: var(--uui-color-text-alt, #515054); }
+        .combobox-arrow { flex: 0 0 auto; }
+        .combobox-dropdown { position: absolute; z-index: 20; top: calc(100% + 4px); left: 0; right: 0; display: grid; gap: var(--uui-size-space-2, 8px); border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); box-shadow: 0 4px 12px rgb(0 0 0 / 18%); }
+        .combobox-dropdown[hidden] { display: none; }
+        .chip { display: inline-flex; align-items: center; gap: var(--uui-size-space-1, 4px); border-radius: 999px; padding: 3px 6px 3px 10px; background: var(--uui-color-surface-alt, #f3f3f5); color: var(--uui-color-text, #1b264f); }
+        .chip button { display: grid; place-items: center; width: 20px; height: 20px; border: 0; border-radius: 50%; padding: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; font-size: 18px; line-height: 1; }
+        .chip button:hover { background: var(--uui-color-border, #d8d7d9); }
+        .option-list { display: grid; max-height: 220px; overflow-y: auto; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); background: var(--uui-color-surface, #fff); }
+        .option { display: flex; align-items: center; gap: var(--uui-size-space-2, 8px); border: 0; padding: var(--uui-size-space-2, 8px); background: transparent; color: inherit; font: inherit; font-weight: 400; text-align: left; cursor: pointer; }
+        .option + .option { border-top: 1px solid var(--uui-color-border, #d8d7d9); }
+        .option:hover, .option:focus { background: var(--uui-color-surface-alt, #f3f3f5); }
+        .option-mark { width: 16px; text-align: center; }
+        .empty-options { padding: var(--uui-size-space-3, 12px); color: var(--uui-color-text-alt, #515054); }
+        .clear-button { border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-1, 4px) var(--uui-size-space-2, 8px); background: var(--uui-color-surface-alt, #f3f3f5); color: var(--uui-color-text, #1b264f); cursor: pointer; font: inherit; white-space: nowrap; }
+        button:disabled, input:disabled { cursor: not-allowed; opacity: 0.55; }
         p { margin: 0; color: var(--uui-color-text-alt, #515054); }
         p[data-error='true'] { color: var(--uui-color-danger, #d42054); }
       </style>
@@ -73,104 +97,206 @@ class m extends HTMLElement {
       const t = document.createElement("p");
       t.textContent = "No metafields exist. You can create them under Metafields in Ekom", e.append(t);
     }
-    this.fields.forEach((t, s) => e.append(this.createField(t, s))), this.editor.replaceChildren(e), this.syncDisabledState();
+    this.fields.forEach((t, o) => e.append(this.createField(t, o))), this.editor.replaceChildren(e), this.syncDisabledState();
   }
   createField(e, t) {
+    const o = document.createElement("div");
+    o.className = "field";
     const s = document.createElement("div");
-    s.className = "field";
-    const i = document.createElement("div");
-    i.className = "label-row";
+    s.className = "label-row";
     const a = document.createElement("label");
-    if (a.htmlFor = `metafield_${t}`, a.textContent = e.name ?? e.key ?? "", !this.isEmpty(e.description)) {
-      const u = document.createElement("small");
-      u.textContent = e.description ?? "", a.append(u);
+    a.htmlFor = `metafield_${t}`, a.textContent = e.name ?? e.key ?? "";
+    const r = `metafield_${t}_description`;
+    if (!this.isEmpty(e.description)) {
+      const d = document.createElement("small");
+      d.id = r, d.textContent = e.description ?? "", a.append(d);
     }
-    const n = document.createElement("button");
-    n.type = "button", n.textContent = "Clear", n.addEventListener("click", (u) => this.clearField(u, e)), i.append(a, n), s.append(i);
-    const d = e.values ?? [];
-    return d.length > 0 ? s.append(this.createSelect(e, t, d)) : s.append(this.createTextInput(e, t)), s;
+    const l = document.createElement("button");
+    l.type = "button", l.className = "clear-button", l.dataset.key = e.key ?? "", l.dataset.action = "clear", l.textContent = "Clear", l.addEventListener("click", (d) => this.clearField(d, e)), s.append(a, l), o.append(s);
+    const c = e.values ?? [];
+    return c.length > 0 ? o.append(e.enableMultipleChoice === !0 ? this.createMultiSelect(e, t, r) : this.createSelect(e, t, c, r)) : o.append(this.createTextInput(e, t, r)), o;
   }
-  createSelect(e, t, s) {
-    const i = document.createElement("select");
-    if (i.id = `metafield_${t}`, i.dataset.key = e.key ?? "", i.multiple = e.enableMultipleChoice === !0, !i.multiple) {
-      const a = document.createElement("option");
-      a.value = "", a.textContent = "Select value", i.append(a);
-    }
-    for (const a of s) {
-      const n = document.createElement("option");
-      n.value = a.id ?? "", n.textContent = this.getMetavalueLabel(a), i.append(n);
-    }
-    return this.setSelectValue(i, e), i.addEventListener("change", () => this.setMetafieldSelectValue(e, i)), i;
+  createSelect(e, t, o, s) {
+    return this.createChoicePicker(e, t, s, !1);
   }
-  createTextInput(e, t) {
+  createMultiSelect(e, t, o) {
+    return this.createChoicePicker(e, t, o, !0);
+  }
+  createChoicePicker(e, t, o, s) {
+    const a = document.createElement("div");
+    a.className = `combobox ${s ? "multi-picker" : "single-picker"}`, a.dataset.key = e.key ?? "";
+    const r = document.createElement("div");
+    r.id = `metafield_${t}`, r.className = "combobox-control", r.dataset.key = e.key ?? "", r.dataset.control = "choice", r.tabIndex = 0, r.setAttribute("role", "combobox"), r.setAttribute("aria-haspopup", "listbox"), r.setAttribute("aria-expanded", "false"), r.setAttribute("aria-label", e.name ?? e.key ?? "Metafield"), this.setDescription(r, e, o);
+    const l = document.createElement("div");
+    l.className = "combobox-value", l.setAttribute("aria-label", s ? "Selected values" : "Selected value");
+    const c = document.createElement("span");
+    c.className = "combobox-arrow", c.setAttribute("aria-hidden", "true"), c.textContent = "▾", r.append(l, c);
+    const d = document.createElement("div");
+    d.className = "combobox-dropdown", d.hidden = !0;
+    const n = document.createElement("input");
+    n.type = "search", n.placeholder = "Search values", n.dataset.key = e.key ?? "", n.dataset.control = "search", n.setAttribute("aria-label", `Search ${e.name ?? e.key ?? "metafield"} values`), n.addEventListener("input", () => this.renderChoiceOptions(e, a, n.value, s)), n.addEventListener("keydown", (i) => {
+      var h;
+      i.key === "Escape" ? (i.preventDefault(), this.closeDropdown(a, !0)) : i.key === "ArrowDown" && (i.preventDefault(), (h = a.querySelector(".option")) == null || h.focus());
+    });
+    const u = document.createElement("div");
+    return u.className = "option-list", u.setAttribute("role", "listbox"), u.setAttribute("aria-label", "Available values"), u.setAttribute("aria-multiselectable", String(s)), r.addEventListener("click", () => this.toggleDropdown(e, a, s)), r.addEventListener("keydown", (i) => {
+      i.key === "Enter" || i.key === " " || i.key === "ArrowDown" ? (i.preventDefault(), this.openDropdown(e, a, s)) : i.key === "Escape" && (i.preventDefault(), this.closeDropdown(a));
+    }), d.append(n, u), a.append(r, d), this.syncChoicePicker(e, a, s), a;
+  }
+  createTextInput(e, t, o) {
     const s = document.createElement("input");
-    return s.id = `metafield_${t}`, s.type = "text", s.dataset.key = e.key ?? "", s.value = String(this.getFieldValue(e) ?? ""), s.readOnly = e.readOnly === !0, s.addEventListener("input", () => this.setMetafieldValue(e, s.value)), s;
-  }
-  setSelectValue(e, t) {
-    const s = new Set(this.getSelectedIds(t));
-    for (const i of e.options)
-      i.selected = s.has(i.value);
-  }
-  setMetafieldSelectValue(e, t) {
-    if (this.readonly)
-      return;
-    const s = Array.from(t.selectedOptions).map((i) => (e.values ?? []).find((a) => a.id === i.value)).filter((i) => i != null);
-    this.setMetafieldValue(e, t.multiple ? s : s[0] ?? "");
+    return s.id = `metafield_${t}`, s.type = "text", s.dataset.key = e.key ?? "", s.dataset.control = "text", s.value = String(this.getFieldValue(e) ?? ""), s.readOnly = e.readOnly === !0, this.setDescription(s, e, o), s.addEventListener("input", () => this.setMetafieldValue(e, s.value)), s;
   }
   clearField(e, t) {
-    var i;
-    if (e.preventDefault(), this.readonly)
+    var s;
+    if (e.preventDefault(), this.isFieldReadonly(t))
       return;
-    const s = (((i = t.values) == null ? void 0 : i.length) ?? 0) > 0 && t.enableMultipleChoice === !0 ? [] : "";
-    this.setMetafieldValue(t, s), this.syncInputs();
+    const o = (((s = t.values) == null ? void 0 : s.length) ?? 0) > 0 && t.enableMultipleChoice === !0 ? [] : "";
+    this.setMetafieldValue(t, o), this.syncInputs();
   }
   setMetafieldValue(e, t) {
-    const s = e.key;
-    s != null && (this.items = this.items.map((i) => i.key === s ? {
-      key: s,
+    const o = e.key;
+    o != null && (this.items = this.items.map((s) => s.key === o ? {
+      key: o,
       values: t
-    } : i), this.items.some((i) => i.key === s) || (this.items = [
+    } : s), this.items.some((s) => s.key === o) || (this.items = [
       ...this.items,
       {
-        key: s,
+        key: o,
         values: t
       }
-    ]), this.emitChange());
+    ]), this.syncDisabledState(), this.emitChange());
   }
   ensureFieldValues() {
     var t;
     const e = [...this.items];
-    for (const s of this.fields) {
-      const i = s.key;
-      i == null || e.some((a) => a.key === i) || e.push({
-        key: i,
-        values: (((t = s.values) == null ? void 0 : t.length) ?? 0) > 0 ? [] : ""
+    for (const o of this.fields) {
+      const s = o.key;
+      s == null || e.some((a) => a.key === s) || e.push({
+        key: s,
+        values: (((t = o.values) == null ? void 0 : t.length) ?? 0) > 0 ? [] : ""
       });
     }
     this.items = e;
   }
   syncInputs() {
-    if (!(this.editor == null || this.fields.length === 0))
+    if (!(this.editor == null || this.fields.length === 0)) {
       for (const e of this.fields) {
         const t = e.key;
         if (t == null)
           continue;
-        const s = this.editor.querySelector(`input[data-key="${CSS.escape(t)}"]`), i = this.editor.querySelector(`select[data-key="${CSS.escape(t)}"]`);
-        s != null && (s.value = String(this.getFieldValue(e) ?? "")), i != null && this.setSelectValue(i, e);
+        const o = this.editor.querySelector(`input[data-control="text"][data-key="${CSS.escape(t)}"]`), s = this.editor.querySelector(`.multi-picker[data-key="${CSS.escape(t)}"]`), a = this.editor.querySelector(`.single-picker[data-key="${CSS.escape(t)}"]`);
+        o != null && (o.value = String(this.getFieldValue(e) ?? "")), s != null && this.syncChoicePicker(e, s, !0), a != null && this.syncChoicePicker(e, a, !1);
       }
+      this.syncDisabledState();
+    }
   }
   getFieldValue(e) {
     var t;
-    return (t = this.items.find((s) => s.key === e.key)) == null ? void 0 : t.values;
+    return (t = this.items.find((o) => o.key === e.key)) == null ? void 0 : t.values;
   }
   getSelectedIds(e) {
     const t = this.getFieldValue(e);
-    return Array.isArray(t) ? t.map((s) => this.isRecord(s) ? String(s.id ?? "") : String(s)) : this.isRecord(t) ? [String(t.id ?? "")] : t == null || t === "" ? [] : [String(t)];
+    return Array.isArray(t) ? t.map((o) => this.isRecord(o) ? String(o.id ?? "") : String(o)) : this.isRecord(t) ? [String(t.id ?? "")] : t == null || t === "" ? [] : [String(t)];
+  }
+  syncChoicePicker(e, t, o) {
+    const s = new Set(this.getSelectedIds(e)), a = (e.values ?? []).filter((c) => s.has(c.id ?? "")), r = t.querySelector(".combobox-value"), l = t.querySelector('input[type="search"]');
+    if (r != null)
+      if (o) {
+        const c = a.map((d) => {
+          const n = this.getMetavalueLabel(d), u = document.createElement("span");
+          u.className = "chip", u.append(document.createTextNode(n));
+          const i = document.createElement("button");
+          return i.type = "button", i.dataset.key = e.key ?? "", i.setAttribute("aria-label", `Remove ${n}`), i.textContent = "×", i.addEventListener("click", (h) => {
+            h.preventDefault(), h.stopPropagation(), this.toggleMetavalue(e, d, !1, t);
+          }), u.append(i), u;
+        });
+        c.length === 0 ? r.replaceChildren(this.createPlaceholder("Select values")) : r.replaceChildren(...c);
+      } else {
+        const c = a[0];
+        r.replaceChildren(c == null ? this.createPlaceholder("Select value") : document.createTextNode(this.getMetavalueLabel(c)));
+      }
+    this.isDropdownClosed(t) || this.renderChoiceOptions(e, t, (l == null ? void 0 : l.value) ?? "", o), this.syncDisabledState();
+  }
+  createPlaceholder(e) {
+    const t = document.createElement("span");
+    return t.className = "placeholder", t.textContent = e, t;
+  }
+  toggleDropdown(e, t, o) {
+    this.isDropdownClosed(t) ? this.openDropdown(e, t, o) : this.closeDropdown(t);
+  }
+  openDropdown(e, t, o) {
+    if (this.isFieldReadonly(e))
+      return;
+    this.closeDropdowns(t);
+    const s = t.querySelector(".combobox-control"), a = t.querySelector(".combobox-dropdown"), r = t.querySelector('input[type="search"]');
+    s == null || a == null || r == null || (a.hidden = !1, s.setAttribute("aria-expanded", "true"), this.renderChoiceOptions(e, t, r.value, o), r.focus());
+  }
+  closeDropdown(e, t = !1) {
+    const o = e.querySelector(".combobox-control"), s = e.querySelector(".combobox-dropdown"), a = e.querySelector('input[type="search"]'), r = e.querySelector(".option-list");
+    s != null && (s.hidden = !0, o == null || o.setAttribute("aria-expanded", "false"), r == null || r.replaceChildren(), a != null && (a.value = ""), t && (o == null || o.focus()));
+  }
+  closeDropdowns(e) {
+    for (const t of this.querySelectorAll(".combobox"))
+      t !== e && this.closeDropdown(t);
+  }
+  isDropdownClosed(e) {
+    var t;
+    return ((t = e.querySelector(".combobox-dropdown")) == null ? void 0 : t.hidden) !== !1;
+  }
+  renderChoiceOptions(e, t, o, s) {
+    const a = t.querySelector(".option-list");
+    if (a == null || this.isDropdownClosed(t))
+      return;
+    const r = o.trim().toLocaleLowerCase(), l = new Set(this.getSelectedIds(e)), c = (e.values ?? []).filter((n) => this.getMetavalueLabel(n).toLocaleLowerCase().includes(r));
+    if (c.length === 0) {
+      const n = document.createElement("span");
+      n.className = "empty-options", n.textContent = "No matching values", a.replaceChildren(n);
+      return;
+    }
+    const d = c.map((n) => {
+      const u = n.id ?? "", i = document.createElement("button"), h = l.has(u);
+      i.type = "button", i.className = "option", i.dataset.key = e.key ?? "", i.dataset.valueId = u, i.setAttribute("role", "option"), i.setAttribute("aria-selected", String(h));
+      const y = document.createElement("span");
+      y.className = "option-mark", y.setAttribute("aria-hidden", "true"), y.textContent = h ? "✓" : "";
+      const g = document.createElement("span");
+      return g.textContent = this.getMetavalueLabel(n), i.append(y, g), i.addEventListener("click", (f) => {
+        var x;
+        f.preventDefault(), f.stopPropagation(), s ? (this.toggleMetavalue(e, n, !h, t), (x = t.querySelector(`button[data-value-id="${CSS.escape(u)}"]`)) == null || x.focus()) : this.selectMetavalue(e, n, t);
+      }), i.addEventListener("keydown", (f) => this.handleOptionKeydown(f, t)), i;
+    });
+    a.replaceChildren(...d);
+  }
+  toggleMetavalue(e, t, o, s) {
+    if (this.isFieldReadonly(e))
+      return;
+    const a = t.id ?? "", r = new Set(this.getSelectedIds(e));
+    o ? r.add(a) : r.delete(a);
+    const l = (e.values ?? []).filter((c) => r.has(c.id ?? ""));
+    this.setMetafieldValue(e, l), this.syncChoicePicker(e, s, !0);
+  }
+  selectMetavalue(e, t, o) {
+    this.isFieldReadonly(e) || (this.setMetafieldValue(e, t), this.syncChoicePicker(e, o, !1), this.closeDropdown(o, !0));
+  }
+  handleOptionKeydown(e, t) {
+    var r;
+    if (e.key === "Escape") {
+      e.preventDefault(), this.closeDropdown(t, !0);
+      return;
+    }
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp")
+      return;
+    e.preventDefault();
+    const o = Array.from(t.querySelectorAll(".option")), s = o.indexOf(e.currentTarget), a = e.key === "ArrowDown" ? Math.min(s + 1, o.length - 1) : Math.max(s - 1, 0);
+    (r = o[a]) == null || r.focus();
+  }
+  setDescription(e, t, o) {
+    this.isEmpty(t.description) || e.setAttribute("aria-describedby", o);
   }
   getMetavalueLabel(e) {
-    var s, i, a;
-    const t = (s = this.languages[0]) == null ? void 0 : s.isoCode;
-    return t != null && !this.isEmpty((i = e.values) == null ? void 0 : i[t]) ? ((a = e.values) == null ? void 0 : a[t]) ?? "" : Object.values(e.values ?? {}).find((n) => !this.isEmpty(n)) ?? e.id ?? "";
+    var o, s, a;
+    const t = (o = this.languages[0]) == null ? void 0 : o.isoCode;
+    return t != null && !this.isEmpty((s = e.values) == null ? void 0 : s[t]) ? ((a = e.values) == null ? void 0 : a[t]) ?? "" : Object.values(e.values ?? {}).find((r) => !this.isEmpty(r)) ?? e.id ?? "";
   }
   normalizeValue(e) {
     return Array.isArray(e) ? e.map((t) => {
@@ -182,18 +308,34 @@ class m extends HTMLElement {
     }).filter((t) => t != null) : [];
   }
   syncDisabledState() {
-    for (const e of this.querySelectorAll("input, select, button"))
-      e.disabled = this.readonly;
-    for (const e of this.querySelectorAll("input")) {
-      const t = e.dataset.key, s = this.fields.find((i) => i.key === t);
-      e.readOnly = (s == null ? void 0 : s.readOnly) === !0;
+    for (const e of this.querySelectorAll("input, button")) {
+      const t = e.dataset.key, o = this.fields.find((l) => l.key === t), s = e instanceof HTMLInputElement && e.dataset.control === "text", a = e.dataset.action === "clear" && (o == null || this.isFieldValueEmpty(o)), r = this.readonly || !s && (o == null ? void 0 : o.readOnly) === !0 || a;
+      e.toggleAttribute("disabled", r);
     }
+    for (const e of this.querySelectorAll('input[data-control="text"]')) {
+      const t = e.dataset.key, o = this.fields.find((s) => s.key === t);
+      e.readOnly = (o == null ? void 0 : o.readOnly) === !0;
+    }
+    for (const e of this.querySelectorAll(".combobox-control")) {
+      const t = this.fields.find((s) => s.key === e.dataset.key), o = t == null || this.isFieldReadonly(t);
+      if (e.setAttribute("aria-disabled", String(o)), e.tabIndex = o ? -1 : 0, o) {
+        const s = e.closest(".combobox");
+        s != null && this.closeDropdown(s);
+      }
+    }
+  }
+  isFieldReadonly(e) {
+    return this.readonly || e.readOnly === !0;
+  }
+  isFieldValueEmpty(e) {
+    const t = this.getFieldValue(e);
+    return Array.isArray(t) ? t.length === 0 : t == null || t === "";
   }
   setStatus(e, t = !1) {
     this.status != null && (this.status.textContent = e, this.status.dataset.error = String(t));
   }
   emitChange() {
-    this.dispatchEvent(new h());
+    this.dispatchEvent(new w());
   }
   isEmpty(e) {
     return e == null || String(e).length === 0;
@@ -213,8 +355,8 @@ class m extends HTMLElement {
     return await t.json();
   }
 }
-customElements.define("ekom-metafield-picker", m);
+customElements.define("ekom-metafield-picker", S);
 export {
-  m as EkomMetafieldPickerElement,
-  m as default
+  S as EkomMetafieldPickerElement,
+  S as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/metavalue-editor.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/metavalue-editor.element.js
@@ -1,6 +1,6 @@
-var l = Object.defineProperty;
-var c = (n, o, e) => o in n ? l(n, o, { enumerable: !0, configurable: !0, writable: !0, value: e }) : n[o] = e;
-var r = (n, o, e) => c(n, typeof o != "symbol" ? o + "" : o, e);
+var d = Object.defineProperty;
+var c = (u, o, t) => o in u ? d(u, o, { enumerable: !0, configurable: !0, writable: !0, value: t }) : u[o] = t;
+var r = (u, o, t) => c(u, typeof o != "symbol" ? o + "" : o, t);
 import { UmbChangeEvent as h } from "@umbraco-cms/backoffice/event";
 class m extends HTMLElement {
   constructor() {
@@ -19,14 +19,15 @@ class m extends HTMLElement {
   get value() {
     return this.items;
   }
-  set value(e) {
-    this.items = this.normalizeValue(e), this.renderRows();
+  set value(t) {
+    const e = this.normalizeValue(t), a = this.hasMatchingRows(e);
+    this.items = e, a ? this.syncInputs() : this.renderRows();
   }
   get readonly() {
     return this.hasAttribute("readonly");
   }
-  set readonly(e) {
-    this.toggleAttribute("readonly", e), this.syncDisabledState();
+  set readonly(t) {
+    this.toggleAttribute("readonly", t), this.syncDisabledState();
   }
   connectedCallback() {
     this.renderShell(), this.loadLanguages();
@@ -35,9 +36,9 @@ class m extends HTMLElement {
     this.setStatus("Loading languages...");
     try {
       this.languages = await this.fetchJson("/ekom/backoffice/Languages"), this.renderRows(), this.setStatus("");
-    } catch (e) {
-      const t = e instanceof Error ? e.message : "Could not load languages.";
-      this.setStatus(t, !0);
+    } catch (t) {
+      const e = t instanceof Error ? t.message : "Could not load languages.";
+      this.setStatus(e, !0);
     }
   }
   renderShell() {
@@ -64,113 +65,134 @@ class m extends HTMLElement {
     if (this.editor == null)
       return;
     this.editor.style.setProperty("--language-count", String(Math.max(this.languages.length, 1)));
-    const e = document.createDocumentFragment();
+    const t = document.createDocumentFragment();
     if (this.languages.length > 0 && this.items.length > 0) {
       const a = document.createElement("div");
       a.className = "header";
-      for (const s of this.languages) {
-        const i = document.createElement("div");
-        i.textContent = s.cultureName ?? s.isoCode ?? "", a.append(i);
+      for (const i of this.languages) {
+        const s = document.createElement("div");
+        s.textContent = i.cultureName ?? i.isoCode ?? "", a.append(s);
       }
-      a.append(document.createElement("div")), e.append(a);
+      a.append(document.createElement("div")), t.append(a);
     }
-    this.items.forEach((a, s) => e.append(this.createRow(a, s)));
-    const t = document.createElement("button");
-    t.type = "button", t.textContent = "Add", t.addEventListener("click", (a) => this.addItem(a)), e.append(t), this.editor.replaceChildren(e), this.syncDisabledState();
+    this.items.forEach((a, i) => t.append(this.createRow(a, i)));
+    const e = document.createElement("button");
+    e.type = "button", e.textContent = "Add", e.addEventListener("click", (a) => this.addItem(a)), t.append(e), this.editor.replaceChildren(t), this.syncDisabledState();
   }
-  createRow(e, t) {
+  createRow(t, e) {
     const a = document.createElement("div");
-    a.className = "row";
-    for (const i of this.languages) {
-      const u = i.isoCode ?? "", d = document.createElement("input");
-      d.type = "text", d.value = e.values[u] ?? "", d.addEventListener("input", () => this.setLanguageValue(t, u, d.value)), a.append(d);
+    a.className = "row", a.dataset.itemId = t.id;
+    for (const s of this.languages) {
+      const n = s.isoCode ?? "", l = document.createElement("input");
+      l.type = "text", l.dataset.language = n, l.value = t.values[n] ?? "", l.addEventListener("input", () => this.setLanguageValue(e, n, l.value)), a.append(l);
     }
-    const s = document.createElement("div");
-    return s.className = "actions", s.append(
-      this.createActionButton("↑", () => this.moveItem(t, -1), "secondary", t === 0),
-      this.createActionButton("↓", () => this.moveItem(t, 1), "secondary", t === this.items.length - 1),
-      this.createActionButton("Remove", () => this.removeItem(t), "danger")
-    ), a.append(s), a;
+    const i = document.createElement("div");
+    return i.className = "actions", i.append(
+      this.createActionButton("↑", () => this.moveItem(e, -1), "secondary", e === 0),
+      this.createActionButton("↓", () => this.moveItem(e, 1), "secondary", e === this.items.length - 1),
+      this.createActionButton("Remove", () => this.removeItem(e), "danger")
+    ), a.append(i), a;
   }
-  createActionButton(e, t, a, s = !1) {
-    const i = document.createElement("button");
-    return i.type = "button", i.textContent = e, a != null && (i.dataset.kind = a), i.dataset.disabledWhenEnabled = String(s), i.disabled = s, i.addEventListener("click", (u) => {
-      u.preventDefault(), this.readonly || t();
-    }), i;
+  createActionButton(t, e, a, i = !1) {
+    const s = document.createElement("button");
+    return s.type = "button", s.textContent = t, a != null && (s.dataset.kind = a), s.dataset.disabledWhenEnabled = String(i), s.disabled = i, s.addEventListener("click", (n) => {
+      n.preventDefault(), this.readonly || e();
+    }), s;
   }
-  addItem(e) {
-    if (e.preventDefault(), this.readonly)
+  addItem(t) {
+    if (t.preventDefault(), this.readonly)
       return;
-    const t = {};
+    const e = {};
     for (const a of this.languages)
-      a.isoCode != null && (t[a.isoCode] = "");
+      a.isoCode != null && (e[a.isoCode] = "");
     this.items = [
       ...this.items,
       {
         id: Math.random().toString(16).slice(2),
-        values: t
+        values: e
       }
     ], this.renderRows(), this.emitChange();
   }
-  removeItem(e) {
-    this.items = this.items.filter((t, a) => a !== e), this.renderRows(), this.emitChange();
+  removeItem(t) {
+    this.items = this.items.filter((e, a) => a !== t), this.renderRows(), this.emitChange();
   }
-  moveItem(e, t) {
-    const a = e + t;
+  moveItem(t, e) {
+    const a = t + e;
     if (a < 0 || a >= this.items.length)
       return;
-    const s = [...this.items], [i] = s.splice(e, 1);
-    s.splice(a, 0, i), this.items = s, this.renderRows(), this.emitChange();
+    const i = [...this.items], [s] = i.splice(t, 1);
+    i.splice(a, 0, s), this.items = i, this.renderRows(), this.emitChange();
   }
-  setLanguageValue(e, t, a) {
-    this.items[e] != null && (this.items = this.items.map((i, u) => u === e ? {
-      ...i,
+  setLanguageValue(t, e, a) {
+    this.items[t] != null && (this.items = this.items.map((s, n) => n === t ? {
+      ...s,
       values: {
-        ...i.values,
-        [t]: a
+        ...s.values,
+        [e]: a
       }
-    } : i), this.emitChange());
+    } : s), this.emitChange());
   }
-  normalizeValue(e) {
-    return Array.isArray(e) ? e.map((t) => {
-      if (this.isRecord(t))
+  hasMatchingRows(t) {
+    if (this.editor == null || this.editor.childElementCount === 0)
+      return !1;
+    const e = this.editor.querySelectorAll(".row");
+    return e.length === t.length && t.every((a, i) => {
+      var s;
+      return ((s = e[i]) == null ? void 0 : s.dataset.itemId) === a.id;
+    });
+  }
+  syncInputs() {
+    if (this.editor == null)
+      return;
+    this.editor.querySelectorAll(".row").forEach((e, a) => {
+      const i = this.items[a];
+      if (i != null)
+        for (const s of e.querySelectorAll("input[data-language]")) {
+          const n = i.values[s.dataset.language ?? ""] ?? "";
+          s.value !== n && (s.value = n);
+        }
+    });
+  }
+  normalizeValue(t) {
+    return Array.isArray(t) ? t.map((e) => {
+      if (this.isRecord(e))
         return {
-          id: String(t.id ?? Math.random().toString(16).slice(2)),
-          values: this.isRecord(t.values) ? this.normalizeValues(t.values) : {}
+          id: String(e.id ?? Math.random().toString(16).slice(2)),
+          values: this.isRecord(e.values) ? this.normalizeValues(e.values) : {}
         };
-    }).filter((t) => t != null) : [];
+    }).filter((e) => e != null) : [];
   }
-  normalizeValues(e) {
-    const t = {};
-    for (const [a, s] of Object.entries(e))
-      t[a] = s == null ? "" : String(s);
-    return t;
+  normalizeValues(t) {
+    const e = {};
+    for (const [a, i] of Object.entries(t))
+      e[a] = i == null ? "" : String(i);
+    return e;
   }
   syncDisabledState() {
-    for (const e of this.querySelectorAll("input"))
-      e.disabled = this.readonly;
-    for (const e of this.querySelectorAll("button"))
-      e.disabled = this.readonly || e.dataset.disabledWhenEnabled === "true";
+    for (const t of this.querySelectorAll("input"))
+      t.disabled = this.readonly;
+    for (const t of this.querySelectorAll("button"))
+      t.disabled = this.readonly || t.dataset.disabledWhenEnabled === "true";
   }
-  setStatus(e, t = !1) {
-    this.status != null && (this.status.textContent = e, this.status.dataset.error = String(t));
+  setStatus(t, e = !1) {
+    this.status != null && (this.status.textContent = t, this.status.dataset.error = String(e));
   }
   emitChange() {
     this.dispatchEvent(new h());
   }
-  isRecord(e) {
-    return e != null && typeof e == "object" && !Array.isArray(e);
+  isRecord(t) {
+    return t != null && typeof t == "object" && !Array.isArray(t);
   }
-  async fetchJson(e) {
-    const t = await fetch(e, {
+  async fetchJson(t) {
+    const e = await fetch(t, {
       credentials: "same-origin",
       headers: {
         Accept: "application/json"
       }
     });
-    if (!t.ok)
-      throw new Error(`Request to ${e} failed with status ${t.status}.`);
-    return await t.json();
+    if (!e.ok)
+      throw new Error(`Request to ${t} failed with status ${e.status}.`);
+    return await e.json();
   }
 }
 customElements.define("ekom-metavalue-editor", m);

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/metafield-picker.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/metafield-picker.element.ts
@@ -42,6 +42,14 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
   private languages: Language[] = [];
   private fields: Metafield[] = [];
   private items: MetafieldValue[] = [];
+  private readonly handleDocumentClick = (event: MouseEvent): void => {
+    const picker = event.composedPath()
+      .find(target => target instanceof Element && target.classList.contains('combobox'));
+
+    if (!(picker instanceof Element) || !this.contains(picker)) {
+      this.closeDropdowns();
+    }
+  };
 
   get value(): MetafieldValue[] {
     return this.items;
@@ -63,7 +71,12 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
 
   override connectedCallback(): void {
     this.renderShell();
+    document.addEventListener('click', this.handleDocumentClick);
     void this.loadData();
+  }
+
+  override disconnectedCallback(): void {
+    document.removeEventListener('click', this.handleDocumentClick);
   }
 
   private async loadData(): Promise<void> {
@@ -95,10 +108,27 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
         .label-row { display: flex; align-items: start; justify-content: space-between; gap: var(--uui-size-space-4, 16px); }
         label { display: grid; gap: var(--uui-size-space-1, 4px); font-weight: 700; }
         small { display: block; color: var(--uui-color-text-alt, #515054); font-weight: 400; }
-        input, select { box-sizing: border-box; width: 100%; min-height: 32px; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); color: var(--uui-color-text, #1b264f); font: inherit; }
-        select[multiple] { min-height: 130px; }
-        button { border: 0; border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px) var(--uui-size-space-3, 12px); background: var(--uui-color-surface-alt, #f3f3f5); color: var(--uui-color-text, #1b264f); border: 1px solid var(--uui-color-border, #d8d7d9); cursor: pointer; font: inherit; font-weight: 600; white-space: nowrap; }
-        button:disabled, input:disabled, select:disabled { cursor: not-allowed; opacity: 0.55; }
+        input { box-sizing: border-box; width: 100%; min-height: 32px; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); color: var(--uui-color-text, #1b264f); font: inherit; }
+        .combobox { position: relative; }
+        .combobox-control { display: flex; align-items: center; gap: var(--uui-size-space-2, 8px); box-sizing: border-box; width: 100%; min-height: 40px; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-1, 4px) var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); color: var(--uui-color-text, #1b264f); cursor: pointer; }
+        .combobox-control:focus { outline: 2px solid var(--uui-color-focus, #3544b1); outline-offset: 1px; }
+        .combobox-control[aria-disabled='true'] { cursor: not-allowed; opacity: 0.55; }
+        .combobox-value { display: flex; flex: 1; flex-wrap: wrap; gap: var(--uui-size-space-1, 4px); min-width: 0; }
+        .placeholder { color: var(--uui-color-text-alt, #515054); }
+        .combobox-arrow { flex: 0 0 auto; }
+        .combobox-dropdown { position: absolute; z-index: 20; top: calc(100% + 4px); left: 0; right: 0; display: grid; gap: var(--uui-size-space-2, 8px); border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-2, 8px); background: var(--uui-color-surface, #fff); box-shadow: 0 4px 12px rgb(0 0 0 / 18%); }
+        .combobox-dropdown[hidden] { display: none; }
+        .chip { display: inline-flex; align-items: center; gap: var(--uui-size-space-1, 4px); border-radius: 999px; padding: 3px 6px 3px 10px; background: var(--uui-color-surface-alt, #f3f3f5); color: var(--uui-color-text, #1b264f); }
+        .chip button { display: grid; place-items: center; width: 20px; height: 20px; border: 0; border-radius: 50%; padding: 0; background: transparent; color: inherit; cursor: pointer; font: inherit; font-size: 18px; line-height: 1; }
+        .chip button:hover { background: var(--uui-color-border, #d8d7d9); }
+        .option-list { display: grid; max-height: 220px; overflow-y: auto; border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); background: var(--uui-color-surface, #fff); }
+        .option { display: flex; align-items: center; gap: var(--uui-size-space-2, 8px); border: 0; padding: var(--uui-size-space-2, 8px); background: transparent; color: inherit; font: inherit; font-weight: 400; text-align: left; cursor: pointer; }
+        .option + .option { border-top: 1px solid var(--uui-color-border, #d8d7d9); }
+        .option:hover, .option:focus { background: var(--uui-color-surface-alt, #f3f3f5); }
+        .option-mark { width: 16px; text-align: center; }
+        .empty-options { padding: var(--uui-size-space-3, 12px); color: var(--uui-color-text-alt, #515054); }
+        .clear-button { border: 1px solid var(--uui-color-border, #d8d7d9); border-radius: var(--uui-border-radius, 3px); padding: var(--uui-size-space-1, 4px) var(--uui-size-space-2, 8px); background: var(--uui-color-surface-alt, #f3f3f5); color: var(--uui-color-text, #1b264f); cursor: pointer; font: inherit; white-space: nowrap; }
+        button:disabled, input:disabled { cursor: not-allowed; opacity: 0.55; }
         p { margin: 0; color: var(--uui-color-text-alt, #515054); }
         p[data-error='true'] { color: var(--uui-color-danger, #d42054); }
       </style>
@@ -139,15 +169,20 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
     const label = document.createElement('label');
     label.htmlFor = `metafield_${index}`;
     label.textContent = field.name ?? field.key ?? '';
+    const descriptionId = `metafield_${index}_description`;
 
     if (!this.isEmpty(field.description)) {
       const description = document.createElement('small');
+      description.id = descriptionId;
       description.textContent = field.description ?? '';
       label.append(description);
     }
 
     const clearButton = document.createElement('button');
     clearButton.type = 'button';
+    clearButton.className = 'clear-button';
+    clearButton.dataset.key = field.key ?? '';
+    clearButton.dataset.action = 'clear';
     clearButton.textContent = 'Clear';
     clearButton.addEventListener('click', event => this.clearField(event, field));
 
@@ -157,76 +192,114 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
     const predefinedValues = field.values ?? [];
 
     if (predefinedValues.length > 0) {
-      wrapper.append(this.createSelect(field, index, predefinedValues));
+      wrapper.append(field.enableMultipleChoice === true
+        ? this.createMultiSelect(field, index, descriptionId)
+        : this.createSelect(field, index, predefinedValues, descriptionId));
     } else {
-      wrapper.append(this.createTextInput(field, index));
+      wrapper.append(this.createTextInput(field, index, descriptionId));
     }
 
     return wrapper;
   }
 
-  private createSelect(field: Metafield, index: number, predefinedValues: Metavalue[]): HTMLSelectElement {
-    const select = document.createElement('select');
-    select.id = `metafield_${index}`;
-    select.dataset.key = field.key ?? '';
-    select.multiple = field.enableMultipleChoice === true;
-
-    if (!select.multiple) {
-      const emptyOption = document.createElement('option');
-      emptyOption.value = '';
-      emptyOption.textContent = 'Select value';
-      select.append(emptyOption);
-    }
-
-    for (const value of predefinedValues) {
-      const option = document.createElement('option');
-      option.value = value.id ?? '';
-      option.textContent = this.getMetavalueLabel(value);
-      select.append(option);
-    }
-
-    this.setSelectValue(select, field);
-    select.addEventListener('change', () => this.setMetafieldSelectValue(field, select));
-
-    return select;
+  private createSelect(field: Metafield, index: number, _predefinedValues: Metavalue[], descriptionId: string): HTMLDivElement {
+    return this.createChoicePicker(field, index, descriptionId, false);
   }
 
-  private createTextInput(field: Metafield, index: number): HTMLInputElement {
+  private createMultiSelect(field: Metafield, index: number, descriptionId: string): HTMLDivElement {
+    return this.createChoicePicker(field, index, descriptionId, true);
+  }
+
+  private createChoicePicker(field: Metafield, index: number, descriptionId: string, multiple: boolean): HTMLDivElement {
+    const picker = document.createElement('div');
+    picker.className = `combobox ${multiple ? 'multi-picker' : 'single-picker'}`;
+    picker.dataset.key = field.key ?? '';
+
+    const control = document.createElement('div');
+    control.id = `metafield_${index}`;
+    control.className = 'combobox-control';
+    control.dataset.key = field.key ?? '';
+    control.dataset.control = 'choice';
+    control.tabIndex = 0;
+    control.setAttribute('role', 'combobox');
+    control.setAttribute('aria-haspopup', 'listbox');
+    control.setAttribute('aria-expanded', 'false');
+    control.setAttribute('aria-label', field.name ?? field.key ?? 'Metafield');
+    this.setDescription(control, field, descriptionId);
+
+    const selectedValues = document.createElement('div');
+    selectedValues.className = 'combobox-value';
+    selectedValues.setAttribute('aria-label', multiple ? 'Selected values' : 'Selected value');
+
+    const arrow = document.createElement('span');
+    arrow.className = 'combobox-arrow';
+    arrow.setAttribute('aria-hidden', 'true');
+    arrow.textContent = '▾';
+    control.append(selectedValues, arrow);
+
+    const dropdown = document.createElement('div');
+    dropdown.className = 'combobox-dropdown';
+    dropdown.hidden = true;
+
+    const search = document.createElement('input');
+    search.type = 'search';
+    search.placeholder = 'Search values';
+    search.dataset.key = field.key ?? '';
+    search.dataset.control = 'search';
+    search.setAttribute('aria-label', `Search ${field.name ?? field.key ?? 'metafield'} values`);
+    search.addEventListener('input', () => this.renderChoiceOptions(field, picker, search.value, multiple));
+    search.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        this.closeDropdown(picker, true);
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        picker.querySelector<HTMLButtonElement>('.option')?.focus();
+      }
+    });
+
+    const optionList = document.createElement('div');
+    optionList.className = 'option-list';
+    optionList.setAttribute('role', 'listbox');
+    optionList.setAttribute('aria-label', 'Available values');
+    optionList.setAttribute('aria-multiselectable', String(multiple));
+
+    control.addEventListener('click', () => this.toggleDropdown(field, picker, multiple));
+    control.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        this.openDropdown(field, picker, multiple);
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        this.closeDropdown(picker);
+      }
+    });
+
+    dropdown.append(search, optionList);
+    picker.append(control, dropdown);
+    this.syncChoicePicker(field, picker, multiple);
+
+    return picker;
+  }
+
+  private createTextInput(field: Metafield, index: number, descriptionId: string): HTMLInputElement {
     const input = document.createElement('input');
     input.id = `metafield_${index}`;
     input.type = 'text';
     input.dataset.key = field.key ?? '';
+    input.dataset.control = 'text';
     input.value = String(this.getFieldValue(field) ?? '');
     input.readOnly = field.readOnly === true;
+    this.setDescription(input, field, descriptionId);
     input.addEventListener('input', () => this.setMetafieldValue(field, input.value));
 
     return input;
   }
 
-  private setSelectValue(select: HTMLSelectElement, field: Metafield): void {
-    const selectedIds = new Set(this.getSelectedIds(field));
-
-    for (const option of select.options) {
-      option.selected = selectedIds.has(option.value);
-    }
-  }
-
-  private setMetafieldSelectValue(field: Metafield, select: HTMLSelectElement): void {
-    if (this.readonly) {
-      return;
-    }
-
-    const selectedValues = Array.from(select.selectedOptions)
-      .map(option => (field.values ?? []).find(value => value.id === option.value))
-      .filter(value => value != null);
-
-    this.setMetafieldValue(field, select.multiple ? selectedValues : selectedValues[0] ?? '');
-  }
-
   private clearField(event: Event, field: Metafield): void {
     event.preventDefault();
 
-    if (this.readonly) {
+    if (this.isFieldReadonly(field)) {
       return;
     }
 
@@ -259,6 +332,7 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
       ];
     }
 
+    this.syncDisabledState();
     this.emitChange();
   }
 
@@ -293,17 +367,24 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
         continue;
       }
 
-      const input = this.editor.querySelector<HTMLInputElement>(`input[data-key="${CSS.escape(key)}"]`);
-      const select = this.editor.querySelector<HTMLSelectElement>(`select[data-key="${CSS.escape(key)}"]`);
+      const input = this.editor.querySelector<HTMLInputElement>(`input[data-control="text"][data-key="${CSS.escape(key)}"]`);
+      const multiPicker = this.editor.querySelector<HTMLDivElement>(`.multi-picker[data-key="${CSS.escape(key)}"]`);
+      const singlePicker = this.editor.querySelector<HTMLDivElement>(`.single-picker[data-key="${CSS.escape(key)}"]`);
 
       if (input != null) {
         input.value = String(this.getFieldValue(field) ?? '');
       }
 
-      if (select != null) {
-        this.setSelectValue(select, field);
+      if (multiPicker != null) {
+        this.syncChoicePicker(field, multiPicker, true);
+      }
+
+      if (singlePicker != null) {
+        this.syncChoicePicker(field, singlePicker, false);
       }
     }
+
+    this.syncDisabledState();
   }
 
   private getFieldValue(field: Metafield): unknown {
@@ -322,6 +403,238 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
     }
 
     return value == null || value === '' ? [] : [String(value)];
+  }
+
+  private syncChoicePicker(field: Metafield, picker: HTMLDivElement, multiple: boolean): void {
+    const selectedIds = new Set(this.getSelectedIds(field));
+    const selectedValues = (field.values ?? [])
+      .filter(value => selectedIds.has(value.id ?? ''));
+    const selectedContainer = picker.querySelector<HTMLDivElement>('.combobox-value');
+    const search = picker.querySelector<HTMLInputElement>('input[type="search"]');
+
+    if (selectedContainer != null) {
+      if (multiple) {
+        const chips = selectedValues.map(value => {
+          const label = this.getMetavalueLabel(value);
+          const chip = document.createElement('span');
+          chip.className = 'chip';
+          chip.append(document.createTextNode(label));
+
+          const removeButton = document.createElement('button');
+          removeButton.type = 'button';
+          removeButton.dataset.key = field.key ?? '';
+          removeButton.setAttribute('aria-label', `Remove ${label}`);
+          removeButton.textContent = '×';
+          removeButton.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            this.toggleMetavalue(field, value, false, picker);
+          });
+          chip.append(removeButton);
+
+          return chip;
+        });
+
+        if (chips.length === 0) {
+          selectedContainer.replaceChildren(this.createPlaceholder('Select values'));
+        } else {
+          selectedContainer.replaceChildren(...chips);
+        }
+      } else {
+        const selectedValue = selectedValues[0];
+        selectedContainer.replaceChildren(selectedValue == null
+          ? this.createPlaceholder('Select value')
+          : document.createTextNode(this.getMetavalueLabel(selectedValue)));
+      }
+    }
+
+    if (!this.isDropdownClosed(picker)) {
+      this.renderChoiceOptions(field, picker, search?.value ?? '', multiple);
+    }
+
+    this.syncDisabledState();
+  }
+
+  private createPlaceholder(text: string): HTMLSpanElement {
+    const placeholder = document.createElement('span');
+    placeholder.className = 'placeholder';
+    placeholder.textContent = text;
+    return placeholder;
+  }
+
+  private toggleDropdown(field: Metafield, picker: HTMLDivElement, multiple: boolean): void {
+    if (this.isDropdownClosed(picker)) {
+      this.openDropdown(field, picker, multiple);
+    } else {
+      this.closeDropdown(picker);
+    }
+  }
+
+  private openDropdown(field: Metafield, picker: HTMLDivElement, multiple: boolean): void {
+    if (this.isFieldReadonly(field)) {
+      return;
+    }
+
+    this.closeDropdowns(picker);
+    const control = picker.querySelector<HTMLDivElement>('.combobox-control');
+    const dropdown = picker.querySelector<HTMLDivElement>('.combobox-dropdown');
+    const search = picker.querySelector<HTMLInputElement>('input[type="search"]');
+
+    if (control == null || dropdown == null || search == null) {
+      return;
+    }
+
+    dropdown.hidden = false;
+    control.setAttribute('aria-expanded', 'true');
+    this.renderChoiceOptions(field, picker, search.value, multiple);
+    search.focus();
+  }
+
+  private closeDropdown(picker: HTMLDivElement, restoreFocus = false): void {
+    const control = picker.querySelector<HTMLDivElement>('.combobox-control');
+    const dropdown = picker.querySelector<HTMLDivElement>('.combobox-dropdown');
+    const search = picker.querySelector<HTMLInputElement>('input[type="search"]');
+    const optionList = picker.querySelector<HTMLDivElement>('.option-list');
+
+    if (dropdown == null) {
+      return;
+    }
+
+    dropdown.hidden = true;
+    control?.setAttribute('aria-expanded', 'false');
+    optionList?.replaceChildren();
+
+    if (search != null) {
+      search.value = '';
+    }
+
+    if (restoreFocus) {
+      control?.focus();
+    }
+  }
+
+  private closeDropdowns(except?: HTMLDivElement): void {
+    for (const picker of this.querySelectorAll<HTMLDivElement>('.combobox')) {
+      if (picker !== except) {
+        this.closeDropdown(picker);
+      }
+    }
+  }
+
+  private isDropdownClosed(picker: HTMLDivElement): boolean {
+    return picker.querySelector<HTMLDivElement>('.combobox-dropdown')?.hidden !== false;
+  }
+
+  private renderChoiceOptions(field: Metafield, picker: HTMLDivElement, query: string, multiple: boolean): void {
+    const optionList = picker.querySelector<HTMLDivElement>('.option-list');
+
+    if (optionList == null || this.isDropdownClosed(picker)) {
+      return;
+    }
+
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    const selectedIds = new Set(this.getSelectedIds(field));
+    const values = (field.values ?? [])
+      .filter(value => this.getMetavalueLabel(value).toLocaleLowerCase().includes(normalizedQuery));
+
+    if (values.length === 0) {
+      const emptyMessage = document.createElement('span');
+      emptyMessage.className = 'empty-options';
+      emptyMessage.textContent = 'No matching values';
+      optionList.replaceChildren(emptyMessage);
+      return;
+    }
+
+    const options = values.map(value => {
+      const valueId = value.id ?? '';
+      const option = document.createElement('button');
+      const selected = selectedIds.has(valueId);
+      option.type = 'button';
+      option.className = 'option';
+      option.dataset.key = field.key ?? '';
+      option.dataset.valueId = valueId;
+      option.setAttribute('role', 'option');
+      option.setAttribute('aria-selected', String(selected));
+
+      const mark = document.createElement('span');
+      mark.className = 'option-mark';
+      mark.setAttribute('aria-hidden', 'true');
+      mark.textContent = selected ? '✓' : '';
+
+      const text = document.createElement('span');
+      text.textContent = this.getMetavalueLabel(value);
+      option.append(mark, text);
+      option.addEventListener('click', event => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (multiple) {
+          this.toggleMetavalue(field, value, !selected, picker);
+          picker.querySelector<HTMLButtonElement>(`button[data-value-id="${CSS.escape(valueId)}"]`)?.focus();
+        } else {
+          this.selectMetavalue(field, value, picker);
+        }
+      });
+      option.addEventListener('keydown', event => this.handleOptionKeydown(event, picker));
+
+      return option;
+    });
+    optionList.replaceChildren(...options);
+  }
+
+  private toggleMetavalue(field: Metafield, value: Metavalue, selected: boolean, picker: HTMLDivElement): void {
+    if (this.isFieldReadonly(field)) {
+      return;
+    }
+
+    const valueId = value.id ?? '';
+    const selectedIds = new Set(this.getSelectedIds(field));
+
+    if (selected) {
+      selectedIds.add(valueId);
+    } else {
+      selectedIds.delete(valueId);
+    }
+
+    const selectedValues = (field.values ?? []).filter(item => selectedIds.has(item.id ?? ''));
+    this.setMetafieldValue(field, selectedValues);
+    this.syncChoicePicker(field, picker, true);
+  }
+
+  private selectMetavalue(field: Metafield, value: Metavalue, picker: HTMLDivElement): void {
+    if (this.isFieldReadonly(field)) {
+      return;
+    }
+
+    this.setMetafieldValue(field, value);
+    this.syncChoicePicker(field, picker, false);
+    this.closeDropdown(picker, true);
+  }
+
+  private handleOptionKeydown(event: KeyboardEvent, picker: HTMLDivElement): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.closeDropdown(picker, true);
+      return;
+    }
+
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return;
+    }
+
+    event.preventDefault();
+    const options = Array.from(picker.querySelectorAll<HTMLButtonElement>('.option'));
+    const currentIndex = options.indexOf(event.currentTarget as HTMLButtonElement);
+    const nextIndex = event.key === 'ArrowDown'
+      ? Math.min(currentIndex + 1, options.length - 1)
+      : Math.max(currentIndex - 1, 0);
+    options[nextIndex]?.focus();
+  }
+
+  private setDescription(element: HTMLElement, field: Metafield, descriptionId: string): void {
+    if (!this.isEmpty(field.description)) {
+      element.setAttribute('aria-describedby', descriptionId);
+    }
   }
 
   private getMetavalueLabel(value: Metavalue): string {
@@ -352,15 +665,44 @@ export class EkomMetafieldPickerElement extends HTMLElement implements UmbProper
   }
 
   private syncDisabledState(): void {
-    for (const element of this.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLButtonElement>('input, select, button')) {
-      element.disabled = this.readonly;
+    for (const element of this.querySelectorAll<HTMLElement>('input, button')) {
+      const key = element.dataset.key;
+      const field = this.fields.find(item => item.key === key);
+      const isTextInput = element instanceof HTMLInputElement && element.dataset.control === 'text';
+      const isEmptyClearButton = element.dataset.action === 'clear' && (field == null || this.isFieldValueEmpty(field));
+      const disabled = this.readonly || (!isTextInput && field?.readOnly === true) || isEmptyClearButton;
+      element.toggleAttribute('disabled', disabled);
     }
 
-    for (const input of this.querySelectorAll<HTMLInputElement>('input')) {
+    for (const input of this.querySelectorAll<HTMLInputElement>('input[data-control="text"]')) {
       const key = input.dataset.key;
       const field = this.fields.find(item => item.key === key);
       input.readOnly = field?.readOnly === true;
     }
+
+    for (const control of this.querySelectorAll<HTMLDivElement>('.combobox-control')) {
+      const field = this.fields.find(item => item.key === control.dataset.key);
+      const disabled = field == null || this.isFieldReadonly(field);
+      control.setAttribute('aria-disabled', String(disabled));
+      control.tabIndex = disabled ? -1 : 0;
+
+      if (disabled) {
+        const picker = control.closest<HTMLDivElement>('.combobox');
+
+        if (picker != null) {
+          this.closeDropdown(picker);
+        }
+      }
+    }
+  }
+
+  private isFieldReadonly(field: Metafield): boolean {
+    return this.readonly || field.readOnly === true;
+  }
+
+  private isFieldValueEmpty(field: Metafield): boolean {
+    const value = this.getFieldValue(field);
+    return Array.isArray(value) ? value.length === 0 : value == null || value === '';
   }
 
   private setStatus(message: string, isError = false): void {

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/metavalue-editor.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/metavalue-editor.element.ts
@@ -33,8 +33,15 @@ export class EkomMetavalueEditorElement extends HTMLElement implements UmbProper
   }
 
   set value(value: unknown) {
-    this.items = this.normalizeValue(value);
-    this.renderRows();
+    const items = this.normalizeValue(value);
+    const canSyncInputs = this.hasMatchingRows(items);
+    this.items = items;
+
+    if (canSyncInputs) {
+      this.syncInputs();
+    } else {
+      this.renderRows();
+    }
   }
 
   get readonly(): boolean {
@@ -125,11 +132,13 @@ export class EkomMetavalueEditorElement extends HTMLElement implements UmbProper
   private createRow(item: MetavalueItem, index: number): HTMLDivElement {
     const row = document.createElement('div');
     row.className = 'row';
+    row.dataset.itemId = item.id;
 
     for (const language of this.languages) {
       const isoCode = language.isoCode ?? '';
       const input = document.createElement('input');
       input.type = 'text';
+      input.dataset.language = isoCode;
       input.value = item.values[isoCode] ?? '';
       input.addEventListener('input', () => this.setLanguageValue(index, isoCode, input.value));
       row.append(input);
@@ -236,6 +245,40 @@ export class EkomMetavalueEditorElement extends HTMLElement implements UmbProper
       : currentItem);
 
     this.emitChange();
+  }
+
+  private hasMatchingRows(items: MetavalueItem[]): boolean {
+    if (this.editor == null || this.editor.childElementCount === 0) {
+      return false;
+    }
+
+    const rows = this.editor.querySelectorAll<HTMLDivElement>('.row');
+    return rows.length === items.length
+      && items.every((item, index) => rows[index]?.dataset.itemId === item.id);
+  }
+
+  private syncInputs(): void {
+    if (this.editor == null) {
+      return;
+    }
+
+    const rows = this.editor.querySelectorAll<HTMLDivElement>('.row');
+
+    rows.forEach((row, index) => {
+      const item = this.items[index];
+
+      if (item == null) {
+        return;
+      }
+
+      for (const input of row.querySelectorAll<HTMLInputElement>('input[data-language]')) {
+        const value = item.values[input.dataset.language ?? ''] ?? '';
+
+        if (input.value !== value) {
+          input.value = value;
+        }
+      }
+    });
   }
 
   private normalizeValue(value: unknown): MetavalueItem[] {


### PR DESCRIPTION
## Summary
- replace the U17 metafield picker with collapsed searchable single- and multi-select comboboxes
- display multi-select choices as removable pills and preserve keyboard, read-only, and clear behavior
- keep MetaValue inputs focused by synchronizing existing controls instead of rerendering each keystroke
- correct metafield property aliases for new U10 and U17 installations
- refresh cached metafield definitions after publishing so renamed fields appear in the picker
- include generated U17 backoffice bundles and simplify import result counts

## Test Plan
- create single-select and multi-select metafields with many values
- verify both pickers open, search, select, clear, and close correctly
- verify multi-select pills can be removed and selected values persist after saving
- type continuously in the MetaValue editor and confirm focus remains in the input
- rename and publish a metafield, then reopen the picker and confirm the new node name appears
- run `npm run typecheck` and `npm run build` in the U17 client
- run `dotnet build Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj`
- run `dotnet build Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj`
