### PR TITLE
feat(algolia): correlate insights with order lines

### DIFF
--- a/Ekom/Ekom.Core/Ekom/API/Settings/OrderSettings.cs
+++ b/Ekom/Ekom.Core/Ekom/API/Settings/OrderSettings.cs
@@ -46,6 +46,7 @@ public class OrderSettings
 
     public OrderDynamicRequest OrderDynamicRequest { get; set; }
     public Dictionary<string, string> CustomData { get; set; } = [];
+    public string? AlgoliaQueryId { get; set; }
     public OrderConsent? Consent { get; set; }
     public OrderTracking? Tracking { get; set; }
 }

--- a/Ekom/Ekom.Core/Ekom/Controllers/EkomOrderController.cs
+++ b/Ekom/Ekom.Core/Ekom/Controllers/EkomOrderController.cs
@@ -109,6 +109,8 @@ public partial class EkomOrderController : ControllerBase
             }
         }
 
+        customData.Remove("algoliaQueryId");
+
         IOrderInfo orderInfo = await _order.AddOrderLineAsync(
             request.ProductId,
             request.Quantity,
@@ -118,6 +120,7 @@ public partial class EkomOrderController : ControllerBase
                 OrderAction = request.Action ?? OrderAction.AddOrUpdate,
                 VariantKey = request.VariantId,
                 CustomData = customData,
+                AlgoliaQueryId = request.AlgoliaQueryId,
                 Consent = request.Consent,
                 Tracking = request.Tracking
             }, ct);

--- a/Ekom/Ekom.Core/Ekom/Events/OrderEvents.cs
+++ b/Ekom/Ekom.Core/Ekom/Events/OrderEvents.cs
@@ -185,6 +185,7 @@ public sealed class AddedOrderlineEventArgs : EventArgs
 {
     public required OrderInfo OrderInfo { get; set; }
     public required OrderLine OrderLine { get; set; }
+    public required OrderSettings Settings { get; set; }
 }
 
 public sealed class RemovedOrderlineEventArgs : EventArgs

--- a/Ekom/Ekom.Core/Ekom/Models/OrderRequest.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderRequest.cs
@@ -10,6 +10,7 @@ public class OrderRequest
     public decimal Quantity { get; set; } = 1;
     [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
     public OrderAction? Action { get; set; } = OrderAction.AddOrUpdate;
+    public string? AlgoliaQueryId { get; set; }
     public OrderConsent? Consent { get; set; }
     public OrderTracking? Tracking { get; set; }
 }

--- a/Ekom/Ekom.Core/Ekom/Models/OrderTracking.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderTracking.cs
@@ -16,6 +16,7 @@ public sealed class OrderTracking
     public string? CaptureMethod { get; set; }
     public Ga4OrderTracking Ga4 { get; set; } = new();
     public MetaOrderTracking Meta { get; set; } = new();
+    public AlgoliaOrderTracking Algolia { get; set; } = new();
 
     public bool HasData()
         => !string.IsNullOrWhiteSpace(Source)
@@ -27,7 +28,8 @@ public sealed class OrderTracking
         || !string.IsNullOrWhiteSpace(LandingUrl)
         || !string.IsNullOrWhiteSpace(Referrer)
         || Ga4.HasData()
-        || Meta.HasData();
+        || Meta.HasData()
+        || Algolia?.HasData() == true;
 
     public OrderTracking Clone()
         => new()
@@ -45,7 +47,8 @@ public sealed class OrderTracking
             HasCookieSupport = HasCookieSupport,
             CaptureMethod = CaptureMethod,
             Ga4 = Ga4.Clone(),
-            Meta = Meta.Clone()
+            Meta = Meta.Clone(),
+            Algolia = Algolia?.Clone() ?? new()
         };
 }
 
@@ -86,5 +89,53 @@ public sealed class MetaOrderTracking
             Fbp = Fbp,
             Fbc = Fbc,
             Data = new Dictionary<string, string?>(Data, StringComparer.OrdinalIgnoreCase)
+        };
+}
+
+public sealed class AlgoliaOrderTracking
+{
+    public string? UserToken { get; set; }
+    public List<AlgoliaOrderLineTracking> Lines { get; set; } = [];
+
+    public bool HasData()
+        => !string.IsNullOrWhiteSpace(UserToken)
+        || Lines.Count > 0;
+
+    public void AddLine(Guid orderLineKey, string? queryId)
+    {
+        if (string.IsNullOrWhiteSpace(queryId) || Lines.Any(line => line.OrderLineKey == orderLineKey))
+            return;
+
+        Lines.Add(new AlgoliaOrderLineTracking
+        {
+            OrderLineKey = orderLineKey,
+            QueryId = queryId
+        });
+    }
+
+    public void RemoveLine(Guid orderLineKey)
+        => Lines.RemoveAll(line => line.OrderLineKey == orderLineKey);
+
+    public string? GetQueryId(Guid orderLineKey)
+        => Lines.FirstOrDefault(line => line.OrderLineKey == orderLineKey)?.QueryId;
+
+    public AlgoliaOrderTracking Clone()
+        => new()
+        {
+            UserToken = UserToken,
+            Lines = Lines.Select(line => line.Clone()).ToList()
+        };
+}
+
+public sealed class AlgoliaOrderLineTracking
+{
+    public Guid OrderLineKey { get; set; }
+    public string QueryId { get; set; } = string.Empty;
+
+    public AlgoliaOrderLineTracking Clone()
+        => new()
+        {
+            OrderLineKey = OrderLineKey,
+            QueryId = QueryId
         };
 }

--- a/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/OrderService.cs
@@ -1399,7 +1399,8 @@ partial class OrderService
             var addedEventArgs = new AddedOrderlineEventArgs()
             {
                 OrderInfo = orderInfo,
-                OrderLine = orderLine
+                OrderLine = orderLine,
+                Settings = settings
             };
 
             if (settings.FireEvents)

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/orders-section-view.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/orders-section-view.element.js
@@ -1,9 +1,9 @@
-var V = Object.defineProperty;
-var U = (r, d, e) => d in r ? V(r, d, { enumerable: !0, configurable: !0, writable: !0, value: e }) : r[d] = e;
-var n = (r, d, e) => U(r, typeof d != "symbol" ? d + "" : d, e);
-import { UmbElementMixin as B } from "@umbraco-cms/backoffice/element-api";
-import { UMB_NOTIFICATION_CONTEXT as K } from "@umbraco-cms/backoffice/notification";
-import { E as R, m as o, a as z, e as s, g as f, f as b, p as H, d as g, b as Z } from "./manager-shared.js";
+var U = Object.defineProperty;
+var B = (r, o, e) => o in r ? U(r, o, { enumerable: !0, configurable: !0, writable: !0, value: e }) : r[o] = e;
+var n = (r, o, e) => B(r, typeof o != "symbol" ? o + "" : o, e);
+import { UmbElementMixin as K } from "@umbraco-cms/backoffice/element-api";
+import { UMB_NOTIFICATION_CONTEXT as R } from "@umbraco-cms/backoffice/notification";
+import { E as z, m as d, a as H, e as s, g as f, f as y, p as Z, d as O, b as Q } from "./manager-shared.js";
 const W = [
   { key: "customerName", label: "Name", property: "name" },
   { key: "customerEmail", label: "Email", property: "email" },
@@ -13,7 +13,7 @@ const W = [
   { key: "customerCountry", label: "Country", property: "country" },
   { key: "customerZipCode", label: "Zipcode", property: "zipCode" },
   { key: "customerPhone", label: "Phone", property: "phone" }
-], Q = [
+], G = [
   { key: "shippingName", label: "Name", property: "name" },
   { key: "shippingEmail", label: "Email", property: "email" },
   { key: "shippingAddress", label: "Address", property: "address" },
@@ -23,10 +23,10 @@ const W = [
   { key: "shippingZipCode", label: "Zipcode", property: "zipCode" },
   { key: "shippingPhone", label: "Phone", property: "phone" }
 ];
-class G extends B(HTMLElement) {
+class Y extends K(HTMLElement) {
   constructor() {
     super(...arguments);
-    n(this, "api", new R());
+    n(this, "api", new z());
     n(this, "notificationContext");
     n(this, "result", { orders: [], count: 0, totalPages: 0 });
     n(this, "page", 1);
@@ -70,7 +70,7 @@ class G extends B(HTMLElement) {
     });
   }
   connectedCallback() {
-    super.connectedCallback(), this.consumeContext(K, (e) => {
+    super.connectedCallback(), this.consumeContext(R, (e) => {
       this.notificationContext = e;
     }), document.addEventListener("keydown", this.handleKeyDown), this.render(), this.initialize();
   }
@@ -83,39 +83,39 @@ class G extends B(HTMLElement) {
         this.api.statusList(),
         this.api.stores()
       ]);
-      o.statusList = e || [], o.stores = t || [], !o.filters.store && o.stores.length && (o.filters.store = o.stores[0].alias), await this.loadPaymentProviders(), await this.loadOrders();
+      d.statusList = e || [], d.stores = t || [], !d.filters.store && d.stores.length && (d.filters.store = d.stores[0].alias), await this.loadPaymentProviders(), await this.loadOrders();
     } catch (e) {
-      this.error = h(e, "Error loading Ekom Manager."), this.loading = !1, this.render();
+      this.error = v(e, "Error loading Ekom Manager."), this.loading = !1, this.render();
     }
   }
   async loadPaymentProviders(e = !1) {
-    if (!o.filters.store) {
-      o.paymentProviders = [];
+    if (!d.filters.store) {
+      d.paymentProviders = [];
       return;
     }
-    o.paymentProviders = await this.api.paymentProviders(o.filters.store), e && (o.filters.paymentProvider = ""), o.filters.paymentProvider && (o.paymentProviders.some((i) => i.key === o.filters.paymentProvider) || (o.filters.paymentProvider = ""));
+    d.paymentProviders = await this.api.paymentProviders(d.filters.store), e && (d.filters.paymentProvider = ""), d.filters.paymentProvider && (d.paymentProviders.some((i) => i.key === d.filters.paymentProvider) || (d.filters.paymentProvider = ""));
   }
   async loadOrders() {
-    if (!o.filters.store) {
+    if (!d.filters.store) {
       this.loading = !1, this.result = { orders: [], count: 0, totalPages: 0 }, this.render();
       return;
     }
     this.loading = !0, this.error = "", this.render();
     try {
-      const e = await this.api.searchOrders(o.filters, this.page);
+      const e = await this.api.searchOrders(d.filters, this.page);
       this.result = {
         ...e,
         orders: e.orders || []
       };
     } catch (e) {
-      this.error = h(e, "Error searching orders.");
+      this.error = v(e, "Error searching orders.");
     } finally {
       this.loading = !1, this.render();
     }
   }
   render() {
     this.innerHTML = `
-      <style>${z}</style>
+      <style>${H}</style>
       <section class="ekmManager">
         <div class="ekmManager__body">
           ${this.renderOrders()}
@@ -147,7 +147,7 @@ class G extends B(HTMLElement) {
     `;
   }
   renderToolbar() {
-    const e = o.filters;
+    const e = d.filters;
     return `
       <div class="umb-sub-header">
         <div class="ekmManager__filters">
@@ -155,7 +155,7 @@ class G extends B(HTMLElement) {
             <select data-field="orderStatus">
               <option value="CompletedOrders" ${e.orderStatus === "CompletedOrders" ? "selected" : ""}>Completed Orders</option>
               <option value="AllOrders" ${e.orderStatus === "AllOrders" ? "selected" : ""}>All Orders</option>
-              ${o.statusList.map((t) => {
+              ${d.statusList.map((t) => {
       const i = f(t);
       return `<option value="${s(i)}" ${e.orderStatus === i ? "selected" : ""}>${s(t.label)}</option>`;
     }).join("")}
@@ -169,7 +169,7 @@ class G extends B(HTMLElement) {
           </label>
           <label class="ekmManager__filter">Store:
             <select data-field="store">
-              ${o.stores.map((t) => `<option value="${s(t.alias)}" ${e.store === t.alias ? "selected" : ""}>${s(t.title)}</option>`).join("")}
+              ${d.stores.map((t) => `<option value="${s(t.alias)}" ${e.store === t.alias ? "selected" : ""}>${s(t.title)}</option>`).join("")}
             </select>
           </label>
           <div class="ekmManager__search">
@@ -208,7 +208,7 @@ class G extends B(HTMLElement) {
         <div class="umb-table-cell" data-label="Order Number" title="${s(e.uniqueId)}">${s(e.referenceId)}</div>
         <div class="umb-table-cell" data-label="Status">
           <select data-action="change-row-status" data-order-id="${s(e.uniqueId)}">
-            ${o.statusList.map((t) => {
+            ${d.statusList.map((t) => {
       const i = f(t);
       return `<option value="${s(i)}" ${e.orderStatusCol === i ? "selected" : ""}>${s(t.label)}</option>`;
     }).join("")}
@@ -216,7 +216,7 @@ class G extends B(HTMLElement) {
         </div>
         <div class="umb-table-cell" data-label="Name">${s(e.customerName)}</div>
         <div class="umb-table-cell" data-label="Store">${s(e.storeAlias)}</div>
-        <div class="umb-table-cell" data-label="Created">${s(b(e.createDate))}</div>
+        <div class="umb-table-cell" data-label="Created">${s(y(e.createDate))}</div>
         <div class="umb-table-cell" data-label="Payment">${s(e.formattedTotal)}</div>
       </div>
     `;
@@ -225,7 +225,7 @@ class G extends B(HTMLElement) {
     return `
       <div class="pagination">
         <ul>
-          ${H(this.page, this.result.totalPages).map((e) => {
+          ${Z(this.page, this.result.totalPages).map((e) => {
       const t = Number(String(e).replace("...", ""));
       return `<li class="${t === this.page ? "active" : ""}"><button type="button" data-action="set-page" data-page="${t}" ${t === this.page ? "disabled" : ""}>${s(e)}</button></li>`;
     }).join("")}
@@ -237,7 +237,7 @@ class G extends B(HTMLElement) {
     return this.overlay === "filter" ? this.renderFilterOverlay() : this.overlay === "export" ? this.renderExportOverlay() : this.overlay === "order" && this.selectedOrder ? this.renderOrderOverlay(this.selectedOrder) : "";
   }
   renderFilterOverlay() {
-    const e = o.filters;
+    const e = d.filters;
     return `
       <div class="ekmOverlay">
         <div class="ekmOverlay__panel ekmOverlay__panel--small">
@@ -246,7 +246,7 @@ class G extends B(HTMLElement) {
             <label class="control-group">Payment provider:
               <select data-filter-field="paymentProvider">
                 <option value="">Select payment provider</option>
-                ${o.paymentProviders.map((t) => `<option value="${s(t.key)}" ${e.paymentProvider === t.key ? "selected" : ""}>${s(t.title)}</option>`).join("")}
+                ${d.paymentProviders.map((t) => `<option value="${s(t.key)}" ${e.paymentProvider === t.key ? "selected" : ""}>${s(t.title)}</option>`).join("")}
               </select>
             </label>
             ${this.renderFilterInput("productSku", "Product SKU:", "Exact SKU")}
@@ -265,7 +265,7 @@ class G extends B(HTMLElement) {
   renderFilterInput(e, t, i) {
     return `
       <label class="control-group">${s(t)}
-        <input type="text" data-filter-field="${s(e)}" value="${s(o.filters[e])}" placeholder="${s(i)}">
+        <input type="text" data-filter-field="${s(e)}" value="${s(d.filters[e])}" placeholder="${s(i)}">
       </label>
     `;
   }
@@ -300,17 +300,17 @@ class G extends B(HTMLElement) {
     `;
   }
   renderOrderDetails(e) {
-    var l, c, p, v;
-    const t = ((l = e.customerInformation) == null ? void 0 : l.customer) || {}, i = ((c = e.customerInformation) == null ? void 0 : c.shipping) || {}, a = this.getOrderStatusValue(e.orderStatus);
+    var l, u, p, h;
+    const t = ((l = e.customerInformation) == null ? void 0 : l.customer) || {}, i = ((u = e.customerInformation) == null ? void 0 : u.shipping) || {}, a = this.getOrderStatusValue(e.orderStatus);
     return `
       <div class="ekmOrder__header">
         <h1>Order number: ${s(e.referenceId)}</h1>
         <div class="ekmOrderStatusBar">
           <label class="ekmOrderStatusBar__status">Order Status:
             <select data-field="orderStatusOverlay">
-              ${o.statusList.map((y) => {
-      const u = f(y);
-      return `<option value="${s(u)}" ${a === u ? "selected" : ""}>${s(y.label)}</option>`;
+              ${d.statusList.map((b) => {
+      const c = f(b);
+      return `<option value="${s(c)}" ${a === c ? "selected" : ""}>${s(b.label)}</option>`;
     }).join("")}
             </select>
           </label>
@@ -319,15 +319,15 @@ class G extends B(HTMLElement) {
           <button type="button" class="btn-outline ekmOrderStatusBar__print" data-action="print-order">Print</button>
         </div>
         <p>UniqueId: ${s(e.uniqueId)}</p>
-        <p>Created date: ${s(b(e.createDate))}</p>
-        <p>Paid date: ${s(b(e.paidDate))}</p>
+        <p>Created date: ${s(y(e.createDate))}</p>
+        <p>Paid date: ${s(y(e.paidDate))}</p>
         <p>Store: ${s(((p = e.storeInfo) == null ? void 0 : p.alias) || e.storeAlias)}</p>
-        <p>Payment: <strong>${s((v = e.chargedAmount) == null ? void 0 : v.currencyString)}</strong></p>
+        <p>Payment: <strong>${s((h = e.chargedAmount) == null ? void 0 : h.currencyString)}</strong></p>
         ${this.renderOrderActions()}
       </div>
       <div class="ekmSplit">
         <div class="ekmSplit__column"><h4>Billing</h4><button type="button" class="btn-outline" data-action="open-customer-editor" style="margin-bottom:10px;">Edit customer information</button>${this.renderAddress(t)}${this.renderExtraProperties(t.properties, "customer")}</div>
-        <div class="ekmSplit__column"><h4>Shipping</h4>${X(i) ? `${this.renderAddress(i)}${this.renderExtraProperties(i.properties, "shipping")}` : '<p style="font-weight:bold">Same as billing address</p>'}</div>
+        <div class="ekmSplit__column"><h4>Shipping</h4>${ee(i) ? `${this.renderAddress(i)}${this.renderExtraProperties(i.properties, "shipping")}` : '<p style="font-weight:bold">Same as billing address</p>'}</div>
       </div>
       <div class="ekmSplit">
         <div class="ekmSplit__column">${this.renderProvider("Payment Method", e.paymentProvider, "custompayment")}</div>
@@ -340,7 +340,7 @@ class G extends B(HTMLElement) {
     `;
   }
   renderAddress(e) {
-    return ["name", "email", "address", "apartment", "city", "country", "zipCode", "phone"].filter((t) => e[t]).map((t) => `<p>${Y(t)}: ${s(g(e[t]))}</p>`).join("");
+    return ["name", "email", "address", "apartment", "city", "country", "zipCode", "phone"].filter((t) => e[t]).map((t) => `<p>${J(t)}: ${s(O(e[t]))}</p>`).join("");
   }
   renderExtraProperties(e, t) {
     const i = j(e, t);
@@ -351,37 +351,37 @@ class G extends B(HTMLElement) {
     return t ? `<h4>${s(e)}</h4><h4><strong>${s(t.title)}</strong></h4>${t.price ? `<p>Price: ${s((a = t.price.withVat) == null ? void 0 : a.currencyString)}</p>` : ""}${this.renderExtraProperties(t.customData, i)}` : "";
   }
   renderOrderLines(e) {
-    var i, a, l, c, p, v, y;
+    var i, a, l, u, p, h, b;
     return `
       <div style="align-items:center; display:flex; gap:10px; justify-content:space-between;"><h4>Order Details</h4><button type="button" class="btn-outline" data-action="open-order-line-editor">Add order line</button></div>
       <div class="umb-table">
         <div class="umb-table-head"><div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed">Product</div><div class="umb-table-cell">Quantity</div><div class="umb-table-cell">Unit Price (inc VAT)</div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">Discount</div><div class="umb-table-cell">Total (inc VAT)</div></div></div>
         <div class="umb-table-body">
-          ${(Array.isArray(e.orderLines) ? e.orderLines : []).map((u) => {
-      var O, $, S, k, w, E, L, x, _, C, A, I, P;
-      return `<div class="umb-table-row"><div class="umb-table-cell"><button type="button" class="btn-reset" data-action="remove-order-line" data-order-line-id="${s(u.key)}" data-product-title="${s((O = u.product) == null ? void 0 : O.title)}" ${this.removingOrderLineId === u.key ? "disabled" : ""} aria-label="Remove ${s(($ = u.product) == null ? void 0 : $.title)}" title="Remove order line">&#128465;</button></div><div class="umb-table-cell not-fixed">${s((S = u.product) == null ? void 0 : S.title)} (${s((k = u.product) == null ? void 0 : k.sku)})${u.variant ? `<small style="display:block; margin-top:3px;">${s(u.variant.title)} ${u.variant.sku ? `(${s(u.variant.sku)})` : ""}</small>` : ""}${ee(u)}</div><div class="umb-table-cell">${s(u.quantity)}</div><div class="umb-table-cell">${s((L = (E = (w = u.product) == null ? void 0 : w.price) == null ? void 0 : E.withVat) == null ? void 0 : L.currencyString)}</div><div class="umb-table-cell">${s((_ = (x = u.amount) == null ? void 0 : x.vat) == null ? void 0 : _.currencyString)}</div><div class="umb-table-cell">-${s((A = (C = u.amount) == null ? void 0 : C.discountAmount) == null ? void 0 : A.currencyString)}</div><div class="umb-table-cell"><strong>${s((P = (I = u.amount) == null ? void 0 : I.withVat) == null ? void 0 : P.currencyString)}</strong></div></div>`;
+          ${(Array.isArray(e.orderLines) ? e.orderLines : []).map((c) => {
+      var g, $, k, S, w, E, L, x, _, A, C, I, T;
+      return `<div class="umb-table-row"><div class="umb-table-cell"><button type="button" class="btn-reset" data-action="remove-order-line" data-order-line-id="${s(c.key)}" data-product-title="${s((g = c.product) == null ? void 0 : g.title)}" ${this.removingOrderLineId === c.key ? "disabled" : ""} aria-label="Remove ${s(($ = c.product) == null ? void 0 : $.title)}" title="Remove order line">&#128465;</button></div><div class="umb-table-cell not-fixed">${s((k = c.product) == null ? void 0 : k.title)} (${s((S = c.product) == null ? void 0 : S.sku)})${c.variant ? `<small style="display:block; margin-top:3px;">${s(c.variant.title)} ${c.variant.sku ? `(${s(c.variant.sku)})` : ""}</small>` : ""}${te(c)}</div><div class="umb-table-cell">${s(c.quantity)}</div><div class="umb-table-cell">${s((L = (E = (w = c.product) == null ? void 0 : w.price) == null ? void 0 : E.withVat) == null ? void 0 : L.currencyString)}</div><div class="umb-table-cell">${s((_ = (x = c.amount) == null ? void 0 : x.vat) == null ? void 0 : _.currencyString)}</div><div class="umb-table-cell">-${s((C = (A = c.amount) == null ? void 0 : A.discountAmount) == null ? void 0 : C.currencyString)}</div><div class="umb-table-cell"><strong>${s((T = (I = c.amount) == null ? void 0 : I.withVat) == null ? void 0 : T.currencyString)}</strong></div></div>`;
     }).join("")}
         </div>
         <div class="umb-table-footer">
           <div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Sub Total (inc VAT)</div><div class="umb-table-cell">${s((a = (i = e.subTotal) == null ? void 0 : i.withVat) == null ? void 0 : a.currencyString)}</div></div>
           <div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Discount</div><div class="umb-table-cell">-${s((l = e.discountAmount) == null ? void 0 : l.currencyString)}</div></div>
-          ${e.shippingProvider ? `<div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Shipping Total</div><div class="umb-table-cell">${s((p = (c = e.shippingProvider.price) == null ? void 0 : c.withVat) == null ? void 0 : p.currencyString)}</div></div>` : ""}
-          <div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">${s((v = e.chargedVat) == null ? void 0 : v.currencyString)}</div></div>
-          <div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Total</div><div class="umb-table-cell"><strong>${s((y = e.chargedAmount) == null ? void 0 : y.currencyString)}</strong></div></div>
+          ${e.shippingProvider ? `<div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Shipping Total</div><div class="umb-table-cell">${s((p = (u = e.shippingProvider.price) == null ? void 0 : u.withVat) == null ? void 0 : p.currencyString)}</div></div>` : ""}
+          <div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Vat</div><div class="umb-table-cell">${s((h = e.chargedVat) == null ? void 0 : h.currencyString)}</div></div>
+          <div class="umb-table-row"><div class="umb-table-cell"></div><div class="umb-table-cell not-fixed"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell"></div><div class="umb-table-cell">Total</div><div class="umb-table-cell"><strong>${s((b = e.chargedAmount) == null ? void 0 : b.currencyString)}</strong></div></div>
         </div>
       </div>
     `;
   }
   renderTracking(e) {
     const t = e.tracking;
-    return re(t) ? `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Tracking</h4><button class="btn-reset" type="button" data-action="toggle-tracking">${this.trackingExpanded ? "Hide" : "Show"}</button></div>${this.trackingExpanded ? ie(t) : ""}</div>` : '<div class="ekmOrderTracking"><h4>Tracking</h4><p>No tracking data was captured for this order.</p></div>';
+    return ie(t) ? `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Tracking</h4><button class="btn-reset" type="button" data-action="toggle-tracking">${this.trackingExpanded ? "Hide" : "Show"}</button></div>${this.trackingExpanded ? se(t) : ""}</div>` : '<div class="ekmOrderTracking"><h4>Tracking</h4><p>No tracking data was captured for this order.</p></div>';
   }
   renderConsent(e) {
     const t = e.consent;
-    return se(t) ? `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Consent</h4><button class="btn-reset" type="button" data-action="toggle-consent">${this.consentExpanded ? "Hide" : "Show"}</button></div>${this.consentExpanded ? `<p>Resolved: ${s(b(t.resolvedAtUtc))}</p><p>Source: ${s(t.source)}</p><p>Analytics: ${M(t.analytics)}</p><p>Marketing: ${M(t.marketing)}</p>` : ""}</div>` : '<div class="ekmOrderTracking"><h4>Consent</h4><p>No consent data was captured for this order.</p></div>';
+    return ae(t) ? `<div class="ekmOrderTracking"><div class="ekmOrderTracking__header"><h4>Consent</h4><button class="btn-reset" type="button" data-action="toggle-consent">${this.consentExpanded ? "Hide" : "Show"}</button></div>${this.consentExpanded ? `<p>Resolved: ${s(y(t.resolvedAtUtc))}</p><p>Source: ${s(t.source)}</p><p>Analytics: ${M(t.analytics)}</p><p>Marketing: ${M(t.marketing)}</p>` : ""}</div>` : '<div class="ekmOrderTracking"><h4>Consent</h4><p>No consent data was captured for this order.</p></div>';
   }
   renderActivityLogs() {
-    return this.orderLogsLoading ? '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>Loading activity...</p></div>' : this.orderLogs.length ? `<div class="ekmOrderActivityLog"><h4>Activity log</h4>${this.orderLogs.map((e) => `<div class="ekmOrderActivityLog__item"><div class="ekmOrderActivityLog__date">${s(b(e.date))}</div><div>${s(e.message)}</div></div>`).join("")}</div>` : '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>No activity yet.</p></div>';
+    return this.orderLogsLoading ? '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>Loading activity...</p></div>' : this.orderLogs.length ? `<div class="ekmOrderActivityLog"><h4>Activity log</h4>${this.orderLogs.map((e) => `<div class="ekmOrderActivityLog__item"><div class="ekmOrderActivityLog__date">${s(y(e.date))}</div><div>${s(e.message)}</div></div>`).join("")}</div>` : '<div class="ekmOrderActivityLog"><h4>Activity log</h4><p>No activity yet.</p></div>';
   }
   renderOrderActions() {
     return !this.orderActions.length && !this.orderActionsLoading ? "" : `<div style="margin-top:15px;"><h4>Order Actions</h4><div style="display:flex; flex-wrap:wrap; gap:10px;">${this.orderActions.map((e) => `<button type="button" class="${e.look === "primary" ? "btn-success" : "btn-outline"}" data-action="execute-order-action" data-action-key="${s(e.key)}" ${e.enabled === !1 || this.executingActionKey === e.key ? "disabled" : ""}>${s(e.label)}</button>`).join("")}</div>${this.orderActionsLoading ? "<p>Loading actions...</p>" : ""}</div>`;
@@ -486,26 +486,26 @@ class G extends B(HTMLElement) {
       this.exportIncludeOrderLines = t.checked, this.render();
       return;
     }
-    i === "orderStatusOverlay" || i === "notifyOrderStatus" || i === "query" || !i || !(i in o.filters) || (o.filters[i] = t.value, this.page = 1, i === "store" && await this.loadPaymentProviders(!0), await this.loadOrders());
+    i === "orderStatusOverlay" || i === "notifyOrderStatus" || i === "query" || !i || !(i in d.filters) || (d.filters[i] = t.value, this.page = 1, i === "store" && await this.loadPaymentProviders(!0), await this.loadOrders());
   }
   handleSearchInput(e) {
     const t = e.currentTarget;
-    o.filters.query = t.value, this.page = 1, window.clearTimeout(this.searchTimer), this.searchTimer = window.setTimeout(() => void this.loadOrders(), 700);
+    d.filters.query = t.value, this.page = 1, window.clearTimeout(this.searchTimer), this.searchTimer = window.setTimeout(() => void this.loadOrders(), 700);
   }
   applyFilterOverlay() {
     this.querySelectorAll("[data-filter-field]").forEach((e) => {
       const t = e.dataset.filterField;
-      t && t in o.filters && (o.filters[t] = e.value);
+      t && t in d.filters && (d.filters[t] = e.value);
     });
   }
   async exportOrders() {
     if (this.result.count) {
       this.exporting = !0, this.render();
       try {
-        const e = await this.api.exportOrders(o.filters, this.result.count, this.exportIncludeOrderLines);
-        Z(e, this.exportIncludeOrderLines ? "orders-with-orderlines.csv" : "orders.csv"), this.overlay = "";
+        const e = await this.api.exportOrders(d.filters, this.result.count, this.exportIncludeOrderLines);
+        Q(e, this.exportIncludeOrderLines ? "orders-with-orderlines.csv" : "orders.csv"), this.overlay = "";
       } catch (e) {
-        this.showError(h(e, "Error exporting orders."));
+        this.showError(v(e, "Error exporting orders."));
       } finally {
         this.exporting = !1, this.render();
       }
@@ -516,7 +516,7 @@ class G extends B(HTMLElement) {
       try {
         this.selectedOrder = await this.api.orderInfo(e), this.overlay = "order", this.trackingExpanded = !1, this.consentExpanded = !1, this.render(), await Promise.all([this.loadOrderLogs(e), this.loadOrderActions(e)]);
       } catch (t) {
-        this.showError(h(t, "Error on getting orderInfo."));
+        this.showError(v(t, "Error on getting orderInfo."));
       }
   }
   async loadOrderLogs(e) {
@@ -546,8 +546,8 @@ class G extends B(HTMLElement) {
     const e = ((a = this.querySelector('[data-field="orderStatusOverlay"]')) == null ? void 0 : a.value) || "", t = ((l = this.querySelector('[data-field="notifyOrderStatus"]')) == null ? void 0 : l.checked) || !1;
     try {
       await this.api.changeOrderStatus(this.selectedOrder.uniqueId, e, t), this.selectedOrder.orderStatus = e, this.showSuccess("Order status updated."), await this.loadOrders(), await this.loadOrderLogs(this.selectedOrder.uniqueId);
-    } catch (c) {
-      this.showError(h(c, "Error updating order status."));
+    } catch (u) {
+      this.showError(v(u, "Error updating order status."));
     }
   }
   showSuccess(e) {
@@ -579,7 +579,7 @@ class G extends B(HTMLElement) {
     this.overlay = "", this.selectedOrder = void 0, this.customerEditorOpen = !1, this.customerEditModel = void 0, this.orderLineEditorOpen = !1, this.orderLineEditModel = void 0, this.render();
   }
   getOrderStatusValue(e) {
-    const t = String(e ?? ""), i = o.statusList.find((a) => String(a.value ?? "") === t || String(a.enumValue ?? "") === t);
+    const t = String(e ?? ""), i = d.statusList.find((a) => String(a.value ?? "") === t || String(a.enumValue ?? "") === t);
     return i ? f(i) : t;
   }
   async changeRowStatus(e) {
@@ -590,7 +590,7 @@ class G extends B(HTMLElement) {
         const i = this.result.orders.find((a) => a.uniqueId === t);
         i && (i.orderStatusCol = e.value), this.showSuccess("Order status updated.");
       } catch (i) {
-        this.showError(h(i, "Error updating order status.")), await this.loadOrders();
+        this.showError(v(i, "Error updating order status.")), await this.loadOrders();
       }
   }
   async executeOrderAction(e) {
@@ -601,16 +601,16 @@ class G extends B(HTMLElement) {
     if (!(t != null && t.confirmMessage && !window.confirm(t.confirmMessage))) {
       this.executingActionKey = e, this.render();
       try {
-        const a = await this.api.executeOrderAction(this.selectedOrder.uniqueId, e), l = await a.blob(), c = a.headers.get("content-disposition") || "", p = a.headers.get("content-type") || "";
-        if (c.toLowerCase().includes("filename=") || p.startsWith("application/pdf") || p.startsWith("application/octet-stream") || p.startsWith("image/"))
+        const a = await this.api.executeOrderAction(this.selectedOrder.uniqueId, e), l = await a.blob(), u = a.headers.get("content-disposition") || "", p = a.headers.get("content-type") || "";
+        if (u.toLowerCase().includes("filename=") || p.startsWith("application/pdf") || p.startsWith("application/octet-stream") || p.startsWith("image/"))
           window.open(URL.createObjectURL(l), "_blank");
         else {
-          const v = await l.text();
-          this.showSuccess(ae(v));
+          const h = await l.text();
+          this.showSuccess(oe(h));
         }
         this.selectedOrder = await this.api.orderInfo(this.selectedOrder.uniqueId), await this.loadOrderLogs(this.selectedOrder.uniqueId), await this.loadOrderActions(this.selectedOrder.uniqueId);
       } catch (a) {
-        this.showError(h(a, "Order action failed."));
+        this.showError(v(a, "Order action failed."));
       } finally {
         this.executingActionKey = "", this.render();
       }
@@ -624,15 +624,15 @@ class G extends B(HTMLElement) {
     const t = ((a = e.customerInformation) == null ? void 0 : a.customer) || {}, i = ((l = e.customerInformation) == null ? void 0 : l.shipping) || {};
     this.customerEditModel = {
       customer: q(t, W).concat(F(t.properties, "customer")),
-      shipping: q(i, Q).concat(F(i.properties, "shipping"))
+      shipping: q(i, G).concat(F(i.properties, "shipping"))
     }, this.customerEditorOpen = !0, this.render();
   }
   async saveCustomerInformation() {
     var e;
     if (!(!((e = this.selectedOrder) != null && e.uniqueId) || !this.customerEditModel || this.customerSaving)) {
       this.querySelectorAll("[data-customer-group]").forEach((t) => {
-        var c;
-        const i = t.dataset.customerGroup, a = t.dataset.customerKey, l = (c = this.customerEditModel) == null ? void 0 : c[i].find((p) => p.key === a);
+        var u;
+        const i = t.dataset.customerGroup, a = t.dataset.customerKey, l = (u = this.customerEditModel) == null ? void 0 : u[i].find((p) => p.key === a);
         l && (l.value = t.value);
       }), this.customerSaving = !0, this.render();
       try {
@@ -642,7 +642,7 @@ class G extends B(HTMLElement) {
           D(this.customerEditModel.shipping)
         ), this.customerEditorOpen = !1, this.customerEditModel = void 0, this.showSuccess("Customer information updated."), await this.loadOrders();
       } catch (t) {
-        this.showError(h(t, "Error updating customer information."));
+        this.showError(v(t, "Error updating customer information."));
       } finally {
         this.customerSaving = !1, this.render();
       }
@@ -652,9 +652,9 @@ class G extends B(HTMLElement) {
     var l;
     if (!((l = this.selectedOrder) != null && l.uniqueId) || !this.orderLineEditModel || this.orderLineSaving)
       return;
-    this.querySelectorAll("[data-order-line-field]").forEach((c) => {
-      const p = c.dataset.orderLineField;
-      p && (this.orderLineEditModel[p] = c.value);
+    this.querySelectorAll("[data-order-line-field]").forEach((u) => {
+      const p = u.dataset.orderLineField;
+      p && (this.orderLineEditModel[p] = u.value);
     });
     const { productId: e, variantId: t, quantity: i } = this.orderLineEditModel, a = Number(i);
     if (!e.trim() || !Number.isFinite(a) || a <= 0) {
@@ -664,8 +664,8 @@ class G extends B(HTMLElement) {
     this.orderLineSaving = !0, this.render();
     try {
       this.selectedOrder = await this.api.addOrderLine(this.selectedOrder.uniqueId, e.trim(), t.trim() || void 0, a), this.orderLineEditorOpen = !1, this.orderLineEditModel = void 0, this.showSuccess("Order line added."), await this.refreshOrderAfterLineChange();
-    } catch (c) {
-      this.showError(h(c, "Error adding order line."));
+    } catch (u) {
+      this.showError(v(u, "Error adding order line."));
     } finally {
       this.orderLineSaving = !1, this.render();
     }
@@ -677,7 +677,7 @@ class G extends B(HTMLElement) {
       try {
         this.selectedOrder = await this.api.removeOrderLine(this.selectedOrder.uniqueId, e), this.showSuccess("Order line removed."), await this.refreshOrderAfterLineChange();
       } catch (a) {
-        this.showError(h(a, "Error removing order line."));
+        this.showError(v(a, "Error removing order line."));
       } finally {
         this.removingOrderLineId = "", this.render();
       }
@@ -691,67 +691,70 @@ class G extends B(HTMLElement) {
     await Promise.all([this.loadOrders(), this.loadOrderLogs(e), this.loadOrderActions(e)]);
   }
 }
-function h(r, d) {
-  return r instanceof Error ? r.message : d;
-}
-function Y(r) {
-  return r === "zipCode" ? "Zipcode" : r.charAt(0).toUpperCase() + r.slice(1);
+function v(r, o) {
+  return r instanceof Error ? r.message : o;
 }
 function J(r) {
+  return r === "zipCode" ? "Zipcode" : r.charAt(0).toUpperCase() + r.slice(1);
+}
+function X(r) {
   return (/* @__PURE__ */ new Set(["shippingname", "shippingaddress", "shippingcity", "shippingcountry", "shippingemail", "shippingapartment", "shippingzipcode", "shippingphone", "customeremail", "customername", "customeraddress", "customerapartment", "customercity", "customercountry", "customerzipcode", "customerphone"])).has(r.toLowerCase());
 }
 function N(r) {
   return r.replace(/^customshipping/i, "").replace(/^custompayment/i, "").replace(/^shipping/i, "").replace(/^customer/i, "");
 }
-function j(r, d) {
-  return Object.entries(r || {}).filter(([e, t]) => !!t && e.toLowerCase().startsWith(d) && !J(e)).map(([e, t]) => [e, g(t)]);
-}
-function X(r) {
-  return !!(r != null && r.name || r != null && r.email || r != null && r.address || r != null && r.apartment || r != null && r.city || r != null && r.country || r != null && r.zipCode || r != null && r.phone);
+function j(r, o) {
+  return Object.entries(r || {}).filter(([e, t]) => !!t && e.toLowerCase().startsWith(o) && !X(e)).map(([e, t]) => [e, O(t)]);
 }
 function ee(r) {
-  var e;
-  const d = ((e = r.orderLineInfo) == null ? void 0 : e.properties) || {};
-  return Object.entries(d).filter(([, t]) => !!t).map(([t, i]) => `<small style="display:block; margin-top:3px;"><strong>${s(te(t))}</strong>: ${s(g(i))}</small>`).join("");
+  return !!(r != null && r.name || r != null && r.email || r != null && r.address || r != null && r.apartment || r != null && r.city || r != null && r.country || r != null && r.zipCode || r != null && r.phone);
 }
 function te(r) {
-  const d = r.replace(/^orderline/i, "").replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
-  return d ? d.charAt(0).toUpperCase() + d.slice(1) : r;
+  var e;
+  const o = ((e = r.orderLineInfo) == null ? void 0 : e.properties) || {};
+  return Object.entries(o).filter(([, t]) => !!t).map(([t, i]) => `<small style="display:block; margin-top:3px;"><strong>${s(re(t))}</strong>: ${s(O(i))}</small>`).join("");
 }
 function re(r) {
-  var d, e, t, i;
-  return !!(r && (r.source || r.medium || r.campaign || r.term || r.content || r.clickId || r.clickIdType || r.landingUrl || r.referrer || r.captureMethod || r.capturedAtUtc || r.hasCookieSupport !== null && r.hasCookieSupport !== void 0 || (d = r.ga4) != null && d.clientId || (e = r.ga4) != null && e.sessionId || (t = r.meta) != null && t.fbp || (i = r.meta) != null && i.fbc));
+  const o = r.replace(/^orderline/i, "").replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim();
+  return o ? o.charAt(0).toUpperCase() + o.slice(1) : r;
 }
 function ie(r) {
-  var t, i, a, l, c, p;
-  const d = Object.entries(((t = r.ga4) == null ? void 0 : t.data) || {}), e = Object.entries(((i = r.meta) == null ? void 0 : i.data) || {});
-  return `<div class="ekmSplit"><div class="ekmSplit__column">${m("Captured", b(r.capturedAtUtc))}${m("Capture method", r.captureMethod)}${r.hasCookieSupport !== null && r.hasCookieSupport !== void 0 ? `<p>Cookie support: ${r.hasCookieSupport ? "Yes" : "No"}</p>` : ""}${m("Source", r.source)}${m("Medium", r.medium)}${m("Campaign", r.campaign)}${m("Term", r.term)}${m("Content", r.content)}${m("Click ID", r.clickId)}${m("Click ID Type", r.clickIdType)}${m("Landing URL", r.landingUrl)}${m("Referrer", r.referrer)}</div><div class="ekmSplit__column"><h5>GA4</h5>${m("Client ID", (a = r.ga4) == null ? void 0 : a.clientId)}${m("Session ID", (l = r.ga4) == null ? void 0 : l.sessionId)}${T(d)}<h5>Meta</h5>${m("FBP", (c = r.meta) == null ? void 0 : c.fbp)}${m("FBC", (p = r.meta) == null ? void 0 : p.fbc)}${T(e)}</div></div>`;
-}
-function m(r, d) {
-  return d ? `<p class="ekmOrderTracking__wrap">${s(r)}: ${s(d)}</p>` : "";
-}
-function T(r) {
-  return r.length ? `<ul>${r.map(([d, e]) => `<li><strong>${s(d)}</strong>: ${s(e)}</li>`).join("")}</ul>` : "";
+  var o, e, t, i;
+  return !!(r && (r.source || r.medium || r.campaign || r.term || r.content || r.clickId || r.clickIdType || r.landingUrl || r.referrer || r.captureMethod || r.capturedAtUtc || r.hasCookieSupport !== null && r.hasCookieSupport !== void 0 || (o = r.ga4) != null && o.clientId || (e = r.ga4) != null && e.sessionId || (t = r.meta) != null && t.fbp || (i = r.meta) != null && i.fbc || V(r.algolia)));
 }
 function se(r) {
+  var l, u, p, h, b, c;
+  const o = Object.entries(((l = r.ga4) == null ? void 0 : l.data) || {}), e = Object.entries(((u = r.meta) == null ? void 0 : u.data) || {}), t = r.algolia, i = Array.isArray(t == null ? void 0 : t.lines) ? t.lines : [], a = V(t) ? `<div class="ekmOrderTracking__provider"><h5>Algolia</h5>${m("User token", t.userToken)}${i.length ? `<ul>${i.map((g) => `<li class="ekmOrderTracking__wrap"><strong>Order line key</strong>: ${s(g.orderLineKey)}<br><strong>Query ID</strong>: ${s(g.queryId)}</li>`).join("")}</ul>` : ""}</div>` : "";
+  return `<div class="ekmSplit"><div class="ekmSplit__column">${m("Captured", y(r.capturedAtUtc))}${m("Capture method", r.captureMethod)}${r.hasCookieSupport !== null && r.hasCookieSupport !== void 0 ? `<p>Cookie support: ${r.hasCookieSupport ? "Yes" : "No"}</p>` : ""}${m("Source", r.source)}${m("Medium", r.medium)}${m("Campaign", r.campaign)}${m("Term", r.term)}${m("Content", r.content)}${m("Click ID", r.clickId)}${m("Click ID Type", r.clickIdType)}${m("Landing URL", r.landingUrl)}${m("Referrer", r.referrer)}</div><div class="ekmSplit__column"><h5>GA4</h5>${m("Client ID", (p = r.ga4) == null ? void 0 : p.clientId)}${m("Session ID", (h = r.ga4) == null ? void 0 : h.sessionId)}${P(o)}<h5>Meta</h5>${m("FBP", (b = r.meta) == null ? void 0 : b.fbp)}${m("FBC", (c = r.meta) == null ? void 0 : c.fbc)}${P(e)}${a}</div></div>`;
+}
+function V(r) {
+  return !!(r && (r.userToken || Array.isArray(r.lines) && r.lines.length));
+}
+function m(r, o) {
+  return o ? `<p class="ekmOrderTracking__wrap">${s(r)}: ${s(o)}</p>` : "";
+}
+function P(r) {
+  return r.length ? `<ul>${r.map(([o, e]) => `<li><strong>${s(o)}</strong>: ${s(e)}</li>`).join("")}</ul>` : "";
+}
+function ae(r) {
   return !!(r && (r.resolvedAtUtc || r.source || r.analytics !== null && r.analytics !== void 0 || r.marketing !== null && r.marketing !== void 0));
 }
 function M(r) {
   return r === !0 ? "Yes" : r === !1 ? "No" : "Unknown";
 }
-function q(r, d) {
-  return d.map((e) => {
+function q(r, o) {
+  return o.map((e) => {
     var t;
     return {
       key: e.key,
       label: e.label,
-      value: g(r[e.property] || ((t = r.properties) == null ? void 0 : t[e.key]) || ""),
+      value: O(r[e.property] || ((t = r.properties) == null ? void 0 : t[e.key]) || ""),
       isExtra: !1
     };
   });
 }
-function F(r, d) {
-  return j(r, d).map(([e, t]) => ({
+function F(r, o) {
+  return j(r, o).map(([e, t]) => ({
     key: e,
     label: N(e).replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ").trim() || e,
     value: t,
@@ -759,17 +762,17 @@ function F(r, d) {
   }));
 }
 function D(r) {
-  return Object.fromEntries(r.map((d) => [d.key, d.value || ""]));
+  return Object.fromEntries(r.map((o) => [o.key, o.value || ""]));
 }
-function ae(r) {
+function oe(r) {
   try {
     return JSON.parse(r).message || r;
   } catch {
     return r;
   }
 }
-customElements.define("ekom-orders-section-view", G);
+customElements.define("ekom-orders-section-view", Y);
 export {
-  G as EkomOrdersSectionViewElement,
-  G as default
+  Y as EkomOrdersSectionViewElement,
+  Y as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/orders-section-view.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/manager/orders-section-view.element.ts
@@ -1099,13 +1099,22 @@ function formatOrderLinePropertyKey(key: string): string {
 }
 
 function hasTrackingData(tracking: Record<string, any> | undefined): boolean {
-  return Boolean(tracking && (tracking.source || tracking.medium || tracking.campaign || tracking.term || tracking.content || tracking.clickId || tracking.clickIdType || tracking.landingUrl || tracking.referrer || tracking.captureMethod || tracking.capturedAtUtc || tracking.hasCookieSupport !== null && tracking.hasCookieSupport !== undefined || tracking.ga4?.clientId || tracking.ga4?.sessionId || tracking.meta?.fbp || tracking.meta?.fbc));
+  return Boolean(tracking && (tracking.source || tracking.medium || tracking.campaign || tracking.term || tracking.content || tracking.clickId || tracking.clickIdType || tracking.landingUrl || tracking.referrer || tracking.captureMethod || tracking.capturedAtUtc || tracking.hasCookieSupport !== null && tracking.hasCookieSupport !== undefined || tracking.ga4?.clientId || tracking.ga4?.sessionId || tracking.meta?.fbp || tracking.meta?.fbc || hasAlgoliaTrackingData(tracking.algolia)));
 }
 
 function renderTrackingDetails(tracking: Record<string, any>): string {
   const ga4Data = Object.entries(tracking.ga4?.data || {});
   const metaData = Object.entries(tracking.meta?.data || {});
-  return `<div class="ekmSplit"><div class="ekmSplit__column">${renderOptional('Captured', formatDate(tracking.capturedAtUtc))}${renderOptional('Capture method', tracking.captureMethod)}${tracking.hasCookieSupport !== null && tracking.hasCookieSupport !== undefined ? `<p>Cookie support: ${tracking.hasCookieSupport ? 'Yes' : 'No'}</p>` : ''}${renderOptional('Source', tracking.source)}${renderOptional('Medium', tracking.medium)}${renderOptional('Campaign', tracking.campaign)}${renderOptional('Term', tracking.term)}${renderOptional('Content', tracking.content)}${renderOptional('Click ID', tracking.clickId)}${renderOptional('Click ID Type', tracking.clickIdType)}${renderOptional('Landing URL', tracking.landingUrl)}${renderOptional('Referrer', tracking.referrer)}</div><div class="ekmSplit__column"><h5>GA4</h5>${renderOptional('Client ID', tracking.ga4?.clientId)}${renderOptional('Session ID', tracking.ga4?.sessionId)}${renderPairs(ga4Data)}<h5>Meta</h5>${renderOptional('FBP', tracking.meta?.fbp)}${renderOptional('FBC', tracking.meta?.fbc)}${renderPairs(metaData)}</div></div>`;
+  const algolia = tracking.algolia;
+  const algoliaLines = Array.isArray(algolia?.lines) ? algolia.lines : [];
+  const algoliaTracking = hasAlgoliaTrackingData(algolia)
+    ? `<div class="ekmOrderTracking__provider"><h5>Algolia</h5>${renderOptional('User token', algolia.userToken)}${algoliaLines.length ? `<ul>${algoliaLines.map((line: Record<string, any>) => `<li class="ekmOrderTracking__wrap"><strong>Order line key</strong>: ${escapeHtml(line.orderLineKey)}<br><strong>Query ID</strong>: ${escapeHtml(line.queryId)}</li>`).join('')}</ul>` : ''}</div>`
+    : '';
+  return `<div class="ekmSplit"><div class="ekmSplit__column">${renderOptional('Captured', formatDate(tracking.capturedAtUtc))}${renderOptional('Capture method', tracking.captureMethod)}${tracking.hasCookieSupport !== null && tracking.hasCookieSupport !== undefined ? `<p>Cookie support: ${tracking.hasCookieSupport ? 'Yes' : 'No'}</p>` : ''}${renderOptional('Source', tracking.source)}${renderOptional('Medium', tracking.medium)}${renderOptional('Campaign', tracking.campaign)}${renderOptional('Term', tracking.term)}${renderOptional('Content', tracking.content)}${renderOptional('Click ID', tracking.clickId)}${renderOptional('Click ID Type', tracking.clickIdType)}${renderOptional('Landing URL', tracking.landingUrl)}${renderOptional('Referrer', tracking.referrer)}</div><div class="ekmSplit__column"><h5>GA4</h5>${renderOptional('Client ID', tracking.ga4?.clientId)}${renderOptional('Session ID', tracking.ga4?.sessionId)}${renderPairs(ga4Data)}<h5>Meta</h5>${renderOptional('FBP', tracking.meta?.fbp)}${renderOptional('FBC', tracking.meta?.fbc)}${renderPairs(metaData)}${algoliaTracking}</div></div>`;
+}
+
+function hasAlgoliaTrackingData(algolia: Record<string, any> | undefined): boolean {
+  return Boolean(algolia && (algolia.userToken || Array.isArray(algolia.lines) && algolia.lines.length));
 }
 
 function renderOptional(label: string, value: unknown): string {

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Manager/controllers/ekmOrder.controller.js
@@ -25,6 +25,7 @@
     $scope.executingOrderActionKey = null;
     $scope.ga4TrackingData = [];
     $scope.metaTrackingData = [];
+    $scope.algoliaTrackingLines = [];
     $scope.customerInformationEditorOpen = false;
     $scope.customerInformationSaving = false;
     $scope.customerInformationEditModel = null;
@@ -272,6 +273,7 @@
       $scope.model.editModel.order = order;
       $scope.ga4TrackingData = tracking && tracking.ga4 && tracking.ga4.data ? Object.entries(tracking.ga4.data) : [];
       $scope.metaTrackingData = tracking && tracking.meta && tracking.meta.data ? Object.entries(tracking.meta.data) : [];
+      $scope.algoliaTrackingLines = tracking && tracking.algolia && Array.isArray(tracking.algolia.lines) ? tracking.algolia.lines : [];
 
       orderLines.forEach(function (orderLine) {
         orderLine.displayProperties = getOrderLineProperties(orderLine);
@@ -647,7 +649,8 @@
         orderTracking.capturedAtUtc ||
         orderTracking.hasCookieSupport !== null && orderTracking.hasCookieSupport !== undefined ||
         (orderTracking.ga4 && (orderTracking.ga4.clientId || orderTracking.ga4.sessionId || $scope.ga4TrackingData.length > 0)) ||
-        (orderTracking.meta && (orderTracking.meta.fbp || orderTracking.meta.fbc || $scope.metaTrackingData.length > 0))
+        (orderTracking.meta && (orderTracking.meta.fbp || orderTracking.meta.fbc || $scope.metaTrackingData.length > 0)) ||
+        (orderTracking.algolia && (orderTracking.algolia.userToken || $scope.algoliaTrackingLines.length > 0))
       );
     };
 

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/Manager/views/overlays/ekmOrder.html
@@ -320,6 +320,14 @@
               <li ng-repeat="pair in metaTrackingData track by $index" class="ekmOrderTracking__wrap"><strong>{{ pair[0] }}</strong>: {{ pair[1] }}</li>
             </ul>
           </div>
+
+          <div ng-if="model.editModel.order.tracking.algolia && (model.editModel.order.tracking.algolia.userToken || algoliaTrackingLines.length > 0)" class="ekmOrderTracking__provider">
+            <h5>Algolia</h5>
+            <p ng-if="model.editModel.order.tracking.algolia.userToken" class="ekmOrderTracking__wrap">User token: {{ model.editModel.order.tracking.algolia.userToken }}</p>
+            <ul ng-if="algoliaTrackingLines.length > 0" class="ekmOrderTracking__list">
+              <li ng-repeat="line in algoliaTrackingLines track by line.orderLineKey" class="ekmOrderTracking__wrap"><strong>Order line key</strong>: {{ line.orderLineKey }}<br><strong>Query ID</strong>: {{ line.queryId }}</li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaInsightsClientTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaInsightsClientTests.cs
@@ -50,6 +50,32 @@ public class AlgoliaInsightsClientTests
         Assert.Equal("USD", objectData[0].GetProperty("currency").GetString());
     }
 
+    [Fact]
+    public async Task Sends_Query_Id_When_Present()
+    {
+        using var handler = new CapturingHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://insights.algolia.io/1/")
+        };
+        var client = new AlgoliaInsightsClient(httpClient, NullLogger<AlgoliaInsightsClient>.Instance);
+        var evt = new AlgoliaInsightsEvent
+        {
+            EventType = "conversion",
+            EventName = "Purchased",
+            Index = "products",
+            UserToken = "user-token",
+            QueryId = "query-id",
+            ObjectIds = ["product-1"]
+        };
+
+        await client.SendEventsAsync([evt]);
+
+        using var document = JsonDocument.Parse(handler.RequestBody);
+        var sentEvent = document.RootElement.GetProperty("events")[0];
+        Assert.Equal("query-id", sentEvent.GetProperty("queryID").GetString());
+    }
+
     private sealed class CapturingHandler : HttpMessageHandler
     {
         public string RequestBody { get; private set; } = string.Empty;

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaOrderTrackingTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaOrderTrackingTests.cs
@@ -1,0 +1,33 @@
+using Ekom.Models;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public sealed class AlgoliaOrderTrackingTests
+{
+    [Fact]
+    public void AddLine_Preserves_The_First_Query_Id_For_A_Line()
+    {
+        var lineKey = Guid.NewGuid();
+        var tracking = new AlgoliaOrderTracking();
+
+        tracking.AddLine(lineKey, "first-query");
+        tracking.AddLine(lineKey, "second-query");
+
+        Assert.Single(tracking.Lines);
+        Assert.Equal("first-query", tracking.GetQueryId(lineKey));
+    }
+
+    [Fact]
+    public void RemoveLine_Removes_The_Associated_Query_Id()
+    {
+        var lineKey = Guid.NewGuid();
+        var tracking = new AlgoliaOrderTracking();
+        tracking.AddLine(lineKey, "query-id");
+
+        tracking.RemoveLine(lineKey);
+
+        Assert.Empty(tracking.Lines);
+        Assert.Null(tracking.GetQueryId(lineKey));
+    }
+}

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -239,6 +239,47 @@ public sealed class ProductSearchController
 
 ## Usage notes
 
+### Insights user-token correlation with InstantSearch
+
+Ekom issues an opaque first-party user-token cookie the first time `IAlgoliaUserTokenProvider.GetOrCreateUserToken()` is called. Use that same value to initialize the browser's Search Insights client so frontend click events and server-side conversion events share one Algolia user token. The token is not derived from a username or other personally identifiable information.
+
+Resolve the token while rendering the Razor page and initialize Search Insights with it. Do not let Search Insights generate a competing user token.
+
+```cshtml
+@using Ekom.Algolia.Services
+@inject IAlgoliaUserTokenProvider AlgoliaUserTokenProvider
+
+@{
+    var algoliaUserToken = AlgoliaUserTokenProvider.GetOrCreateUserToken();
+}
+
+<script>
+    aa('init', {
+        appId: '@algoliaOptions.ApplicationId',
+        apiKey: '@algoliaOptions.SearchApiKey',
+        useCookie: false,
+    });
+    aa('setUserToken', '@algoliaUserToken');
+</script>
+```
+
+When a result is added to an Ekom order, include that result's Algolia `queryID` as `algoliaQueryId` in the add-to-order request. Ekom persists the first query ID received for each order line along with the shared user token in `OrderInfo.Tracking.Algolia`.
+
+```js
+await fetch('/ekom/order/add', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    productId,
+    quantity: 1,
+    storeAlias,
+    algoliaQueryId: searchResult.queryID,
+  }),
+});
+```
+
+The stored token is used for Ekom's add-to-cart, checkout, and purchase Insights events. Ekom also uses each persisted line query ID for the corresponding conversion event. The Order Info tracking view shows an Algolia subsection only when this data exists.
+
 ### Indexing triggers and API keys
 
 Product and category indexing is triggered from Umbraco content notifications for `ekmProduct` and `ekmCategory`.

--- a/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
@@ -65,7 +65,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
         if (!_options.Enabled || !_options.Events.Enabled || !_options.Events.AddedToCart)
             return Task.CompletedTask;
 
-        var userToken = _userTokenProvider.GetUserToken();
+        var userToken = GetUserToken(orderInfo);
         if (string.IsNullOrWhiteSpace(userToken))
             return Task.CompletedTask;
 
@@ -85,6 +85,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             Index = indexName,
             UserToken = userToken,
             ObjectIds = new[] { orderLine.ProductKey.ToString() },
+            QueryId = orderInfo.Tracking?.Algolia?.GetQueryId(orderLine.Key),
             ObjectData =
             [
                 new Dictionary<string, object?>
@@ -104,7 +105,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
         if (!_options.Enabled || !_options.Events.Enabled || !_options.Events.StartedCheckout)
             return Task.CompletedTask;
 
-        var userToken = _userTokenProvider.GetUserToken();
+        var userToken = GetUserToken(orderInfo);
         if (string.IsNullOrWhiteSpace(userToken))
             return Task.CompletedTask;
 
@@ -117,32 +118,11 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             localeOverride: orderInfo.StoreInfo.Culture,
             currencyOverride: orderInfo.StoreInfo.Currency.CurrencyValue);
 
-        var objectIds = orderInfo.OrderLines
-            .Select(l => l.ProductKey.ToString())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (objectIds.Count == 0)
+        var events = CreateOrderLineConversionEvents(orderInfo, userToken, indexName, "Started Checkout");
+        if (events.Count == 0)
             return Task.CompletedTask;
 
-        var evt = new AlgoliaInsightsEvent
-        {
-            EventType = "conversion",
-            EventName = "Started Checkout",
-            Index = indexName,
-            UserToken = userToken,
-            ObjectIds = objectIds,
-            ObjectData =
-            [
-                new Dictionary<string, object?>
-                {
-                    ["value"] = orderInfo.ChargedAmount.Value,
-                    ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-                }
-            ]
-        };
-
-        return _insightsClient.SendEventsAsync(new[] { evt }, ct);
+        return _insightsClient.SendEventsAsync(events, ct);
     }
 
     public Task TrackPurchaseAsync(IOrderInfo orderInfo, CancellationToken ct = default)
@@ -150,7 +130,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
         if (!_options.Enabled || !_options.Events.Enabled || !_options.Events.Purchase)
             return Task.CompletedTask;
 
-        var userToken = _userTokenProvider.GetUserToken();
+        var userToken = GetUserToken(orderInfo);
         if (string.IsNullOrWhiteSpace(userToken))
             return Task.CompletedTask;
 
@@ -163,32 +143,40 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             localeOverride: orderInfo.StoreInfo.Culture,
             currencyOverride: orderInfo.StoreInfo.Currency.CurrencyValue);
 
-        var objectIds = orderInfo.OrderLines
-            .Select(l => l.ProductKey.ToString())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (objectIds.Count == 0)
+        var events = CreateOrderLineConversionEvents(orderInfo, userToken, indexName, "Purchased");
+        if (events.Count == 0)
             return Task.CompletedTask;
 
-        var evt = new AlgoliaInsightsEvent
-        {
-            EventType = "conversion",
-            EventName = "Purchased",
-            Index = indexName,
-            UserToken = userToken,
-            ObjectIds = objectIds,
-            ObjectData =
-            [
-                new Dictionary<string, object?>
-                {
-                    ["value"] = orderInfo.ChargedAmount.Value,
-                    ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-                }
-            ]
-        };
-
-        return _insightsClient.SendEventsAsync(new[] { evt }, ct);
+        return _insightsClient.SendEventsAsync(events, ct);
     }
+
+    private string? GetUserToken(IOrderInfo orderInfo)
+        => orderInfo.Tracking?.Algolia?.UserToken ?? _userTokenProvider.GetOrCreateUserToken();
+
+    private static IReadOnlyList<AlgoliaInsightsEvent> CreateOrderLineConversionEvents(
+        IOrderInfo orderInfo,
+        string userToken,
+        string indexName,
+        string eventName)
+        => orderInfo.OrderLines
+            .Select(orderLine => new AlgoliaInsightsEvent
+            {
+                EventType = "conversion",
+                EventName = eventName,
+                Index = indexName,
+                UserToken = userToken,
+                ObjectIds = new[] { orderLine.ProductKey.ToString() },
+                QueryId = orderInfo.Tracking?.Algolia?.GetQueryId(orderLine.Key),
+                ObjectData =
+                [
+                    new Dictionary<string, object?>
+                    {
+                        ["quantity"] = orderLine.Quantity,
+                        ["value"] = orderLine.Amount.Value,
+                        ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
+                    }
+                ]
+            })
+            .ToList();
 
 }

--- a/Plugins/Ekom.Algolia/Services/AlgoliaUserTokenProvider.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaUserTokenProvider.cs
@@ -1,14 +1,19 @@
 using Microsoft.AspNetCore.Http;
+using System.Security.Cryptography;
 
 namespace Ekom.Algolia.Services;
 
 public interface IAlgoliaUserTokenProvider
 {
     string? GetUserToken();
+    string? GetOrCreateUserToken();
 }
 
 internal sealed class DefaultAlgoliaUserTokenProvider : IAlgoliaUserTokenProvider
 {
+    private const string CookieName = "ekom_algolia_user_token";
+    private const string HttpContextItemKey = "Ekom.Algolia.UserToken";
+
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public DefaultAlgoliaUserTokenProvider(IHttpContextAccessor httpContextAccessor)
@@ -17,18 +22,43 @@ internal sealed class DefaultAlgoliaUserTokenProvider : IAlgoliaUserTokenProvide
     }
 
     public string? GetUserToken()
+        => GetOrCreateUserToken();
+
+    public string? GetOrCreateUserToken()
     {
         var context = _httpContextAccessor.HttpContext;
         if (context == null)
             return null;
 
-        var userName = context.User?.Identity?.Name;
-        if (!string.IsNullOrWhiteSpace(userName))
-            return userName;
+        if (context.Items.TryGetValue(HttpContextItemKey, out var item)
+            && item is string itemToken
+            && !string.IsNullOrWhiteSpace(itemToken))
+        {
+            return itemToken;
+        }
 
-        if (context.Session?.IsAvailable == true)
-            return context.Session.Id;
+        var cookieToken = context.Request.Cookies[CookieName];
+        if (!string.IsNullOrWhiteSpace(cookieToken))
+        {
+            context.Items[HttpContextItemKey] = cookieToken;
+            return cookieToken;
+        }
 
-        return context.TraceIdentifier;
+        var userToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+        context.Items[HttpContextItemKey] = userToken;
+
+        if (!context.Response.HasStarted)
+        {
+            context.Response.Cookies.Append(CookieName, userToken, new CookieOptions
+            {
+                Expires = DateTimeOffset.UtcNow.AddMonths(6),
+                HttpOnly = true,
+                IsEssential = true,
+                SameSite = SameSiteMode.Lax,
+                Secure = context.Request.IsHttps
+            });
+        }
+
+        return userToken;
     }
 }

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
@@ -22,6 +22,7 @@ internal sealed class AlgoliaEkomEvents : IComponent
     {
         //CatalogEvents.BeforeReturnProductAsync += OnBeforeReturnProductAsync;
         OrderEvents.AddedOrderlineAsync += OnAddedOrderlineAsync;
+        OrderEvents.RemovedOrderlineAsync += OnRemovedOrderlineAsync;
         OrderEvents.CustomerEmailAddedAsync += OnCustomerEmailAddedAsync;
         CheckoutEvents.CompleteCheckoutAsync += OnCompleteCheckoutAsync;
     }
@@ -30,6 +31,7 @@ internal sealed class AlgoliaEkomEvents : IComponent
     {
         //CatalogEvents.BeforeReturnProductAsync -= OnBeforeReturnProductAsync;
         OrderEvents.AddedOrderlineAsync -= OnAddedOrderlineAsync;
+        OrderEvents.RemovedOrderlineAsync -= OnRemovedOrderlineAsync;
         OrderEvents.CustomerEmailAddedAsync -= OnCustomerEmailAddedAsync;
         CheckoutEvents.CompleteCheckoutAsync -= OnCompleteCheckoutAsync;
     }
@@ -50,16 +52,30 @@ internal sealed class AlgoliaEkomEvents : IComponent
 
     private async Task OnAddedOrderlineAsync(object sender, AddedOrderlineEventArgs args, CancellationToken ct)
     {
-        if (!_options.Enabled || !_options.Events.Enabled || !_options.Events.AddedToCart)
+        if (!_options.Enabled)
             return;
 
-        var orderInfo = args.OrderInfo;
-        var orderLine = args.OrderLine;
-
         using var scope = _scopeFactory.CreateScope();
+        var userTokenProvider = scope.ServiceProvider.GetRequiredService<IAlgoliaUserTokenProvider>();
+        var tracking = args.OrderInfo.Tracking ??= new();
+        var algoliaTracking = tracking.Algolia ??= new();
+        algoliaTracking.UserToken ??= userTokenProvider.GetOrCreateUserToken();
+        algoliaTracking.AddLine(args.OrderLine.Key, args.Settings.AlgoliaQueryId);
+
+        if (!_options.Events.Enabled || !_options.Events.AddedToCart)
+            return;
+
         var service = scope.ServiceProvider.GetRequiredService<IAlgoliaEventService>();
 
-        await service.TrackAddedToCartAsync(orderInfo, orderLine, ct).ConfigureAwait(false);
+        await service.TrackAddedToCartAsync(args.OrderInfo, args.OrderLine, ct).ConfigureAwait(false);
+    }
+
+    private Task OnRemovedOrderlineAsync(object sender, RemovedOrderlineEventArgs args, CancellationToken ct)
+    {
+        if (_options.Enabled)
+            args.OrderInfo.Tracking?.Algolia?.RemoveLine(args.OrderLine.Key);
+
+        return Task.CompletedTask;
     }
 
     private async Task OnCustomerEmailAddedAsync(object sender, CustomerEmailAddedEventArgs args, CancellationToken ct)


### PR DESCRIPTION
## Summary
- persist an opaque Algolia user token and the first query ID for each order line
- send line-level add-to-cart, checkout, and purchase Insights conversions with the persisted correlation data
- display Algolia tracking in Order Info and document InstantSearch initialization and add-to-order usage

## Test Plan
- `dotnet build \"Ekom/Ekom.Core/Ekom/Ekom.csproj\" -c Release`
- `npm run build` in `Ekom/Ekom.Web/Ekom.Web.U17/Client`
- Focused `dotnet test` is blocked locally because untracked U18 output is globbed into the Algolia project; it produces duplicate assembly attributes.