### PR TITLE
fix(algolia): aggregate variant facets on products

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaProductIndexMapperTests.cs
@@ -409,6 +409,29 @@ public class AlgoliaProductIndexMapperTests
     }
 
     [Fact]
+    public void Maps_Variant_Facet_Attributes_To_Product_Record_When_Variants_Are_Disabled()
+    {
+        var blackSmall = CreateVariant(title: "Small", variantGroup: CreateVariantGroup("Black").Object);
+        var blackLarge = CreateVariant(title: "Large", variantGroup: CreateVariantGroup("Black").Object);
+        var whiteLarge = CreateVariant(title: "Large", variantGroup: CreateVariantGroup("White").Object);
+        var mapper = CreateMapper(
+            indexVariants: false,
+            variantFacetAttributes: new Dictionary<string, string>
+            {
+                ["color"] = "variantGroup:title",
+                ["size"] = "variant:title",
+            });
+        var product = CreateProduct(variants: [blackSmall.Object, blackLarge.Object, whiteLarge.Object]);
+
+        var records = mapper.MapRecords(product.Object, CreateStore(), "products");
+
+        var record = Assert.Single(records);
+        var attributes = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(record.Data["attributes"]);
+        Assert.Equal(["Black", "White"], Assert.IsAssignableFrom<IEnumerable<object?>>(attributes["color"]));
+        Assert.Equal(["Small", "Large"], Assert.IsAssignableFrom<IEnumerable<object?>>(attributes["size"]));
+    }
+
+    [Fact]
     public void Maps_One_Level_Variant_Properties_As_Facet_Attributes()
     {
         var variant = CreateVariant(properties: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)

--- a/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
+++ b/Plugins/Ekom.Algolia/Mappers/ProductIndexMapper.cs
@@ -39,6 +39,10 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         var categoryLevels = BuildCategoryLevels(product, locale);
         var nodeName = GetNodeName(product);
         var facetAttributes = BuildProductFacetAttributes(product, store, baseIndexName);
+        if (!_options.Indexing.Variants)
+        {
+            AddVariantFacetAttributes(product, store, baseIndexName, facetAttributes);
+        }
         var title = ApplyBuiltInTextTransform(
             "title",
             GetLocalizedValue(product, "title", product.Title, locale),
@@ -335,6 +339,44 @@ internal sealed class ProductIndexMapper : IAlgoliaProductIndexMapper
         }
 
         return attributes.Values.ToList();
+    }
+
+    private void AddVariantFacetAttributes(
+        IProduct product,
+        AlgoliaResolvedStore store,
+        string baseIndexName,
+        Dictionary<string, object?> attributes)
+    {
+        foreach (var configuredAttribute in BuildVariantFacetAttributes())
+        {
+            var values = product.AllVariants
+                .Select(variant => ResolveVariantFacetValue(variant, store, configuredAttribute))
+                .Select(value => ConvertProperty(
+                    new AlgoliaProductFieldContext(product, store, configuredAttribute.OutputAlias, baseIndexName),
+                    value))
+                .Select(value => ApplyFacetTransform(value, configuredAttribute.Field.Transform))
+                .SelectMany(FlattenFacetValue)
+                .Where(value => !IsEmptyValue(value))
+                .Distinct()
+                .ToList();
+
+            if (values.Count > 0)
+            {
+                attributes[configuredAttribute.OutputAlias] = values;
+            }
+        }
+
+        RemoveEmptyValues(attributes);
+    }
+
+    private static IEnumerable<object?> FlattenFacetValue(object? value)
+    {
+        if (value is not System.Collections.IEnumerable enumerable || value is string)
+        {
+            return [value];
+        }
+
+        return enumerable.Cast<object?>();
     }
 
     private static Dictionary<string, ConfiguredField> BuildConfiguredFields(IEnumerable<string> fields)

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -614,7 +614,7 @@ This produces values such as:
 }
 ```
 
-When variant indexing is enabled, `Indexing:VariantFacetAttributes` maps output facet names to properties on either the variant group or variant node. This supports two-level variants such as color groups containing size variants:
+`Indexing:VariantFacetAttributes` maps output facet names to properties on either the variant group or variant node. When variant indexing is disabled, each configured facet is added to the product record as a distinct array of values from all variants. When variant indexing is enabled, facets are stored on individual variant records to support combination-safe filtering. This supports two-level variants such as color groups containing size variants:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- aggregate configured variant facet values on product records when variant indexing is disabled
- preserve per-variant facet behavior when variant indexing is enabled
- document the indexing-mode behavior and add aggregation coverage

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaProductIndexMapperTests"`