### PR TITLE
feat(algolia): add facet and language index settings

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexExecutorTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexExecutorTests.cs
@@ -1,0 +1,105 @@
+using Algolia.Search.Models.Search;
+using Ekom.Algolia;
+using Ekom.Algolia.Indexing;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaProductIndexExecutorTests
+{
+    [Fact]
+    public void Configures_Product_Facets_Without_Distinct_When_Variants_Are_Disabled()
+    {
+        var options = new AlgoliaIndexingOptions
+        {
+            FacetAttributes = ["brand", "metafield:material"],
+        };
+
+        var attributes = AlgoliaProductIndexExecutor.BuildAttributesForFaceting(options);
+
+        Assert.Equal(["attributes.brand", "attributes.material"], attributes);
+    }
+
+    [Fact]
+    public void Configures_Facets_After_Distinct_When_Variants_Are_Enabled()
+    {
+        var options = new AlgoliaIndexingOptions
+        {
+            Variants = true,
+            FacetAttributes = ["brand"],
+            VariantFacetAttributes = new Dictionary<string, string>
+            {
+                ["color"] = "variantGroup:title",
+                ["size"] = "variant:title",
+            },
+        };
+
+        var attributes = AlgoliaProductIndexExecutor.BuildAttributesForFaceting(options);
+
+        Assert.Equal(
+            [
+                "filterOnly(ProductId)",
+                "filterOnly(categoryPageId)",
+                "afterDistinct(attributes.brand)",
+                "afterDistinct(attributes.color)",
+                "afterDistinct(attributes.size)",
+            ],
+            attributes);
+    }
+
+    [Fact]
+    public void Applies_Store_Language_Settings_To_Index_Settings()
+    {
+        var store = new AlgoliaResolvedStore
+        {
+            Alias = "Store",
+            LanguageSettings = new AlgoliaLanguageSettingsOptions
+            {
+                QueryLanguages = ["is", "en"],
+                IndexLanguages = ["is"],
+                RemoveStopWords = true,
+                IgnorePlurals = false,
+            },
+        };
+        var settings = new IndexSettings();
+
+        AlgoliaProductIndexExecutor.ApplyLanguageSettings(settings, store);
+
+        Assert.Equal([SupportedLanguage.Is, SupportedLanguage.En], settings.QueryLanguages);
+        Assert.Equal([SupportedLanguage.Is], settings.IndexLanguages);
+        Assert.True(settings.RemoveStopWords!.AsBool());
+        Assert.False(settings.IgnorePlurals!.AsBool());
+    }
+
+    [Fact]
+    public void Rejects_Unsupported_Store_Language()
+    {
+        var store = new AlgoliaResolvedStore
+        {
+            Alias = "Store",
+            LanguageSettings = new AlgoliaLanguageSettingsOptions
+            {
+                QueryLanguages = ["invalid"],
+            },
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            AlgoliaProductIndexExecutor.ApplyLanguageSettings(new IndexSettings(), store));
+
+        Assert.Contains("invalid", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Store", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("QueryLanguages", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Detects_Explicitly_Disabled_Language_Processing_As_Configured()
+    {
+        var settings = new AlgoliaLanguageSettingsOptions
+        {
+            RemoveStopWords = false,
+            IgnorePlurals = false,
+        };
+
+        Assert.True(AlgoliaProductIndexExecutor.HasLanguageSettings(settings));
+    }
+}

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -158,9 +158,9 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Fact]
-    public void Strips_Html_From_Built_In_Product_Text_Fields()
+    public void Strips_Html_From_Built_In_Summary_And_Description_Fields()
     {
-        var mapper = CreateMapper(productProperties: ["TITLE|STRIPHTML", "summary|striphtml", "description|striphtml"]);
+        var mapper = CreateMapper(productProperties: ["summary|striphtml", "description|striphtml"]);
         var product = CreateProduct(
             title: "<p>Product <strong>title</strong></p>",
             summary: "<div>Product&nbsp;summary</div>",
@@ -169,7 +169,7 @@ public class AlgoliaProductIndexMapperTests
         var record = mapper.Map(product.Object, CreateStore(), "products");
 
         Assert.NotNull(record);
-        Assert.Equal("Product title", record!.Title);
+        Assert.Equal("<p>Product <strong>title</strong></p>", record!.Title);
         Assert.Equal("Product summary", record.Summary);
         Assert.Equal("Product description", record.Description);
         Assert.DoesNotContain(record.Data.Keys, key => key.Equals("title", StringComparison.OrdinalIgnoreCase));
@@ -348,6 +348,139 @@ public class AlgoliaProductIndexMapperTests
         var variantRecord = records.Single(x => x.IsVariant);
         Assert.Equal("Variant description", variantRecord.Description);
         Assert.Equal("Variant description", Assert.IsType<string>(variantRecord.Data["variantDescription"]));
+    }
+
+    [Fact]
+    public void Maps_Product_Properties_And_Metafields_As_Nested_Facet_Attributes()
+    {
+        var mapper = CreateMapper(facetAttributes: ["brand", "metafield:material"]);
+        var product = CreateProduct(
+            metafields: [CreateMetafield("material", [CreateMetafieldValue((string.Empty, "Leather"))])],
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["brand"] = "Nike"
+            });
+
+        var record = mapper.Map(product.Object, CreateStore(), "products");
+
+        Assert.NotNull(record);
+        var recordAttributes = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(record!.Data["attributes"]);
+        Assert.Equal("Nike", Assert.IsType<string>(recordAttributes["brand"]));
+        Assert.Equal("Leather", Assert.IsType<string>(recordAttributes["material"]));
+        Assert.DoesNotContain("brand", record.Data.Keys);
+        Assert.DoesNotContain("material", record.Data.Keys);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(record));
+        var attributes = json.RootElement.GetProperty("attributes");
+        Assert.Equal("Nike", attributes.GetProperty("brand").GetString());
+        Assert.Equal("Leather", attributes.GetProperty("material").GetString());
+    }
+
+    [Fact]
+    public void Maps_Variant_Group_And_Variant_Properties_As_Facet_Attributes()
+    {
+        var variantGroup = CreateVariantGroup(title: "Black");
+        var variant = CreateVariant(title: "XL", variantGroup: variantGroup.Object);
+        var mapper = CreateMapper(
+            indexVariants: true,
+            facetAttributes: ["brand"],
+            variantFacetAttributes: new Dictionary<string, string>
+            {
+                ["color"] = "variantGroup:title",
+                ["size"] = "variant:title"
+            });
+        var product = CreateProduct(
+            properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["brand"] = "Nike"
+            },
+            variants: [variant.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        var productRecord = records.Single(record => !record.IsVariant);
+        var variantRecord = records.Single(record => record.IsVariant);
+        var productAttributes = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(productRecord.Data["attributes"]);
+        var variantAttributes = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(variantRecord.Data["attributes"]);
+        Assert.Equal("Nike", Assert.IsType<string>(productAttributes["brand"]));
+        Assert.Equal("Nike", Assert.IsType<string>(variantAttributes["brand"]));
+        Assert.Equal("Black", Assert.IsType<string>(variantAttributes["color"]));
+        Assert.Equal("XL", Assert.IsType<string>(variantAttributes["size"]));
+    }
+
+    [Fact]
+    public void Maps_One_Level_Variant_Properties_As_Facet_Attributes()
+    {
+        var variant = CreateVariant(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["color"] = "White",
+            ["size"] = "Large"
+        });
+        var mapper = CreateMapper(
+            indexVariants: true,
+            variantFacetAttributes: new Dictionary<string, string>
+            {
+                ["color"] = "variant:color",
+                ["size"] = "variant:size"
+            });
+        var product = CreateProduct(variants: [variant.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        var variantRecord = records.Single(record => record.IsVariant);
+        var attributes = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(variantRecord.Data["attributes"]);
+        Assert.Equal("White", Assert.IsType<string>(attributes["color"]));
+        Assert.Equal("Large", Assert.IsType<string>(attributes["size"]));
+    }
+
+    [Fact]
+    public void Keeps_Facet_Values_On_Their_Own_Variant_Records()
+    {
+        var blackMedium = CreateVariant(
+            sku: "black-medium",
+            title: "Medium",
+            variantGroup: CreateVariantGroup("Black").Object);
+        var whiteLarge = CreateVariant(
+            sku: "white-large",
+            title: "Large",
+            variantGroup: CreateVariantGroup("White").Object);
+        var mapper = CreateMapper(
+            indexVariants: true,
+            variantFacetAttributes: new Dictionary<string, string>
+            {
+                ["color"] = "variantGroup:title",
+                ["size"] = "variant:title"
+            });
+        var product = CreateProduct(variants: [blackMedium.Object, whiteLarge.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        var combinations = records
+            .Where(record => record.IsVariant)
+            .Select(record => Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(record.Data["attributes"]))
+            .Select(attributes => $"{attributes["color"]}/{attributes["size"]}")
+            .ToList();
+        Assert.Equal(["Black/Medium", "White/Large"], combinations);
+        Assert.DoesNotContain("Black/Large", combinations);
+    }
+
+    [Fact]
+    public void Skips_Variant_Group_Facet_When_Group_Cannot_Be_Resolved()
+    {
+        var variant = CreateVariant();
+        variant.SetupGet(x => x.VariantGroup).Returns((Ekom.Models.IVariantGroup)null!);
+        var mapper = CreateMapper(
+            indexVariants: true,
+            variantFacetAttributes: new Dictionary<string, string>
+            {
+                ["color"] = "variantGroup:title"
+            });
+        var product = CreateProduct(variants: [variant.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        var variantRecord = records.Single(record => record.IsVariant);
+        Assert.DoesNotContain("attributes", variantRecord.Data.Keys);
     }
 
     [Fact]
@@ -584,7 +717,11 @@ public class AlgoliaProductIndexMapperTests
         Assert.Equal(0, record.CategoryRanking);
     }
 
-    private static ProductIndexMapper CreateMapper(IReadOnlyCollection<string>? productProperties = null, bool indexVariants = false)
+    private static ProductIndexMapper CreateMapper(
+        IReadOnlyCollection<string>? productProperties = null,
+        bool indexVariants = false,
+        IReadOnlyCollection<string>? facetAttributes = null,
+        Dictionary<string, string>? variantFacetAttributes = null)
     {
         var options = Options.Create(new AlgoliaOptions
         {
@@ -594,7 +731,9 @@ public class AlgoliaProductIndexMapperTests
             Indexing = new AlgoliaIndexingOptions
             {
                 Variants = indexVariants,
-                ProductProperties = productProperties ?? []
+                ProductProperties = productProperties ?? [],
+                FacetAttributes = facetAttributes ?? [],
+                VariantFacetAttributes = variantFacetAttributes ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
             }
         });
 
@@ -677,7 +816,9 @@ public class AlgoliaProductIndexMapperTests
         string sku = "variant-sku",
         string title = "Variant",
         string description = "Variant description",
-        bool available = true)
+        bool available = true,
+        IReadOnlyDictionary<string, string>? properties = null,
+        Ekom.Models.IVariantGroup? variantGroup = null)
     {
         var price = new Mock<Ekom.Models.IPrice>();
         price.SetupGet(x => x.Value).Returns(10m);
@@ -696,10 +837,25 @@ public class AlgoliaProductIndexMapperTests
         variant.SetupGet(x => x.Price).Returns(price.Object);
         variant.SetupGet(x => x.Prices).Returns([price.Object]);
         variant.SetupGet(x => x.VariantGroupId).Returns(123);
+        variant.SetupGet(x => x.VariantGroup).Returns(variantGroup ?? Mock.Of<Ekom.Models.IVariantGroup>());
         variant.SetupGet(x => x.CreateDate).Returns(new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc));
         variant.SetupGet(x => x.UpdateDate).Returns(new DateTime(2024, 1, 4, 0, 0, 0, DateTimeKind.Utc));
+        variant.Setup(x => x.GetValue(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns((string alias, string? _, bool _) => properties != null && properties.TryGetValue(alias, out var value) ? value : string.Empty);
 
         return variant;
+    }
+
+    private static Mock<Ekom.Models.IVariantGroup> CreateVariantGroup(
+        string title = "Variant group",
+        IReadOnlyDictionary<string, string>? properties = null)
+    {
+        var variantGroup = new Mock<Ekom.Models.IVariantGroup>();
+        variantGroup.SetupGet(x => x.Title).Returns(title);
+        variantGroup.Setup(x => x.GetValue(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns((string alias, string? _, bool _) => properties != null && properties.TryGetValue(alias, out var value) ? value : string.Empty);
+
+        return variantGroup;
     }
 
     private static Ekom.Models.MetavalueSlim CreateMetafield(

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -32,6 +32,14 @@ public class AlgoliaSearchTests
                 ["Ekom:Algolia:Search:Cache:Enabled"] = "true",
                 ["Ekom:Algolia:Search:Cache:DurationMinutes"] = "15",
                 ["Ekom:Algolia:Search:Cache:CacheEmptyResults"] = "false",
+                ["Ekom:Algolia:Indexing:FacetAttributes:0"] = "metafield:material",
+                ["Ekom:Algolia:Indexing:VariantFacetAttributes:color"] = "variantGroup:title",
+                ["Ekom:Algolia:Indexing:VariantFacetAttributes:size"] = "variant:title",
+                ["Ekom:Algolia:Stores:0:Alias"] = "Store",
+                ["Ekom:Algolia:Stores:0:LanguageSettings:QueryLanguages:0"] = "is",
+                ["Ekom:Algolia:Stores:0:LanguageSettings:IndexLanguages:0"] = "is",
+                ["Ekom:Algolia:Stores:0:LanguageSettings:RemoveStopWords"] = "true",
+                ["Ekom:Algolia:Stores:0:LanguageSettings:IgnorePlurals"] = "true",
                 ["Ekom:Algolia:ContentIndexing:Enabled"] = "true",
                 ["Ekom:Algolia:ContentIndexing:OversizedRecords:Behavior"] = "Skip",
                 ["Ekom:Algolia:ContentIndexing:OversizedRecords:MaxSizeBytes"] = "90000",
@@ -58,6 +66,14 @@ public class AlgoliaSearchTests
         Assert.Equal(50, options.Search.MaxHitsPerPage);
         Assert.Equal(15, options.Search.Cache.DurationMinutes);
         Assert.False(options.Search.Cache.CacheEmptyResults);
+        Assert.Equal(["metafield:material"], options.Indexing.FacetAttributes);
+        Assert.Equal("variantGroup:title", options.Indexing.VariantFacetAttributes["color"]);
+        Assert.Equal("variant:title", options.Indexing.VariantFacetAttributes["size"]);
+        var store = Assert.Single(options.Stores);
+        Assert.Equal(["is"], store.LanguageSettings.QueryLanguages);
+        Assert.Equal(["is"], store.LanguageSettings.IndexLanguages);
+        Assert.True(store.LanguageSettings.RemoveStopWords);
+        Assert.True(store.LanguageSettings.IgnorePlurals);
         Assert.True(options.ContentIndexing.Enabled);
         Assert.Equal(AlgoliaOversizedRecordBehavior.Skip, options.ContentIndexing.OversizedRecords.Behavior);
         Assert.Equal(90_000, options.ContentIndexing.OversizedRecords.MaxSizeBytes);

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -38,6 +38,8 @@ public sealed class AlgoliaIndexingOptions
     public int BatchSize { get; set; } = 1000;
 
     public IReadOnlyCollection<string> ProductProperties { get; init; } = [];
+    public IReadOnlyCollection<string> FacetAttributes { get; init; } = [];
+    public Dictionary<string, string> VariantFacetAttributes { get; init; } = new(StringComparer.OrdinalIgnoreCase);
     public IReadOnlyCollection<AlgoliaSortedReplicaOptions> SortedReplicas { get; init; } = [];
 
     public AlgoliaDispatcherOptions Dispatching { get; init; } = new();
@@ -139,6 +141,15 @@ public sealed class AlgoliaStoreOptions
 {
     public required string Alias { get; set; }
     public bool IncludeStock { get; set; }
+    public AlgoliaLanguageSettingsOptions LanguageSettings { get; init; } = new();
+}
+
+public sealed class AlgoliaLanguageSettingsOptions
+{
+    public IReadOnlyCollection<string> QueryLanguages { get; init; } = [];
+    public IReadOnlyCollection<string> IndexLanguages { get; init; } = [];
+    public bool? RemoveStopWords { get; init; }
+    public bool? IgnorePlurals { get; init; }
 }
 
 public sealed class AlgoliaResolvedStore
@@ -149,6 +160,7 @@ public sealed class AlgoliaResolvedStore
     public bool IncludeStock { get; init; }
     public IReadOnlyList<string> Locales { get; init; } = [];
     public IReadOnlyList<string> Currencies { get; init; } = [];
+    public AlgoliaLanguageSettingsOptions LanguageSettings { get; init; } = new();
 
     public IReadOnlyList<AlgoliaResolvedStore> ExpandIndexTargets()
     {
@@ -173,7 +185,8 @@ public sealed class AlgoliaResolvedStore
             Currency = currency,
             IncludeStock = IncludeStock,
             Locales = Locales,
-            Currencies = Currencies
+            Currencies = Currencies,
+            LanguageSettings = LanguageSettings,
         };
 }
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexExecutor.cs
@@ -317,7 +317,9 @@ internal sealed class AlgoliaProductIndexExecutor
 
     private async Task EnsureIndexSettingsAsync(AlgoliaResolvedStore store, string primaryIndexName, CancellationToken ct)
     {
-        if (_options.Indexing.SortedReplicas.Count == 0 && !_options.Indexing.Variants)
+        var attributesForFaceting = BuildAttributesForFaceting(_options.Indexing);
+        var hasLanguageSettings = HasLanguageSettings(store.LanguageSettings);
+        if (_options.Indexing.SortedReplicas.Count == 0 && attributesForFaceting.Count == 0 && !hasLanguageSettings)
             return;
 
         var replicas = _options.Indexing.SortedReplicas
@@ -330,7 +332,7 @@ internal sealed class AlgoliaProductIndexExecutor
             .DistinctBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        if (replicas.Count == 0 && !_options.Indexing.Variants)
+        if (replicas.Count == 0 && attributesForFaceting.Count == 0 && !hasLanguageSettings)
             return;
 
         _logger.LogDebug(
@@ -339,32 +341,120 @@ internal sealed class AlgoliaProductIndexExecutor
             primaryIndexName,
             store.Alias);
 
+        var primarySettings = new IndexSettings
+        {
+            Replicas = replicas.Select(x => x.Name).ToList(),
+            AttributeForDistinct = _options.Indexing.Variants ? "ProductId" : null,
+            AttributesForFaceting = attributesForFaceting.Count > 0 ? attributesForFaceting : null,
+        };
+        ApplyLanguageSettings(primarySettings, store);
+
         await _client.SetSettingsAsync(
             primaryIndexName,
-            new IndexSettings
-            {
-                Replicas = replicas.Select(x => x.Name).ToList(),
-                AttributeForDistinct = _options.Indexing.Variants ? "ProductId" : null,
-                AttributesForFaceting = _options.Indexing.Variants
-                    ? ["filterOnly(ProductId)", "filterOnly(categoryPageId)"]
-                    : null
-            },
+            primarySettings,
             forwardToReplicas: false,
             options: null,
             cancellationToken: ct).ConfigureAwait(false);
 
         foreach (var replica in replicas)
         {
+            var replicaSettings = new IndexSettings
+            {
+                Ranking = BuildReplicaRanking(replica.Options),
+                AttributeForDistinct = _options.Indexing.Variants ? "ProductId" : null,
+                AttributesForFaceting = attributesForFaceting.Count > 0 ? attributesForFaceting : null,
+            };
+            ApplyLanguageSettings(replicaSettings, store);
+
             await _client.SetSettingsAsync(
                 replica.Name,
-                new IndexSettings
-                {
-                    Ranking = BuildReplicaRanking(replica.Options)
-                },
+                replicaSettings,
                 forwardToReplicas: false,
                 options: null,
                 cancellationToken: ct).ConfigureAwait(false);
         }
+    }
+
+    internal static void ApplyLanguageSettings(IndexSettings indexSettings, AlgoliaResolvedStore store)
+    {
+        var languageSettings = store.LanguageSettings;
+
+        indexSettings.QueryLanguages = ParseLanguages(
+            languageSettings.QueryLanguages,
+            nameof(languageSettings.QueryLanguages),
+            store.Alias);
+        indexSettings.IndexLanguages = ParseLanguages(
+            languageSettings.IndexLanguages,
+            nameof(languageSettings.IndexLanguages),
+            store.Alias);
+        indexSettings.RemoveStopWords = languageSettings.RemoveStopWords.HasValue
+            ? new RemoveStopWords(languageSettings.RemoveStopWords.Value)
+            : null;
+        indexSettings.IgnorePlurals = languageSettings.IgnorePlurals.HasValue
+            ? new IgnorePlurals(languageSettings.IgnorePlurals.Value)
+            : null;
+    }
+
+    internal static bool HasLanguageSettings(AlgoliaLanguageSettingsOptions settings)
+        => settings.QueryLanguages.Count > 0
+            || settings.IndexLanguages.Count > 0
+            || settings.RemoveStopWords.HasValue
+            || settings.IgnorePlurals.HasValue;
+
+    private static List<SupportedLanguage>? ParseLanguages(
+        IReadOnlyCollection<string> languages,
+        string settingName,
+        string storeAlias)
+    {
+        if (languages.Count == 0)
+            return null;
+
+        var parsedLanguages = new List<SupportedLanguage>(languages.Count);
+        foreach (var language in languages)
+        {
+            var value = language?.Trim();
+            if (string.IsNullOrWhiteSpace(value)
+                || !Enum.TryParse(value, ignoreCase: true, out SupportedLanguage parsedLanguage)
+                || !Enum.IsDefined(parsedLanguage))
+            {
+                throw new InvalidOperationException(
+                    $"Unsupported Algolia language '{language}' configured for store '{storeAlias}' in '{settingName}'. Use a supported ISO 639-1 language code.");
+            }
+
+            if (!parsedLanguages.Contains(parsedLanguage))
+                parsedLanguages.Add(parsedLanguage);
+        }
+
+        return parsedLanguages;
+    }
+
+    internal static List<string> BuildAttributesForFaceting(AlgoliaIndexingOptions options)
+    {
+        var attributes = options.FacetAttributes
+            .Select(ProductIndexMapper.ConfiguredField.Parse)
+            .Select(field => field.Alias)
+            .Concat(options.VariantFacetAttributes
+                .Select(x => ProductIndexMapper.ConfiguredVariantFacet.Parse(x.Key, x.Value))
+                .Where(attribute => !string.IsNullOrWhiteSpace(attribute.Field.Alias))
+                .Select(attribute => attribute.OutputAlias))
+            .Where(alias => !string.IsNullOrWhiteSpace(alias))
+            .Select(alias => alias.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var attributesForFaceting = new List<string>();
+        if (options.Variants)
+        {
+            attributesForFaceting.Add("filterOnly(ProductId)");
+            attributesForFaceting.Add("filterOnly(categoryPageId)");
+        }
+
+        attributesForFaceting.AddRange(attributes.Select(attribute =>
+            options.Variants
+                ? $"afterDistinct(attributes.{attribute})"
+                : $"attributes.{attribute}"));
+
+        return attributesForFaceting;
     }
 
     private async Task DeleteByProductIdsAsync(string indexName, IEnumerable<Guid> productKeys, bool waitForTasks, CancellationToken ct)

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -38,6 +38,7 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         var locale = store.Locale;
         var categoryLevels = BuildCategoryLevels(product, locale);
         var nodeName = GetNodeName(product);
+        var facetAttributes = BuildProductFacetAttributes(product, store, baseIndexName);
         var title = ApplyBuiltInTextTransform(
             "title",
             GetLocalizedValue(product, "title", product.Title, locale),
@@ -151,6 +152,9 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             }
         }
 
+        if (facetAttributes.Count > 0)
+            record.Data["attributes"] = facetAttributes;
+
         if (_enrichers.Count > 0)
         {
             var ctx = new AlgoliaProductEnrichmentContext(product, store, baseIndexName, allowedTransforms);
@@ -174,10 +178,11 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
         var records = new List<AlgoliaProductRecord> { productRecord };
         var configuredFields = BuildAllowedProperties(product, store);
+        var variantFacetAttributes = BuildVariantFacetAttributes();
 
         foreach (var variant in product.AllVariants)
         {
-            var record = MapVariant(product, variant, productRecord, store, baseIndexName, configuredFields);
+            var record = MapVariant(product, variant, productRecord, store, baseIndexName, configuredFields, variantFacetAttributes);
             if (record is not null)
                 records.Add(record);
         }
@@ -191,7 +196,8 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         AlgoliaProductRecord productRecord,
         AlgoliaResolvedStore store,
         string baseIndexName,
-        IReadOnlyDictionary<string, ConfiguredField> configuredFields)
+        IReadOnlyDictionary<string, ConfiguredField> configuredFields,
+        IReadOnlyList<ConfiguredVariantFacet> variantFacetAttributes)
     {
         if (string.IsNullOrWhiteSpace(variant.SKU))
             return null;
@@ -205,6 +211,20 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
         var price = ResolvePrice(variant, store);
         var variantDescription = ResolveVariantDescription(product, variant, store, baseIndexName, configuredFields);
+        var attributes = CopyAttributes(productRecord.Data);
+
+        foreach (var configuredAttribute in variantFacetAttributes)
+        {
+            var converted = ResolveVariantFacetValue(variant, store, configuredAttribute);
+            var context = new AlgoliaProductFieldContext(product, store, configuredAttribute.OutputAlias, baseIndexName);
+            converted = ConvertProperty(context, converted);
+            converted = ApplyFacetTransform(converted, configuredAttribute.Field.Transform);
+
+            if (converted is not null)
+                attributes[configuredAttribute.OutputAlias] = converted;
+        }
+
+        RemoveEmptyValues(attributes);
         var data = new Dictionary<string, object?>(productRecord.Data, StringComparer.OrdinalIgnoreCase)
         {
             ["variantSku"] = variant.SKU,
@@ -213,6 +233,9 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             ["variantAvailable"] = variant.Available ? 1 : 0,
             ["variantStock"] = store.IncludeStock ? variant.Stock : null
         };
+
+        if (attributes.Count > 0)
+            data["attributes"] = attributes;
 
         RemoveEmptyValues(data);
 
@@ -278,6 +301,49 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
     }
 
+    private Dictionary<string, object?> BuildProductFacetAttributes(IProduct product, AlgoliaResolvedStore store, string baseIndexName)
+    {
+        var attributes = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var field in BuildConfiguredFields(_options.Indexing.FacetAttributes).Values)
+        {
+            var converted = ResolveConfiguredValue(product, store, field);
+            var context = new AlgoliaProductFieldContext(product, store, field.Alias, baseIndexName);
+            converted = ConvertProperty(context, converted);
+            converted = ApplyFacetTransform(converted, field.Transform);
+
+            if (converted is not null)
+                attributes[field.Alias] = converted;
+        }
+
+        RemoveEmptyValues(attributes);
+        return attributes;
+    }
+
+    private IReadOnlyList<ConfiguredVariantFacet> BuildVariantFacetAttributes()
+    {
+        var attributes = new Dictionary<string, ConfiguredVariantFacet>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (outputAlias, source) in _options.Indexing.VariantFacetAttributes)
+        {
+            var configuredAttribute = ConfiguredVariantFacet.Parse(outputAlias, source);
+            if (!string.IsNullOrWhiteSpace(configuredAttribute.OutputAlias)
+                && !string.IsNullOrWhiteSpace(configuredAttribute.Field.Alias))
+            {
+                attributes[configuredAttribute.OutputAlias] = configuredAttribute;
+            }
+        }
+
+        return attributes.Values.ToList();
+    }
+
+    private static Dictionary<string, ConfiguredField> BuildConfiguredFields(IEnumerable<string> fields)
+        => fields
+            .Select(ConfiguredField.Parse)
+            .Where(field => !string.IsNullOrWhiteSpace(field.Alias))
+            .GroupBy(field => field.Alias, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Last(), StringComparer.OrdinalIgnoreCase);
+
     private object? ConvertProperty(AlgoliaProductFieldContext ctx, object? value)
     {
         foreach (var converter in _converters)
@@ -293,6 +359,14 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         => transform == AlgoliaFieldTransform.StripHtml
             ? AlgoliaHtmlTextConverter.Convert(value)
             : value;
+
+    private static object? ApplyFacetTransform(object? value, AlgoliaFieldTransform transform)
+        => transform switch
+        {
+            AlgoliaFieldTransform.UnixSeconds => TryToUnix(value, unixMilliseconds: false),
+            AlgoliaFieldTransform.UnixMilliseconds => TryToUnix(value, unixMilliseconds: true),
+            _ => ApplyTransform(value, transform),
+        };
 
     private string ApplyBuiltInTextTransform(
         string alias,
@@ -334,6 +408,24 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             return null;
 
         return NormalizePropertyValue(raw, configuredField.ValueType);
+    }
+
+    private static object? ResolveVariantFacetValue(IVariant variant, AlgoliaResolvedStore store, ConfiguredVariantFacet configuredAttribute)
+    {
+        INodeEntity? node = configuredAttribute.Source == AlgoliaVariantFacetSource.VariantGroup
+            ? variant.VariantGroup
+            : variant;
+        if (node is null)
+            return null;
+
+        var fallback = configuredAttribute.Field.Alias.Equals("title", StringComparison.OrdinalIgnoreCase)
+            ? node.Title
+            : node.GetValue(configuredAttribute.Field.Alias, store.Alias);
+        var raw = GetLocalizedValue(node, configuredAttribute.Field.Alias, fallback, store.Locale);
+
+        return string.IsNullOrWhiteSpace(raw)
+            ? null
+            : NormalizePropertyValue(raw, configuredAttribute.Field.ValueType);
     }
 
     private static int ResolveCategoryRank(IProduct product, string? storeAlias)
@@ -516,6 +608,17 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
 
         foreach (var key in keysToRemove)
             values.Remove(key);
+    }
+
+    private static Dictionary<string, object?> CopyAttributes(IReadOnlyDictionary<string, object?> data)
+    {
+        if (data.TryGetValue("attributes", out var value)
+            && value is IReadOnlyDictionary<string, object?> attributes)
+        {
+            return attributes.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
     }
 
     private static bool IsEmptyValue(object? value)
@@ -715,6 +818,40 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
             return (rawAlias, AlgoliaFieldSource.Property);
         }
     }
+
+    internal readonly record struct ConfiguredVariantFacet(
+        string OutputAlias,
+        AlgoliaVariantFacetSource Source,
+        ConfiguredField Field)
+    {
+        public static ConfiguredVariantFacet Parse(string outputAlias, string raw)
+        {
+            if (string.IsNullOrWhiteSpace(outputAlias) || string.IsNullOrWhiteSpace(raw))
+                return default;
+
+            const string variantPrefix = "variant:";
+            const string variantGroupPrefix = "variantGroup:";
+            AlgoliaVariantFacetSource source;
+            string field;
+
+            if (raw.StartsWith(variantGroupPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                source = AlgoliaVariantFacetSource.VariantGroup;
+                field = raw[variantGroupPrefix.Length..];
+            }
+            else if (raw.StartsWith(variantPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                source = AlgoliaVariantFacetSource.Variant;
+                field = raw[variantPrefix.Length..];
+            }
+            else
+            {
+                return default;
+            }
+
+            return new ConfiguredVariantFacet(outputAlias.Trim(), source, ConfiguredField.Parse(field));
+        }
+    }
 }
 
 internal enum AlgoliaFieldSource
@@ -729,4 +866,10 @@ internal enum AlgoliaFieldValueType
     Int,
     Decimal,
     Array
+}
+
+internal enum AlgoliaVariantFacetSource
+{
+    Variant,
+    VariantGroup,
 }

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -158,7 +158,13 @@ public sealed class ProductSearchController
       },
       "Stores": [
         {
-          "Alias": "Store"
+          "Alias": "Store",
+          "LanguageSettings": {
+            "QueryLanguages": ["en"],
+            "IndexLanguages": ["en"],
+            "RemoveStopWords": true,
+            "IgnorePlurals": true
+          }
         }
       ]
     }
@@ -184,6 +190,8 @@ public sealed class ProductSearchController
 | `Indexing:Variants` | `bool` | `false` | Indexes product variants as separate product records so variant SKUs can be searched directly. |
 | `Indexing:BatchSize` | `int` | `1000` | Batch size for Algolia save/replace/delete operations. |
 | `Indexing:ProductProperties` | `string[]` | `[]` | Additional product properties/metafields to include in product records. Supports modifiers documented below. |
+| `Indexing:FacetAttributes` | `string[]` | `[]` | Product properties/metafields to include under `attributes` and configure as facets. |
+| `Indexing:VariantFacetAttributes` | `object` | `{}` | Maps facet output names to `variant:` or `variantGroup:` property sources. |
 | `Indexing:SortedReplicas` | `object[]` | `[]` | Replica definitions using `Attribute` and `Direction` (`Asc` or `Desc`). |
 | `Indexing:Dispatching:MaxBatchSize` | `int` | `100` | Maximum queued jobs processed in one worker batch. |
 | `Indexing:Dispatching:FlushIntervalSeconds` | `int` | `2` | Worker delay between queue flushes. |
@@ -223,6 +231,10 @@ public sealed class ProductSearchController
 | `Stores` | `object[]` | `[]` | Store aliases supported by the plugin. Locale/currency are resolved from Ekom store data. |
 | `Stores[*]:Alias` | `string` | required | Ekom store alias. |
 | `Stores[*]:IncludeStock` | `bool` | `false` | Includes product stock in indexed records for this store. |
+| `Stores[*]:LanguageSettings:QueryLanguages` | `string[]` | `[]` | ISO 639-1 languages used for language-specific query processing. |
+| `Stores[*]:LanguageSettings:IndexLanguages` | `string[]` | `[]` | ISO 639-1 languages used for language-specific indexing. |
+| `Stores[*]:LanguageSettings:RemoveStopWords` | `bool` | `null` | Enables or disables stop-word removal for this store's product indexes. |
+| `Stores[*]:LanguageSettings:IgnorePlurals` | `bool` | `null` | Enables or disables matching singular, plural, and inflected forms for this store's product indexes. |
 
 ## Usage notes
 
@@ -258,6 +270,41 @@ When `Search:QuerySuggestions` is enabled, the plugin provisions the separate `q
   }
 }
 ```
+
+### Per-store language settings
+
+Configure Algolia's language processing separately for each store. These settings are applied to the store's primary product indexes and sorted replicas. Algolia recommends configuring both `QueryLanguages` and `IndexLanguages` so query-time and index-time processing are consistent.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Stores": [
+        {
+          "Alias": "IcelandicStore",
+          "LanguageSettings": {
+            "QueryLanguages": ["is"],
+            "IndexLanguages": ["is"],
+            "RemoveStopWords": false,
+            "IgnorePlurals": true
+          }
+        },
+        {
+          "Alias": "EnglishStore",
+          "LanguageSettings": {
+            "QueryLanguages": ["en"],
+            "IndexLanguages": ["en"],
+            "RemoveStopWords": true,
+            "IgnorePlurals": true
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Language values are validated against Algolia's supported ISO 639-1 language codes. Omitted boolean settings preserve Algolia's defaults; explicitly setting them to `false` disables the corresponding processing. These settings don't apply to standard content or query-suggestions indexes.
 
 ### Oversized content records
 
@@ -487,7 +534,7 @@ Product indexes are configured with `AttributeForDistinct = ProductId`. `Search:
 
 ### Additional product properties and metafields
 
-`Indexing:ProductProperties` adds extra product properties and metafields that are not part of the default product record fields listed above. The built-in `title`, `summary`, and `description` aliases may also be configured with `|striphtml` to transform their top-level record fields. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, `|unixms`, or `|striphtml`.
+`Indexing:ProductProperties` adds extra product properties and metafields that are not part of the default product record fields listed above. The built-in `summary` and `description` aliases may also be configured with `|striphtml` to transform their top-level record fields. Each entry supports one optional modifier: `|array`, `|int`, `|decimal`, `|unix`, `|unixms`, or `|striphtml`.
 
 ```json
 {
@@ -534,6 +581,69 @@ Modifier behavior:
 - Metafields with `Enable Multiple Choice` enabled are automatically indexed as string arrays. The `|array` modifier can still be used to explicitly index other metafields as arrays.
 - Invalid `|array`, `|int`, and `|decimal` values are skipped instead of being indexed as strings.
 - Only one modifier is supported for each configured field.
+
+### Facet attributes
+
+`Indexing:FacetAttributes` places selected product properties and metafields under the record's `attributes` object and configures them as Algolia facets. The entries use the same aliases and optional modifiers as `ProductProperties`.
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Indexing": {
+        "FacetAttributes": [
+          "brand",
+          "metafield:material",
+          "metafield:availableSizes"
+        ]
+      }
+    }
+  }
+}
+```
+
+This produces values such as:
+
+```json
+{
+  "attributes": {
+    "brand": "Nike",
+    "material": "Leather",
+    "availableSizes": ["M", "L", "XL"]
+  }
+}
+```
+
+When variant indexing is enabled, `Indexing:VariantFacetAttributes` maps output facet names to properties on either the variant group or variant node. This supports two-level variants such as color groups containing size variants:
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Indexing": {
+        "Variants": true,
+        "VariantFacetAttributes": {
+          "color": "variantGroup:title",
+          "size": "variant:title"
+        }
+      }
+    }
+  }
+}
+```
+
+For one-level variants where both values are stored on each variant node, use property aliases instead:
+
+```json
+"VariantFacetAttributes": {
+  "color": "variant:color",
+  "size": "variant:size"
+}
+```
+
+Variant facets are stored on each variant record, so combined filters such as color and size must match the same variant. Product facet attributes are inherited by variant records, and a variant attribute overrides a product attribute with the same output name.
+
+With variants enabled, the plugin configures these facets with Algolia's `afterDistinct` modifier and groups search results by `ProductId`. This provides product-level facet counts while preserving variant-level combinations. Algolia recommends that facet values are consistent within each distinct group, so validate counts for catalogues where one product has many different variant values. A full product reindex is required after adding or changing facet attributes.
 
 ### Manual reindexing
 

--- a/Plugins/Ekom.Algolia/Services/AlgoliaStoreResolver.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaStoreResolver.cs
@@ -47,7 +47,8 @@ internal sealed class AlgoliaStoreResolver
             Currency = ekomStore?.Currency?.CurrencyValue,
             IncludeStock = configuredStore?.IncludeStock ?? false,
             Locales = locales,
-            Currencies = currencies
+            Currencies = currencies,
+            LanguageSettings = configuredStore?.LanguageSettings ?? new(),
         };
     }
 


### PR DESCRIPTION
## Summary

- add configurable product and metafield facets under each Algolia record's nested `attributes` object
- support variant and variant-group facet sources while preserving exact variant value combinations
- configure product facets, distinct grouping, and sorted replicas through Algolia index settings
- add per-store `queryLanguages`, `indexLanguages`, `removeStopWords`, and `ignorePlurals` settings for product indexes and replicas
- validate configured Algolia language codes and document the new configuration
- add mapper, settings, and configuration-binding coverage

## Test Plan

- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaProductIndex|FullyQualifiedName~AlgoliaSearchTests.Binds_Algolia_Search_Options"`
- `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj"`
- verify separate store configurations apply their language settings to the corresponding primary product indexes and sorted replicas
- verify product and variant facets are emitted under `attributes` and configured in `attributesForFaceting`
