### PR TITLE
fix(discounts): compare actual discount values

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Models/Discounts/DiscountValueCalculator.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Discounts/DiscountValueCalculator.cs
@@ -1,0 +1,50 @@
+namespace Ekom.Models;
+
+internal static class DiscountValueCalculator
+{
+    internal static decimal CalculateDiscountAmount(decimal price, IDiscount discount)
+    {
+        ArgumentNullException.ThrowIfNull(discount);
+
+        return discount.Type switch
+        {
+            DiscountType.Fixed => discount.Amount,
+            DiscountType.Percentage => price * discount.Amount,
+            _ => 0,
+        };
+    }
+
+    internal static bool IsBetterDiscount(decimal price, IDiscount candidate, IDiscount? current)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        return current == null
+            || CalculateDiscountAmount(price, candidate) > CalculateDiscountAmount(price, current);
+    }
+
+    internal static bool IsBetterLineDiscount(
+        IPrice price,
+        IDiscount candidate,
+        IDiscount current,
+        decimal vat,
+        bool vatIncludedInPrice,
+        decimal quantity)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(current);
+
+        decimal candidateTotal = CreatePrice(candidate).Value;
+        decimal currentTotal = CreatePrice(current).Value;
+        return candidateTotal < currentTotal;
+
+        Price CreatePrice(IDiscount discount)
+            => new(
+                discount.Stackable ? price.Value : price.OriginalValue,
+                price.Currency,
+                vat,
+                vatIncludedInPrice,
+                discount as OrderedDiscount ?? new OrderedDiscount(discount),
+                quantity);
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Models/Discounts/ProductDiscount.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Discounts/ProductDiscount.cs
@@ -22,40 +22,16 @@ public class ProductDiscount : Discount, IProductDiscount
 
     public override decimal Amount
     {
-
         get
         {
-            if (!Discounts.Any())
+            if (Discounts.Count == 0)
             {
                 return 0;
             }
 
-            CurrencyValue? discount = Discounts.FirstOrDefault();
-
-            CurrencyModel? currency = CookieHelper.GetCurrencyCookieValue(Store.Currencies, Store.Alias);
-
-            if (Discounts.Any(x => x.Currency == currency.CurrencyValue))
-            {
-                discount = Discounts.FirstOrDefault(x => x.Currency == currency.CurrencyValue);
-            }
-
-            if (discount.Value <= 0)
-            {
-                return 0;
-            }
-            else
-            {
-                decimal value = discount.Value;
-                value = value * 0.01M;
-                if (value > 1)
-                {
-                    return value * 0.01M;
-                }
-                return value;
-            }
-
+            decimal amount = base.Amount;
+            return amount > 0 ? amount : 0;
         }
-
     }
 
     /// <summary>

--- a/Ekom/Ekom.Core/Ekom/Models/OrderLine.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderLine.cs
@@ -69,18 +69,12 @@ public class OrderLine : IOrderLine
         if (OrderInfo?.Discount != null &&
             DiscountApplicability.MatchesLineTargets(this, OrderInfo.Discount))
         {
-            if (Product.Price.HasDiscount && OrderInfo.Discount.Stackable)
-            {
-                discount = OrderInfo.Discount;
-            }
-            else if (!Product.Price.HasDiscount && OrderInfo.Discount != null)
-            {
-                discount = OrderInfo.Discount;
-            }
-            else if ((Product.Price.Discount?.Amount ?? 0) < OrderInfo.Discount?.Amount)
-            {
-                discount = OrderInfo.Discount;
-            }
+            discount = SelectDiscount(
+                orderlinePrice,
+                OrderInfo.Discount,
+                Vat,
+                OrderInfo.StoreInfo.VatIncludedInPrice,
+                Quantity);
         }
 
         Discount = discount;
@@ -105,7 +99,29 @@ public class OrderLine : IOrderLine
             OrderInfo.StoreInfo.VatIncludedInPrice,
             discount,
             Quantity);
-        
+    }
+
+    internal static OrderedDiscount? SelectDiscount(
+        IPrice orderlinePrice,
+        OrderedDiscount orderDiscount,
+        decimal vat,
+        bool vatIncludedInPrice,
+        decimal quantity)
+    {
+        if (orderDiscount.Stackable || !orderlinePrice.HasDiscount)
+        {
+            return orderDiscount;
+        }
+
+        return DiscountValueCalculator.IsBetterLineDiscount(
+            orderlinePrice,
+            orderDiscount,
+            orderlinePrice.Discount,
+            vat,
+            vatIncludedInPrice,
+            quantity)
+                ? orderDiscount
+                : orderlinePrice.Discount;
     }
 
     public decimal Vat

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.Discounts.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.Discounts.cs
@@ -649,21 +649,14 @@ partial class OrderService
             return false;
         }
 
-        if (orderLine.Discount.Type == discount.Type)
-        {
-            return discount.CompareTo(orderLine.Discount) > 0;
-        }
-
-        OrderedDiscount oldDiscount = orderLine.Discount;
-        IPrice oldTotal = orderLine.Amount;
-
-        orderLine.Discount = new OrderedDiscount(discount);
-
-        bool result = orderLine.Amount.Value < oldTotal.Value;
-
-        orderLine.Discount = oldDiscount;
-
-        return result;
+        var orderlinePrice = orderLine.Variant?.Price ?? orderLine.Product.Price;
+        return DiscountValueCalculator.IsBetterLineDiscount(
+            orderlinePrice,
+            discount,
+            orderLine.Discount,
+            orderLine.Vat,
+            orderLine.OrderInfo.StoreInfo.VatIncludedInPrice,
+            orderLine.Quantity);
     }
 
     /// <summary>

--- a/Ekom/Ekom.Core/Ekom/Services/ProductDiscountService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/ProductDiscountService.cs
@@ -143,12 +143,17 @@ class ProductDiscountService
         if (applicableArgs.ApplicableDiscounts.Count == 0)
             return null;
 
-        Guid bestFixedKey = Guid.Empty;
-        Guid bestPercentageKey = Guid.Empty;
-        decimal bestPercentageValue = 0;
-        decimal bestFixedValue = 0;
+        return SelectBestDiscount(applicableArgs.ApplicableDiscounts, price);
+    }
 
-        foreach (var usableDiscount in applicableArgs.ApplicableDiscounts)
+    internal static IProductDiscount? SelectBestDiscount(
+        IReadOnlyCollection<IProductDiscount> applicableDiscounts,
+        decimal price)
+    {
+        IProductDiscount? bestFixed = null;
+        IProductDiscount? bestPercentage = null;
+
+        foreach (var usableDiscount in applicableDiscounts)
         {
             bool inRange =
                 usableDiscount.StartOfRange <= price &&
@@ -157,38 +162,31 @@ class ProductDiscountService
             if (!inRange)
                 continue;
 
+            if (DiscountValueCalculator.CalculateDiscountAmount(price, usableDiscount) <= 0)
+                continue;
+
             if (usableDiscount.Type == DiscountType.Fixed)
             {
-                if (usableDiscount.Amount > bestFixedValue)
+                if (bestFixed == null || usableDiscount.Amount > bestFixed.Amount)
                 {
-                    bestFixedValue = usableDiscount.Amount;
-                    bestFixedKey = usableDiscount.Key;
+                    bestFixed = usableDiscount;
                 }
             }
             else if (usableDiscount.Type == DiscountType.Percentage)
             {
-                if (usableDiscount.Amount > bestPercentageValue)
+                if (bestPercentage == null || usableDiscount.Amount > bestPercentage.Amount)
                 {
-                    bestPercentageValue = usableDiscount.Amount;
-                    bestPercentageKey = usableDiscount.Key;
+                    bestPercentage = usableDiscount;
                 }
             }
         }
 
-        if (bestFixedKey == Guid.Empty && bestPercentageKey == Guid.Empty)
-            return null;
+        if (bestFixed == null)
+            return bestPercentage;
 
-        if (bestFixedKey == Guid.Empty)
-            return applicableArgs.ApplicableDiscounts.SingleOrDefault(x => x.Key == bestPercentageKey);
-
-        if (bestPercentageKey == Guid.Empty)
-            return applicableArgs.ApplicableDiscounts.SingleOrDefault(x => x.Key == bestFixedKey);
-
-        var fixedAsPercent = Math.Abs(bestFixedValue / price * 100m);
-
-        return fixedAsPercent > bestPercentageValue
-            ? applicableArgs.ApplicableDiscounts.SingleOrDefault(x => x.Key == bestFixedKey)
-            : applicableArgs.ApplicableDiscounts.SingleOrDefault(x => x.Key == bestPercentageKey);
+        return bestPercentage == null || DiscountValueCalculator.IsBetterDiscount(price, bestFixed, bestPercentage)
+            ? bestFixed
+            : bestPercentage;
     }
 
 }

--- a/Ekom/Tests/Ekom.Tests/Tests/DiscountCalculationTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/DiscountCalculationTests.cs
@@ -1,0 +1,166 @@
+using Ekom.Models;
+using Ekom.Services;
+using Ekom.Tests.Objects;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class DiscountCalculationTests
+{
+    [Theory]
+    [InlineData(DiscountType.Fixed, 2000, 2000)]
+    [InlineData(DiscountType.Percentage, 20, 0.2)]
+    [InlineData(DiscountType.Fixed, 0, 0)]
+    [InlineData(DiscountType.Percentage, -20, 0)]
+    public void ProductDiscount_UsesTypeSpecificAmountNormalization(
+        DiscountType type,
+        decimal configuredAmount,
+        decimal expectedAmount)
+    {
+        using var configurationScope = new ConfigurationScope();
+        var discount = new TestProductDiscount(Stores.Store_US_0Vat_VatIncluded, type, configuredAmount);
+
+        Assert.Equal(expectedAmount, discount.Amount);
+    }
+
+    [Fact]
+    public void SelectBestDiscount_ChoosesPercentageWhenItSavesMoreThanFixed()
+    {
+        var fixedDiscount = CreateProductDiscount(DiscountType.Fixed, 10m);
+        var percentageDiscount = CreateProductDiscount(DiscountType.Percentage, 0.2m);
+
+        var result = ProductDiscountService.SelectBestDiscount(
+            [fixedDiscount.Object, percentageDiscount.Object],
+            100m);
+
+        Assert.Same(percentageDiscount.Object, result);
+    }
+
+    [Fact]
+    public void SelectBestDiscount_ChoosesFixedWhenItSavesMoreThanPercentage()
+    {
+        var fixedDiscount = CreateProductDiscount(DiscountType.Fixed, 30m);
+        var percentageDiscount = CreateProductDiscount(DiscountType.Percentage, 0.2m);
+
+        var result = ProductDiscountService.SelectBestDiscount(
+            [fixedDiscount.Object, percentageDiscount.Object],
+            100m);
+
+        Assert.Same(fixedDiscount.Object, result);
+    }
+
+    [Fact]
+    public void SelectBestDiscount_IgnoresNonPositiveDiscounts()
+    {
+        var zeroDiscount = CreateProductDiscount(DiscountType.Fixed, 0m);
+        var negativeDiscount = CreateProductDiscount(DiscountType.Percentage, -0.2m);
+
+        var result = ProductDiscountService.SelectBestDiscount(
+            [zeroDiscount.Object, negativeDiscount.Object],
+            100m);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SelectDiscount_UsesMonetaryValueForMixedDiscountTypes()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var currency = new CurrencyModel
+        {
+            CurrencyValue = "en-US",
+            CurrencyFormat = "C",
+        };
+        var productDiscount = CreateOrderedDiscount(DiscountType.Fixed, 10m);
+        var orderDiscount = CreateOrderedDiscount(DiscountType.Percentage, 0.2m);
+        var variantPrice = new Price(100m, currency, 0m, true, productDiscount);
+
+        var result = OrderLine.SelectDiscount(variantPrice, orderDiscount, 0m, true, 1m);
+
+        Assert.Same(orderDiscount, result);
+    }
+
+    [Fact]
+    public void SelectDiscount_RetainsProductDiscountWhenItSavesMore()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var currency = new CurrencyModel
+        {
+            CurrencyValue = "en-US",
+            CurrencyFormat = "C",
+        };
+        var productDiscount = CreateOrderedDiscount(DiscountType.Percentage, 0.2m);
+        var orderDiscount = CreateOrderedDiscount(DiscountType.Fixed, 10m);
+        var variantPrice = new Price(100m, currency, 0m, true, productDiscount);
+
+        var result = OrderLine.SelectDiscount(variantPrice, orderDiscount, 0m, true, 1m);
+
+        Assert.Same(productDiscount, result);
+    }
+
+    [Fact]
+    public void IsBetterLineDiscount_AppliesStackableDiscountToDiscountedPrice()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var currency = new CurrencyModel
+        {
+            CurrencyValue = "en-US",
+            CurrencyFormat = "C",
+        };
+        var productDiscount = CreateOrderedDiscount(DiscountType.Fixed, 20m);
+        var stackableDiscount = CreateOrderedDiscount(DiscountType.Fixed, 5m, true);
+        var price = new Price(100m, currency, 0m, true, productDiscount);
+
+        bool result = DiscountValueCalculator.IsBetterLineDiscount(
+            price,
+            stackableDiscount,
+            productDiscount,
+            0m,
+            true,
+            1m);
+
+        Assert.True(result);
+    }
+
+    private static Mock<IProductDiscount> CreateProductDiscount(DiscountType type, decimal amount)
+    {
+        var discount = new Mock<IProductDiscount>();
+        discount.SetupGet(item => item.Type).Returns(type);
+        discount.SetupGet(item => item.Amount).Returns(amount);
+        discount.SetupGet(item => item.StartOfRange).Returns(0m);
+        discount.SetupGet(item => item.EndOfRange).Returns(0m);
+        return discount;
+    }
+
+    private static OrderedDiscount CreateOrderedDiscount(DiscountType type, decimal amount, bool stackable = false)
+        => new(
+            Guid.NewGuid(),
+            "Test discount",
+            stackable,
+            amount,
+            type,
+            [],
+            [],
+            null!,
+            false,
+            false);
+
+    private sealed class TestProductDiscount : ProductDiscount
+    {
+        private readonly DiscountType _type;
+
+        internal TestProductDiscount(IStore store, DiscountType type, decimal configuredAmount)
+            : base(store)
+        {
+            _type = type;
+            _properties["discount"] = JsonConvert.SerializeObject(new[]
+            {
+                new CurrencyValue(configuredAmount, store.Currencies[0].CurrencyValue),
+            });
+        }
+
+        public override DiscountType Type => _type;
+    }
+}


### PR DESCRIPTION
## Summary
- normalize fixed product discounts as currency amounts and percentage discounts as fractional rates
- compare mixed discount types by their monetary effect instead of their raw configured values
- compare order-line candidates using final charged totals with VAT, quantity, rounding, variants, and stacking
- ignore zero and negative product discounts so they cannot increase prices
- centralize discount comparison logic and add focused regression coverage

## Test Plan
- verify a 20% discount beats a fixed 10 discount on a 100-priced item
- verify a fixed 30 discount beats a 20% discount on a 100-priced item
- verify fixed product discount values are not divided by 100
- verify percentage product discounts are normalized to fractional rates
- verify zero and negative discounts are ignored
- verify variant prices and stackable discounts use the correct calculation base
- run `dotnet test Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj --filter "FullyQualifiedName~DiscountCalculationTests"`
- run `dotnet build Ekom/Ekom.Core/Ekom/Ekom.csproj --no-restore`
