### PR TITLE
feat(order): support giftcard payments

### DIFF
--- a/Bruno/Order/Add Giftcard.bru
+++ b/Bruno/Order/Add Giftcard.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Add Giftcard
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{baseUrl}}/ekom/order/giftcards
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "StoreAlias": "store",
+    "Giftcard": {
+      "Amount": 25,
+      "Code": "GIFT-123",
+      "ValidUntil": "2026-12-31T23:59:59Z"
+    }
+  }
+}

--- a/Bruno/Order/Remove Giftcard.bru
+++ b/Bruno/Order/Remove Giftcard.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Remove Giftcard
+  type: http
+  seq: 15
+}
+
+delete {
+  url: {{baseUrl}}/ekom/order/giftcards/GIFT-123?storeAlias=store
+  body: none
+  auth: none
+}

--- a/Ekom/Ekom.Core/Ekom/API/Order.cs
+++ b/Ekom/Ekom.Core/Ekom/API/Order.cs
@@ -400,6 +400,43 @@ public partial class Order
             .ConfigureAwait(false);
     }
 
+    public async Task<IOrderInfo> AddGiftcardAsync(
+        Giftcard giftcard,
+        string storeAlias,
+        OrderSettings? settings = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(giftcard);
+
+        if (string.IsNullOrWhiteSpace(storeAlias))
+        {
+            throw new ArgumentException("Null or empty storeAlias", nameof(storeAlias));
+        }
+
+        return await _orderService.AddGiftcardAsync(giftcard, storeAlias, settings, ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IOrderInfo> RemoveGiftcardAsync(
+        string code,
+        string storeAlias,
+        OrderSettings? settings = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new ArgumentException("Null or empty code", nameof(code));
+        }
+
+        if (string.IsNullOrWhiteSpace(storeAlias))
+        {
+            throw new ArgumentException("Null or empty storeAlias", nameof(storeAlias));
+        }
+
+        return await _orderService.RemoveGiftcardAsync(code, storeAlias, settings, ct)
+            .ConfigureAwait(false);
+    }
+
     /// <summary>
     /// 
     /// </summary>

--- a/Ekom/Ekom.Core/Ekom/Controllers/EkomOrderController.cs
+++ b/Ekom/Ekom.Core/Ekom/Controllers/EkomOrderController.cs
@@ -126,6 +126,38 @@ public partial class EkomOrderController : ControllerBase
 
     }
 
+    /// <summary>
+    /// Add a giftcard to the current order.
+    /// </summary>
+    [HttpPost]
+    [Route("giftcards")]
+    public async Task<IActionResult> AddGiftcard([FromBody] GiftcardRequest request, CancellationToken ct = default)
+    {
+        if (request == null || request.Giftcard == null)
+        {
+            return BadRequest();
+        }
+
+        IOrderInfo orderInfo = await _order.AddGiftcardAsync(request.Giftcard, request.StoreAlias, ct: ct);
+
+        return Ok(orderInfo);
+    }
+
+    /// <summary>
+    /// Remove a giftcard from the current order by code.
+    /// </summary>
+    [HttpDelete]
+    [Route("giftcards/{code}")]
+    public async Task<IActionResult> RemoveGiftcard(
+        [FromRoute] string code,
+        [FromQuery] string storeAlias,
+        CancellationToken ct = default)
+    {
+        IOrderInfo orderInfo = await _order.RemoveGiftcardAsync(code, storeAlias, ct: ct);
+
+        return Ok(orderInfo);
+    }
+
     ///// <summary>
     ///// Get order
     ///// </summary>

--- a/Ekom/Ekom.Core/Ekom/Models/Giftcard.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Giftcard.cs
@@ -1,0 +1,13 @@
+namespace Ekom.Models;
+
+public sealed class Giftcard
+{
+    public decimal Amount { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public DateTime? UsedDate { get; set; }
+    public string? ClaimId { get; set; }
+    public string? TransactionId { get; set; }
+    public DateTime? ClaimDate { get; set; }
+    public bool Claimed { get; set; }
+    public DateTime? ValidUntil { get; set; }
+}

--- a/Ekom/Ekom.Core/Ekom/Models/IOrderInfo.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/IOrderInfo.cs
@@ -17,6 +17,8 @@ public interface IOrderInfo
     /// </summary>
     string Coupon { get; }
 
+    List<Giftcard> Giftcards { get; set; }
+
     /// <summary>
     /// Gets the uniqueId.
     /// </summary>

--- a/Ekom/Ekom.Core/Ekom/Models/OrderInfo.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderInfo.cs
@@ -48,6 +48,7 @@ public class OrderInfo : IOrderInfo
             CustomerInformation = CreateCustomerInformationFromJson(orderInfoJObject);
             Consent = CreateConsentFromJson(orderInfoJObject);
             Tracking = CreateTrackingFromJson(orderInfoJObject);
+            Giftcards = orderInfoJObject[nameof(Giftcards)]?.ToObject<List<Giftcard>>() ?? new List<Giftcard>();
             Discount = CreateOrderedDiscountFromJson(orderInfoJObject[nameof(Discount)]);
             Coupon = orderInfoJObject[nameof(Coupon)]?.ToObject<string>();
             _hangfireJobs = orderInfoJObject[nameof(HangfireJobs)]?.ToObject<List<string>>();
@@ -58,6 +59,7 @@ public class OrderInfo : IOrderInfo
     public OrderedDiscount Discount { get; internal set; }
     /// <inheritdoc />
     public string Coupon { get; internal set; }
+    public List<Giftcard> Giftcards { get; set; } = new List<Giftcard>();
 
     /// <inheritdoc />
     public Guid UniqueId
@@ -245,7 +247,7 @@ public class OrderInfo : IOrderInfo
             if (ShippingProvider != null) amount += ShippingProvider.Price.WithoutVat.Value;
             if (PaymentProvider != null) amount += PaymentProvider.Price.WithoutVat.Value;
 
-            return new CalculatedPrice(amount, StoreInfo.Currency);
+            return new CalculatedPrice(Math.Max(0, amount - GetApplicableGiftcardAmount()), StoreInfo.Currency);
         }
     }
 
@@ -283,6 +285,21 @@ public class OrderInfo : IOrderInfo
 
             return new CalculatedPrice(amount, StoreInfo.Currency);
         }
+    }
+
+    private decimal GetApplicableGiftcardAmount()
+    {
+        return Giftcards
+            .Where(IsGiftcardApplicable)
+            .Sum(giftcard => giftcard.Amount);
+    }
+
+    private static bool IsGiftcardApplicable(Giftcard giftcard)
+    {
+        return giftcard.Amount > 0
+            && (giftcard.Claimed
+                || !giftcard.ValidUntil.HasValue
+                || giftcard.ValidUntil.Value.ToUniversalTime() > DateTime.UtcNow);
     }
 
     public ICalculatedPrice ProductDiscountAmountWithOutVat
@@ -328,7 +345,7 @@ public class OrderInfo : IOrderInfo
                 amount += PaymentProvider.Price.Value;
             }
 
-            return new CalculatedPrice(amount, StoreInfo.Currency);
+            return new CalculatedPrice(Math.Max(0, amount - GetApplicableGiftcardAmount()), StoreInfo.Currency);
         }
     }
 

--- a/Ekom/Ekom.Core/Ekom/Models/OrderRequest.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderRequest.cs
@@ -27,3 +27,9 @@ public class CouponRequest
     public required string coupon { get; set; }
     public string storeAlias { get; set; } = string.Empty;
 }
+
+public sealed class GiftcardRequest
+{
+    public required Giftcard Giftcard { get; set; }
+    public required string StoreAlias { get; set; }
+}

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -625,6 +625,112 @@ partial class OrderService
         return null;
     }
 
+    public async Task<OrderInfo> AddGiftcardAsync(
+        Giftcard giftcard,
+        string storeAlias,
+        OrderSettings? settings = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(giftcard);
+
+        if (string.IsNullOrWhiteSpace(giftcard.Code))
+        {
+            throw new ArgumentException("Giftcard code is required", nameof(giftcard));
+        }
+
+        if (giftcard.Amount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(giftcard), "Giftcard amount must be greater than zero");
+        }
+
+        settings ??= new OrderSettings();
+        OrderInfo? orderInfo = settings.OrderInfo as OrderInfo
+            ?? await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
+        if (orderInfo == null)
+        {
+            throw new OrderInfoNotFoundException();
+        }
+
+        SemaphoreSlim semaphore = GetOrderLock(orderInfo);
+        if (!settings.IsEventHandler)
+        {
+            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+        }
+
+        try
+        {
+            if (orderInfo.Giftcards.Any(existingGiftcard => string.Equals(
+                existingGiftcard.Code,
+                giftcard.Code,
+                StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new ArgumentException("Giftcard code is already applied", nameof(giftcard));
+            }
+
+            orderInfo.Giftcards.Add(giftcard);
+
+            return await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (!settings.IsEventHandler)
+            {
+                semaphore.Release();
+            }
+        }
+    }
+
+    public async Task<OrderInfo> RemoveGiftcardAsync(
+        string code,
+        string storeAlias,
+        OrderSettings? settings = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            throw new ArgumentException("Giftcard code is required", nameof(code));
+        }
+
+        settings ??= new OrderSettings();
+        OrderInfo? orderInfo = settings.OrderInfo as OrderInfo
+            ?? await GetOrderAsync(storeAlias, ct).ConfigureAwait(false);
+        if (orderInfo == null)
+        {
+            throw new OrderInfoNotFoundException();
+        }
+
+        SemaphoreSlim semaphore = GetOrderLock(orderInfo);
+        if (!settings.IsEventHandler)
+        {
+            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+        }
+
+        try
+        {
+            Giftcard? giftcard = orderInfo.Giftcards.FirstOrDefault(existingGiftcard => string.Equals(
+                existingGiftcard.Code,
+                code,
+                StringComparison.OrdinalIgnoreCase));
+            if (giftcard == null)
+            {
+                throw new ArgumentException("Giftcard code is not applied to the order", nameof(code));
+            }
+
+            orderInfo.Giftcards.Remove(giftcard);
+
+            return await UpdateOrderAndOrderInfoAsync(orderInfo, settings.FireOnOrderUpdatedEvent, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            if (!settings.IsEventHandler)
+            {
+                semaphore.Release();
+            }
+        }
+    }
+
     public async Task UpdatePaidDateAsync(Guid uniqueId, CancellationToken ct)
     {
         // ToDo: Lock

--- a/Ekom/Tests/Ekom.Tests/Tests/OrderInfoTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/OrderInfoTests.cs
@@ -156,6 +156,153 @@ public class OrderInfoTests
         Assert.Null(discount);
     }
 
+    [Fact]
+    public void Constructor_DeserializesGiftcards()
+    {
+        var validUntil = DateTime.UtcNow.AddDays(1);
+        var usedDate = DateTime.UtcNow.AddDays(-1);
+        var claimDate = DateTime.UtcNow;
+        var orderData = new OrderData
+        {
+            OrderInfo = new JObject
+            {
+                [nameof(OrderInfo.Giftcards)] = new JArray
+                {
+                    new JObject
+                    {
+                        [nameof(Giftcard.Amount)] = 25m,
+                        [nameof(Giftcard.Code)] = "giftcard-code",
+                        [nameof(Giftcard.UsedDate)] = usedDate,
+                        [nameof(Giftcard.ClaimId)] = "claim-id",
+                        [nameof(Giftcard.TransactionId)] = "transaction-id",
+                        [nameof(Giftcard.ClaimDate)] = claimDate,
+                        [nameof(Giftcard.Claimed)] = true,
+                        [nameof(Giftcard.ValidUntil)] = validUntil,
+                    },
+                    new JObject
+                    {
+                        [nameof(Giftcard.Amount)] = 10m,
+                        [nameof(Giftcard.Code)] = "second-giftcard-code",
+                    },
+                },
+                [nameof(OrderInfo.OrderLines)] = new JArray(),
+            }.ToString(),
+        };
+
+        var orderInfo = new OrderInfo(orderData);
+
+        Assert.Equal(2, orderInfo.Giftcards.Count);
+        Giftcard giftcard = orderInfo.Giftcards[0];
+        Assert.Equal(25m, giftcard.Amount);
+        Assert.Equal("giftcard-code", giftcard.Code);
+        Assert.Equal(usedDate, giftcard.UsedDate);
+        Assert.Equal("claim-id", giftcard.ClaimId);
+        Assert.Equal("transaction-id", giftcard.TransactionId);
+        Assert.Equal(claimDate, giftcard.ClaimDate);
+        Assert.True(giftcard.Claimed);
+        Assert.Equal(validUntil, giftcard.ValidUntil);
+    }
+
+    [Fact]
+    public void Giftcards_ReducePayableTotalsWhenValid()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var orderInfo = CreateOrderInfoWithPaymentAmount(100m);
+        orderInfo.Giftcards =
+        [
+            new Giftcard { Amount = 25m, Code = "giftcard-code", ValidUntil = DateTime.UtcNow.AddDays(1) },
+            new Giftcard { Amount = 10m, Code = "second-giftcard-code" },
+        ];
+
+        Assert.Equal(65m, orderInfo.ChargedAmount.Value);
+        Assert.Equal(65m, orderInfo.GrandTotal.Value);
+        Assert.Equal(65m, orderInfo.GrandTotalWithOutVat.Value);
+    }
+
+    [Fact]
+    public void UnclaimedGiftcards_DoNotReducePayableTotalsWhenExpired()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var orderInfo = CreateOrderInfoWithPaymentAmount(100m);
+        orderInfo.Giftcards =
+        [
+            new Giftcard { Amount = 25m, Code = "giftcard-code", ValidUntil = DateTime.UtcNow.AddTicks(-1) },
+            new Giftcard { Amount = 10m, Code = "second-giftcard-code", ValidUntil = DateTime.UtcNow.AddTicks(-1) },
+        ];
+
+        Assert.Equal(100m, orderInfo.ChargedAmount.Value);
+        Assert.Equal(100m, orderInfo.GrandTotal.Value);
+        Assert.Equal(100m, orderInfo.GrandTotalWithOutVat.Value);
+    }
+
+    [Fact]
+    public void ClaimedGiftcards_ReducePayableTotalsAfterValidUntil()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var orderInfo = CreateOrderInfoWithPaymentAmount(100m);
+        orderInfo.Giftcards =
+        [
+            new Giftcard { Amount = 25m, Code = "giftcard-code", Claimed = true, ValidUntil = DateTime.UtcNow.AddTicks(-1) },
+            new Giftcard { Amount = 10m, Code = "second-giftcard-code", Claimed = true, ValidUntil = DateTime.UtcNow.AddTicks(-1) },
+        ];
+
+        Assert.Equal(65m, orderInfo.ChargedAmount.Value);
+        Assert.Equal(65m, orderInfo.GrandTotal.Value);
+        Assert.Equal(65m, orderInfo.GrandTotalWithOutVat.Value);
+    }
+
+    [Fact]
+    public void Giftcards_WithoutExpiryCannotReducePayableTotalsBelowZero()
+    {
+        using var configurationScope = new ConfigurationScope();
+        var orderInfo = CreateOrderInfoWithPaymentAmount(100m);
+        orderInfo.Giftcards =
+        [
+            new Giftcard { Amount = 100m, Code = "giftcard-code" },
+            new Giftcard { Amount = 50m, Code = "second-giftcard-code" },
+        ];
+
+        Assert.Equal(0m, orderInfo.ChargedAmount.Value);
+        Assert.Equal(0m, orderInfo.GrandTotal.Value);
+        Assert.Equal(0m, orderInfo.GrandTotalWithOutVat.Value);
+    }
+
+    private static OrderInfo CreateOrderInfoWithPaymentAmount(decimal amount)
+    {
+        var currency = new CurrencyModel
+        {
+            CurrencyFormat = "C",
+            CurrencyValue = "en-US",
+        };
+        var storeInfo = new StoreInfo(
+            Guid.NewGuid(),
+            currency,
+            [currency],
+            "en-US",
+            "Store",
+            vatIncludedInPrice: true,
+            vat: 0,
+            applyVatOnShipping: false);
+        var paymentProvider = new JObject
+        {
+            ["Id"] = 1,
+            ["Key"] = Guid.NewGuid(),
+            ["Title"] = "Test payment",
+            ["Price"] = JToken.FromObject(new Price(amount, currency, 0, vatIncludedInPrice: true)),
+        };
+        var orderData = new OrderData
+        {
+            OrderInfo = new JObject
+            {
+                [nameof(OrderInfo.StoreInfo)] = JToken.FromObject(storeInfo),
+                [nameof(OrderInfo.OrderLines)] = new JArray(),
+                [nameof(OrderInfo.PaymentProvider)] = paymentProvider,
+            }.ToString(),
+        };
+
+        return new OrderInfo(orderData);
+    }
+
     private static OrderedDiscount? CreateOrderedDiscountFromJson(JToken discountJson)
     {
         MethodInfo method = typeof(OrderInfo).GetMethod(


### PR DESCRIPTION
## Summary
- add persisted multi-giftcard order data with claim and validity details
- apply eligible giftcard amounts to payable order totals
- add API and HTTP endpoints to add or remove giftcards by code
- include Bruno requests for giftcard order operations

## Test Plan
- `dotnet build "Ekom/Ekom.Core/Ekom/Ekom.csproj" --no-restore`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~OrderInfoTests"`