### PR TITLE
fix(import): filter media descendant pages

### DIFF
--- a/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Services/ImportImageService.cs
@@ -136,7 +136,11 @@ public class ImportMediaService
         if (rootMedia == null)
             return new List<IMedia>();
 
-        const int pageSize = 1000;
+        const int pageSize = 100;
+        var imageTypeId = GetMediaTypeId(MediaTypes.Image);
+        var fileTypeId = GetMediaTypeId(MediaTypes.File);
+        var filter = new Query<IMedia>(_scopeProvider.SqlContext)
+            .Where(media => !media.Trashed && (media.ContentTypeId == imageTypeId || media.ContentTypeId == fileTypeId));
         var results = new List<IMedia>();
         long total;
         var pageIndex = 0;
@@ -147,12 +151,10 @@ public class ImportMediaService
                 rootMedia.Id,
                 pageIndex,
                 pageSize,
-                out total).ToList();
+                out total,
+                filter).ToList();
 
-            results.AddRange(page.Where(x =>
-                !x.Trashed &&
-                (x.ContentType.Alias == Constants.Conventions.MediaTypes.Image ||
-                 x.ContentType.Alias == Constants.Conventions.MediaTypes.File)));
+            results.AddRange(page);
 
             pageIndex++;
         }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportMediaService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportMediaService.cs
@@ -90,18 +90,19 @@ public class ImportMediaService
 
     public List<IMedia> GetUmbracoMediaFiles(IMedia rootMedia)
     {
-        const int pageSize = 1000;
+        const int pageSize = 100;
+        var imageTypeId = GetMediaTypeId(MediaTypes.Image);
+        var fileTypeId = GetMediaTypeId(MediaTypes.File);
+        var filter = new Query<IMedia>(_scopeProvider.SqlContext)
+            .Where(media => !media.Trashed && (media.ContentTypeId == imageTypeId || media.ContentTypeId == fileTypeId));
         var results = new List<IMedia>();
         var pageIndex = 0;
 
         do
         {
-            var page = _mediaService.GetPagedDescendants(rootMedia.Id, pageIndex, pageSize, out var total).ToList();
+            var page = _mediaService.GetPagedDescendants(rootMedia.Id, pageIndex, pageSize, out var total, filter).ToList();
 
-            results.AddRange(page.Where(x =>
-                !x.Trashed
-                && (x.ContentType.Alias == Constants.Conventions.MediaTypes.Image
-                    || x.ContentType.Alias == Constants.Conventions.MediaTypes.File)));
+            results.AddRange(page);
 
             pageIndex++;
 


### PR DESCRIPTION
## Summary
- Filter media descendant pages to non-trashed image and file media in the database.
- Reduce descendant page size to 100 items in Umbraco 10 and 17.

## Test Plan
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`