### PR TITLE
fix(import): support product summaries

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Models/Import/ImportProduct.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Import/ImportProduct.cs
@@ -16,6 +16,7 @@ public class ImportProduct : ImportBase
     public Dictionary<string, object>? Slug { get; set; } = new Dictionary<string, object>();
     public string? SKU { get; set; }
     public Dictionary<string, object>? Description { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, object>? Summary { get; set; } = new Dictionary<string, object>();
     public List<ImportPrice> Price { get; set; } = new List<ImportPrice>();
     public List<ImportStock> Stock { get; set; } = new List<ImportStock>();
     public bool EnableBackorder { get; set; }

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
@@ -1084,6 +1084,7 @@ public class ImportService : IImportService
 
             if (!importProduct.PreserveExistingValues)
             {
+                productContent.SetProperty("summary", importProduct.Summary);
                 productContent.SetProperty("description", importProduct.Description);
             }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportService.cs
@@ -985,7 +985,7 @@ public class ImportService : IImportService
                 foreach (var property in importCategory.AdditionalProperties)
                 {
                     if (categoryContent.HasProperty(property.Key))
-                        categoryContent.SetValue(property.Key, property.Value);
+                        categoryContent.SetAdditionalProperty(property.Key, property.Value);
                 }
             }
 
@@ -1114,7 +1114,7 @@ public class ImportService : IImportService
                 {
                     if (productContent.HasProperty(property.Key))
                     {
-                        productContent.SetValue(property.Key, property.Value);
+                        productContent.SetAdditionalProperty(property.Key, property.Value);
                     }
                 }
             }
@@ -1186,7 +1186,7 @@ public class ImportService : IImportService
         {
             foreach (var property in importVariantGroup.AdditionalProperties)
             {
-                variantGroupContent.SetValue(property.Key, property.Value);
+                variantGroupContent.SetAdditionalProperty(property.Key, property.Value);
             }
         }
 
@@ -1287,7 +1287,7 @@ public class ImportService : IImportService
         {
             foreach (var property in importVariant.AdditionalProperties)
             {
-                variantContent.SetValue(property.Key, property.Value);
+                variantContent.SetAdditionalProperty(property.Key, property.Value);
             }
         }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/ContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/ContentExtensions.cs
@@ -97,6 +97,20 @@ public static class ContentExtensions
         throw new InvalidOperationException("Unable to find matching property on IContent.");
     }
 
+    public static void SetAdditionalProperty(this IContent content, string alias, object? value)
+    {
+        var property = content.Properties.FirstOrDefault(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+
+        if (value is Dictionary<string, object> values
+            && string.Equals(property?.PropertyType.PropertyEditorAlias, "Ekom.Property", StringComparison.Ordinal))
+        {
+            content.SetProperty(alias, values);
+            return;
+        }
+
+        content.SetValue(alias, value);
+    }
+
     private static IEnumerable<IDataType>? GetDataTypesByEditorAlias(string alias)
     {
         var cache = Configuration.Resolver.GetService<IMemoryCache>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -978,7 +978,7 @@ public class ImportService : IImportService
                 foreach (var property in importCategory.AdditionalProperties)
                 {
                     if (categoryContent.HasProperty(property.Key))
-                        categoryContent.SetValue(property.Key, property.Value);
+                        categoryContent.SetAdditionalProperty(property.Key, property.Value);
                 }
             }
 
@@ -1107,7 +1107,7 @@ public class ImportService : IImportService
                 {
                     if (productContent.HasProperty(property.Key))
                     {
-                        productContent.SetValue(property.Key, property.Value);
+                        productContent.SetAdditionalProperty(property.Key, property.Value);
                     }
                 }
             }
@@ -1176,7 +1176,7 @@ public class ImportService : IImportService
         {
             foreach (var property in importVariantGroup.AdditionalProperties)
             {
-                variantGroupContent.SetValue(property.Key, property.Value);
+                variantGroupContent.SetAdditionalProperty(property.Key, property.Value);
             }
         }
 
@@ -1277,7 +1277,7 @@ public class ImportService : IImportService
         {
             foreach (var property in importVariant.AdditionalProperties)
             {
-                variantContent.SetValue(property.Key, property.Value);
+                variantContent.SetAdditionalProperty(property.Key, property.Value);
             }
         }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -1077,6 +1077,7 @@ public class ImportService : IImportService
 
             if (!importProduct.PreserveExistingValues)
             {
+                productContent.SetProperty("summary", importProduct.Summary);
                 productContent.SetProperty("description", importProduct.Description);
             }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
@@ -40,10 +40,40 @@ public static class ImportContentExtensions
         {
             DtdGuid = dataType?.Key ?? Guid.Empty,
             Values = propertyValues,
-            Type = type == PropertyEditorType.Empty ? PropertyEditorType.Language : type,
+            Type = GetPropertyEditorType(dataType, type),
         });
 
         content.SetValue(alias, value);
+    }
+
+    public static void SetAdditionalProperty(this IContent content, string alias, object? value)
+    {
+        var property = content.Properties.FirstOrDefault(x => x.Alias.Equals(alias, StringComparison.OrdinalIgnoreCase));
+
+        if (value is Dictionary<string, object> values
+            && string.Equals(property?.PropertyType.PropertyEditorAlias, "Ekom.Property", StringComparison.Ordinal))
+        {
+            content.SetProperty(alias, values);
+            return;
+        }
+
+        content.SetValue(alias, value);
+    }
+
+    private static PropertyEditorType GetPropertyEditorType(IDataType? dataType, PropertyEditorType type)
+    {
+        if (type != PropertyEditorType.Empty)
+        {
+            return type;
+        }
+
+        if (dataType?.ConfigurationData?.TryGetValue("useLanguages", out var useLanguages) == true
+            && bool.TryParse(useLanguages?.ToString(), out var value))
+        {
+            return value ? PropertyEditorType.Language : PropertyEditorType.Store;
+        }
+
+        return PropertyEditorType.Language;
     }
 
     private static bool IsRichTextEditor(IDataType? dataType)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
@@ -16,6 +16,7 @@ public static class ImportContentExtensions
 {
     private static readonly string[] AllCultures = ["*"];
     private const string RichTextEditorAlias = "Umbraco.RichText";
+    private const string LegacyRichTextEditorAlias = "Umbraco.TinyMCE";
 
     public static void SetProperty(this IContent content, string alias, Dictionary<string, object> values, PropertyEditorType type = PropertyEditorType.Empty)
     {
@@ -57,7 +58,9 @@ public static class ImportContentExtensions
             return false;
         }
 
-        return string.Equals(GetPropertyEditorAlias(wrappedDataType), RichTextEditorAlias, StringComparison.Ordinal);
+        var propertyEditorAlias = GetPropertyEditorAlias(wrappedDataType);
+        return string.Equals(propertyEditorAlias, RichTextEditorAlias, StringComparison.Ordinal)
+            || string.Equals(propertyEditorAlias, LegacyRichTextEditorAlias, StringComparison.Ordinal);
     }
 
     private static object CreateRichTextValue(object? value)


### PR DESCRIPTION
## Summary
- add Summary to the product import model and persist it through the Ekom property editor
- support Ekom property-editor dictionaries in AdditionalProperties across products, categories, variants, and variant groups
- preserve raw AdditionalProperties values for non-Ekom editors
- keep Summary as localized textarea content in Umbraco 10 and 17
- support legacy `Umbraco.TinyMCE` RTE wrapper aliases during U17 imports so Description is stored with markup JSON

## Test Plan
- `dotnet build \"Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj\"`
- `dotnet build \"Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj\"`