### PR TITLE
fix(algolia): send conversion object data as arrays

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaInsightsClientTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaInsightsClientTests.cs
@@ -1,0 +1,63 @@
+using Ekom.Algolia.Models.Events;
+using Ekom.Algolia.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net;
+using System.Text.Json;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaInsightsClientTests
+{
+    [Theory]
+    [InlineData("Added To Cart")]
+    [InlineData("Started Checkout")]
+    [InlineData("Purchased")]
+    public async Task Sends_Conversion_Object_Data_As_Array(string eventName)
+    {
+        using var handler = new CapturingHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://insights.algolia.io/1/")
+        };
+        var client = new AlgoliaInsightsClient(httpClient, NullLogger<AlgoliaInsightsClient>.Instance);
+        var evt = new AlgoliaInsightsEvent
+        {
+            EventType = "conversion",
+            EventName = eventName,
+            Index = "products",
+            UserToken = "user-token",
+            ObjectIds = ["product-1"],
+            ObjectData =
+            [
+                new Dictionary<string, object?>
+                {
+                    ["value"] = 10m,
+                    ["currency"] = "USD"
+                }
+            ]
+        };
+
+        await client.SendEventsAsync([evt]);
+
+        using var document = JsonDocument.Parse(handler.RequestBody);
+        var objectData = document.RootElement
+            .GetProperty("events")[0]
+            .GetProperty("objectData");
+
+        Assert.Equal(JsonValueKind.Array, objectData.ValueKind);
+        Assert.Equal(10m, objectData[0].GetProperty("value").GetDecimal());
+        Assert.Equal("USD", objectData[0].GetProperty("currency").GetString());
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string RequestBody { get; private set; } = string.Empty;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestBody = await request.Content!.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+}

--- a/Plugins/Ekom.Algolia/Models/Events/AlgoliaInsightsEvent.cs
+++ b/Plugins/Ekom.Algolia/Models/Events/AlgoliaInsightsEvent.cs
@@ -10,5 +10,5 @@ public sealed class AlgoliaInsightsEvent
 
     public string? QueryId { get; init; }
     public DateTimeOffset? Timestamp { get; init; }
-    public IReadOnlyDictionary<string, object?>? ObjectData { get; init; }
+    public IReadOnlyList<IReadOnlyDictionary<string, object?>>? ObjectData { get; init; }
 }

--- a/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
@@ -85,12 +85,15 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             Index = indexName,
             UserToken = userToken,
             ObjectIds = new[] { orderLine.ProductKey.ToString() },
-            ObjectData = new Dictionary<string, object?>
-            {
-                ["quantity"] = orderLine.Quantity,
-                ["value"] = orderLine.Amount.Value,
-                ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-            }
+            ObjectData =
+            [
+                new Dictionary<string, object?>
+                {
+                    ["quantity"] = orderLine.Quantity,
+                    ["value"] = orderLine.Amount.Value,
+                    ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
+                }
+            ]
         };
 
         return _insightsClient.SendEventsAsync(new[] { evt }, ct);
@@ -129,11 +132,14 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             Index = indexName,
             UserToken = userToken,
             ObjectIds = objectIds,
-            ObjectData = new Dictionary<string, object?>
-            {
-                ["value"] = orderInfo.ChargedAmount.Value,
-                ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-            }
+            ObjectData =
+            [
+                new Dictionary<string, object?>
+                {
+                    ["value"] = orderInfo.ChargedAmount.Value,
+                    ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
+                }
+            ]
         };
 
         return _insightsClient.SendEventsAsync(new[] { evt }, ct);
@@ -172,11 +178,14 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             Index = indexName,
             UserToken = userToken,
             ObjectIds = objectIds,
-            ObjectData = new Dictionary<string, object?>
-            {
-                ["value"] = orderInfo.ChargedAmount.Value,
-                ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-            }
+            ObjectData =
+            [
+                new Dictionary<string, object?>
+                {
+                    ["value"] = orderInfo.ChargedAmount.Value,
+                    ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
+                }
+            ]
         };
 
         return _insightsClient.SendEventsAsync(new[] { evt }, ct);

--- a/Plugins/Ekom.Algolia/Services/AlgoliaInsightsClient.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaInsightsClient.cs
@@ -74,9 +74,15 @@ internal sealed class AlgoliaInsightsClient : IAlgoliaInsightsClient
 
         if (evt.ObjectData != null && evt.ObjectData.Count > 0)
         {
-            var data = new JsonObject();
-            foreach (var kvp in evt.ObjectData)
-                data[kvp.Key] = JsonValue.Create(kvp.Value);
+            var data = new JsonArray();
+            foreach (var objectData in evt.ObjectData)
+            {
+                var item = new JsonObject();
+                foreach (var kvp in objectData)
+                    item[kvp.Key] = JsonValue.Create(kvp.Value);
+
+                data.Add(item);
+            }
             json["objectData"] = data;
         }
 


### PR DESCRIPTION
## Summary
- serialize Algolia conversion event object data as an array
- update cart, checkout, and purchase event payloads to match the Insights API contract
- add serialization coverage for each conversion event type

## Test Plan
- dotnet test \"Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj\" --filter \"FullyQualifiedName~AlgoliaInsightsClientTests\" --no-restore
- dotnet build \"Plugins/Ekom.Algolia/Ekom.Algolia.csproj\" --no-restore