### PR TITLE
feat(algolia): add category page identifiers

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -13,12 +13,15 @@ public class AlgoliaProductIndexMapperTests
     [Fact]
     public void Maps_Category_Levels_For_Hierarchical_Menu()
     {
+        var candyKey = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var chocolateKey = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var organicKey = Guid.Parse("33333333-3333-3333-3333-333333333333");
         var mapper = CreateMapper();
         var product = CreateProduct(
             categories:
             [
-                CreateCategory("Chocolate", ancestors: [CreateCategory("Candy")]),
-                CreateCategory("Organic")
+                CreateCategory("Chocolate", ancestors: [CreateCategory("Candy", key: candyKey)], key: chocolateKey),
+                CreateCategory("Organic", key: organicKey)
             ]);
 
         var record = mapper.Map(product.Object, CreateStore(), "products");
@@ -29,6 +32,36 @@ public class AlgoliaProductIndexMapperTests
         Assert.Equal(
             ["Candy", "Candy > Chocolate", "Organic"],
             Assert.IsAssignableFrom<IReadOnlyList<string>>(record.Data["category_paths"]));
+        Assert.Equal(
+            [candyKey.ToString("D"), chocolateKey.ToString("D"), organicKey.ToString("D")],
+            record.CategoryPageId);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(record));
+        Assert.True(json.RootElement.TryGetProperty("categoryPageId", out _));
+        Assert.False(json.RootElement.TryGetProperty("CategoryPageId", out _));
+    }
+
+    [Fact]
+    public void Deduplicates_Category_Page_Ids_While_Preserving_Order()
+    {
+        var rootKey = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var firstKey = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var secondKey = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var root = CreateCategory("Root", key: rootKey);
+        var mapper = CreateMapper();
+        var product = CreateProduct(
+            categories:
+            [
+                CreateCategory("First", ancestors: [root], key: firstKey),
+                CreateCategory("Second", ancestors: [root], key: secondKey)
+            ]);
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        Assert.Equal(
+            [rootKey.ToString("D"), firstKey.ToString("D"), secondKey.ToString("D")],
+            record!.CategoryPageId);
     }
 
     [Fact]
@@ -247,6 +280,7 @@ public class AlgoliaProductIndexMapperTests
         Assert.Null(record.Url);
         Assert.Null(record.ImageUrl);
         Assert.Null(record.ImageUrls);
+        Assert.Null(record.CategoryPageId);
         Assert.DoesNotContain("emptyProp", record.Data.Keys);
         Assert.DoesNotContain("blankProp", record.Data.Keys);
         Assert.False(Assert.IsType<bool>(record.Data["featured"]));
@@ -257,6 +291,7 @@ public class AlgoliaProductIndexMapperTests
         Assert.DoesNotContain("Description", json, StringComparison.Ordinal);
         Assert.DoesNotContain("image_url", json, StringComparison.Ordinal);
         Assert.DoesNotContain("ImageUrls", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("categoryPageId", json, StringComparison.Ordinal);
         Assert.DoesNotContain("emptyProp", json, StringComparison.Ordinal);
         Assert.DoesNotContain("blankProp", json, StringComparison.Ordinal);
         Assert.Contains("\"featured\":false", json, StringComparison.Ordinal);
@@ -280,7 +315,11 @@ public class AlgoliaProductIndexMapperTests
     {
         var mapper = CreateMapper(indexVariants: true);
         var variant = CreateVariant(sku: "variant-sku", title: "Variant title");
-        var product = CreateProduct(sku: "placeholder", variants: [variant.Object]);
+        var categoryKey = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var product = CreateProduct(
+            categories: [CreateCategory("Category", key: categoryKey)],
+            sku: "placeholder",
+            variants: [variant.Object]);
 
         var records = mapper.MapRecords(product.Object, CreateStore(), "products");
 
@@ -292,6 +331,7 @@ public class AlgoliaProductIndexMapperTests
         Assert.Equal(variant.Object.Key.ToString(), variantRecord.VariantId);
         Assert.Equal("variant-sku", variantRecord.Sku);
         Assert.Equal("placeholder", variantRecord.ParentSku);
+        Assert.Equal([categoryKey.ToString("D")], variantRecord.CategoryPageId);
         Assert.Equal("variant-sku", Assert.IsType<string>(variantRecord.Data["variantSku"]));
         Assert.Equal("Variant title", Assert.IsType<string>(variantRecord.Data["variantTitle"]));
     }
@@ -533,9 +573,11 @@ public class AlgoliaProductIndexMapperTests
     private static Mock<Ekom.Models.ICategory> CreateCategory(
         string title,
         IReadOnlyList<Mock<Ekom.Models.ICategory>>? ancestors = null,
-        string? algoliaRank = null)
+        string? algoliaRank = null,
+        Guid? key = null)
     {
         var category = new Mock<Ekom.Models.ICategory>();
+        category.SetupGet(x => x.Key).Returns(key ?? Guid.Empty);
         category.SetupGet(x => x.Title).Returns(title);
         category.SetupGet(x => x.Ancestors).Returns((ancestors ?? []).Select(x => x.Object));
         category.Setup(x => x.GetValue("title", It.IsAny<string?>(), true)).Returns(string.Empty);

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
@@ -345,7 +345,9 @@ internal sealed class AlgoliaProductIndexExecutor
             {
                 Replicas = replicas.Select(x => x.Name).ToList(),
                 AttributeForDistinct = _options.Indexing.Variants ? "ProductId" : null,
-                AttributesForFaceting = _options.Indexing.Variants ? ["filterOnly(ProductId)"] : null
+                AttributesForFaceting = _options.Indexing.Variants
+                    ? ["filterOnly(ProductId)", "filterOnly(categoryPageId)"]
+                    : null
             },
             forwardToReplicas: false,
             options: null,

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -105,6 +105,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             Available = product.Available ? 1 : 0,
             ProductRanking = ResolveRank(product, store.Alias),
             CategoryRanking = ResolveCategoryRank(product, store.Alias),
+            CategoryPageId = BuildCategoryPageIds(product),
             Stock = store.IncludeStock ? product.Stock : null,
             StoreAlias = NullIfWhiteSpace(store.Alias),
             Locale = NullIfWhiteSpace(store.Locale),
@@ -238,6 +239,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             Available = variant.Available ? 1 : 0,
             ProductRanking = productRecord.ProductRanking,
             CategoryRanking = productRecord.CategoryRanking,
+            CategoryPageId = productRecord.CategoryPageId,
             Stock = store.IncludeStock ? variant.Stock : productRecord.Stock,
             StoreAlias = productRecord.StoreAlias,
             Locale = productRecord.Locale,
@@ -485,6 +487,25 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         }
 
         return categoryPaths;
+    }
+
+    private static IReadOnlyList<string>? BuildCategoryPageIds(IProduct product)
+    {
+        var categoryIds = new List<string>();
+        var seen = new HashSet<Guid>();
+
+        foreach (var category in product.Categories)
+        {
+            foreach (var categoryKey in category.Ancestors
+                .Select(ancestor => ancestor.Key)
+                .Append(category.Key))
+            {
+                if (categoryKey != Guid.Empty && seen.Add(categoryKey))
+                    categoryIds.Add(categoryKey.ToString("D"));
+            }
+        }
+
+        return categoryIds.Count > 0 ? categoryIds : null;
     }
 
     private static void RemoveEmptyValues(IDictionary<string, object?> values)

--- a/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
+++ b/Plugins/Ekom.Algolia/Models/Indexing/AlgoliaProductRecord.cs
@@ -64,6 +64,10 @@ public sealed class AlgoliaProductRecord
 
     public int CategoryRanking { get; init; }
 
+    [JsonPropertyName("categoryPageId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? CategoryPageId { get; init; }
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public decimal? Stock { get; init; }
 

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -384,7 +384,7 @@ Product records provide the following fields without requiring any `Indexing:Pro
 - Pricing: `Price`, `PriceWithVat`, `PriceWithoutVat`, and `Currency`.
 - Availability and ranking: `Available`, `ProductRanking`, and `CategoryRanking`.
 - Store context and dates: `StoreAlias`, `Locale`, `CreatedAt`, and `UpdatedAt`.
-- Categories: `hierarchical_categories.lvl0`, additional hierarchy levels when present, and `category_paths`.
+- Categories: `categoryPageId`, `hierarchical_categories.lvl0`, additional hierarchy levels when present, and `category_paths`.
 
 Optional fields are omitted when no value is available. `Stock` is included only when `Stores[*]:IncludeStock` is enabled. Variant-specific fields are included when variant indexing is enabled, as described below.
 
@@ -411,6 +411,31 @@ Product records also include `ProductRanking` and `CategoryRanking` integer fiel
   "CategoryRanking": 5
 }
 ```
+
+### Category pages
+
+`categoryPageId` contains the GUIDs of every category assigned to the product and all their ancestors. Values are deduplicated while preserving root-to-leaf order. This lets a category page filter by its own GUID and include products assigned to descendant categories. Variant records inherit the same identifiers.
+
+```json
+{
+  "categoryPageId": [
+    "0f0ea901-6280-4586-b7fe-7ae731ed9489",
+    "4925fa5f-163a-4882-80af-b12e6501c30c",
+    "acee53b7-c6f6-4cb2-b940-508f1b49208d"
+  ]
+}
+```
+
+Configure `categoryPageId` as `filterOnly(categoryPageId)` in the Algolia dashboard, then apply the category GUID as a fixed InstantSearch filter. When variant indexing is enabled, the plugin applies this setting together with `filterOnly(ProductId)`.
+
+```jsx
+<Configure
+  filters={`categoryPageId:"${categoryKey}"`}
+  analyticsTags={['category-page']}
+/>
+```
+
+Category hierarchy changes are not propagated to product records automatically. After moving, deleting, publishing, or changing a category hierarchy, queue a product-index rebuild with `IAlgoliaProductIndexService.RebuildStoreAsync(storeAlias)` or `RebuildAllAsync()`. The existing product indexing worker performs the rebuild in the background.
 
 ### Variant indexing
 


### PR DESCRIPTION
## Summary
- add `categoryPageId` to Algolia product records using assigned category and ancestor GUIDs
- deduplicate identifiers in root-to-leaf order and propagate them to variant records
- configure `categoryPageId` as a filter-only facet when variant indexing is enabled
- document category-page filtering and add mapper/serialization regression coverage

## Test Plan
- run `dotnet test Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj --filter "FullyQualifiedName~AlgoliaProductIndexMapperTests"`
- run `dotnet build Plugins/Ekom.Algolia/Ekom.Algolia.csproj --no-restore`
- rebuild a product index and verify parent and variant records contain `categoryPageId`
- filter an Algolia query by a category GUID and verify descendant-category products are included
