### PR TITLE
feat(algolia): update availability after stock changes

### DIFF
--- a/Ekom/Ekom.Core/Ekom/API/Stock.cs
+++ b/Ekom/Ekom.Core/Ekom/API/Stock.cs
@@ -1,4 +1,5 @@
 using Ekom.Cache;
+using Ekom.Events;
 using Ekom.Exceptions;
 using Ekom.Models;
 using Ekom.Repositories;
@@ -236,6 +237,7 @@ public partial class Stock
     {
         SemaphoreSlim? semaphore = null;
         StockData stockData;
+        StockChangedEventArgs? stockChangedArgs = null;
 
         try
         {
@@ -264,13 +266,16 @@ public partial class Stock
                 throw new NotEnoughStockException($"Not enough stock available for {stockData.UniqueId}.");
             }
 
-            await SetStockWithLockAsync(stockData, stockData.Stock + value, outerLock: true, ct)
+            stockChangedArgs = await SetStockWithLockAsync(key, storeAlias, stockData, stockData.Stock + value, outerLock: true, ct)
                 .ConfigureAwait(false);
         }
         finally
         {
             semaphore?.Release();
         }
+
+        if (stockChangedArgs is not null)
+            await StockEvents.OnStockChangedAsync(this, stockChangedArgs, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -325,7 +330,12 @@ public partial class Stock
             stockData = _stockCache.Cache[key];
         }
 
-        return await SetStockWithLockAsync(stockData, value, ct: ct).ConfigureAwait(false);
+        var stockChangedArgs = await SetStockWithLockAsync(key, storeAlias, stockData, value, ct: ct).ConfigureAwait(false);
+
+        if (stockChangedArgs is not null)
+            await StockEvents.OnStockChangedAsync(this, stockChangedArgs, ct).ConfigureAwait(false);
+
+        return true;
     }
 
     /// <summary>
@@ -462,7 +472,7 @@ public partial class Stock
     /// Throws an exception when current value and provided value are equal
     /// </exception>
     /// <exception cref="ArgumentNullException"/>
-    private async Task<bool> SetStockWithLockAsync(StockData stockData, decimal value, bool outerLock = false, CancellationToken ct = default)
+    private async Task<StockChangedEventArgs?> SetStockWithLockAsync(Guid key, string? storeAlias, StockData stockData, decimal value, bool outerLock = false, CancellationToken ct = default)
     {
         if (stockData == null)
         {
@@ -470,7 +480,7 @@ public partial class Stock
         }
         if (stockData.Stock == value)
         {
-            return true;
+            return null;
         }
 
         //if (stockData.Stock == value)
@@ -494,7 +504,13 @@ public partial class Stock
 
             await _stockRepo.SetAsync(stockData.UniqueId, value, oldValue, ct).ConfigureAwait(false);
 
-            return true;
+            return new StockChangedEventArgs
+            {
+                Key = key,
+                StoreAlias = _config.PerStoreStock ? storeAlias : null,
+                OldValue = oldValue,
+                NewValue = value
+            };
         }
         finally
         {

--- a/Ekom/Ekom.Core/Ekom/Events/StockEvents.cs
+++ b/Ekom/Ekom.Core/Ekom/Events/StockEvents.cs
@@ -1,0 +1,19 @@
+using Ekom.Utilities;
+
+namespace Ekom.Events;
+
+public static class StockEvents
+{
+    public static event Func<object, StockChangedEventArgs, CancellationToken, Task>? StockChangedAsync;
+
+    public static Task OnStockChangedAsync(object sender, StockChangedEventArgs args, CancellationToken ct = default)
+        => AsyncEventInvoker.InvokeAsync(StockChangedAsync, sender, args, ct);
+}
+
+public sealed class StockChangedEventArgs : EventArgs
+{
+    public Guid Key { get; init; }
+    public string? StoreAlias { get; init; }
+    public decimal OldValue { get; init; }
+    public decimal NewValue { get; init; }
+}

--- a/Ekom/Ekom.Core/Ekom/Utilities/StockBufferHelper.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/StockBufferHelper.cs
@@ -2,7 +2,7 @@ using Ekom.Models;
 
 namespace Ekom.Utilities;
 
-internal static class StockBufferHelper
+public static class StockBufferHelper
 {
     public static decimal GetEffectiveStock(decimal stock, IProduct product, IVariant? variant = null)
     {

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -32,6 +32,7 @@ public class AlgoliaSearchTests
                 ["Ekom:Algolia:Search:Cache:Enabled"] = "true",
                 ["Ekom:Algolia:Search:Cache:DurationMinutes"] = "15",
                 ["Ekom:Algolia:Search:Cache:CacheEmptyResults"] = "false",
+                ["Ekom:Algolia:Indexing:EnableAvailabilityUpdates"] = "true",
                 ["Ekom:Algolia:Indexing:AttributesForFaceting:0"] = "filterOnly(categoryPageId)",
                 ["Ekom:Algolia:Indexing:FacetAttributes:0"] = "metafield:material",
                 ["Ekom:Algolia:Indexing:VariantFacetAttributes:color"] = "variantGroup:title",
@@ -67,6 +68,7 @@ public class AlgoliaSearchTests
         Assert.Equal(50, options.Search.MaxHitsPerPage);
         Assert.Equal(15, options.Search.Cache.DurationMinutes);
         Assert.False(options.Search.Cache.CacheEmptyResults);
+        Assert.True(options.Indexing.EnableAvailabilityUpdates);
         Assert.Equal(["filterOnly(categoryPageId)"], options.Indexing.AttributesForFaceting);
         Assert.Equal(["metafield:material"], options.Indexing.FacetAttributes);
         Assert.Equal("variantGroup:title", options.Indexing.VariantFacetAttributes["color"]);

--- a/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
+++ b/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ public static class AlgoliaServiceCollectionExtensions
         services.AddSingleton<AlgoliaSearchCacheKeyBuilder>();
         services.AddSingleton<IAlgoliaProductIndexMapper, ProductIndexMapper>();
         services.AddSingleton<IAlgoliaCategoryIndexMapper, CategoryIndexMapper>();
+        services.AddSingleton<AlgoliaAvailabilityUpdateService>();
 
         services.AddSingleton<IAlgoliaProductIndexQueue, AlgoliaProductIndexQueue>();
         services.AddSingleton<AlgoliaProductIndexExecutor>();

--- a/Plugins/Ekom.Algolia/CHANGELOG.md
+++ b/Plugins/Ekom.Algolia/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **algolia:** add optional variant-level product indexing for SKU search.
+* **algolia:** optionally update indexed availability and stock after stock changes.
 
 ## [0.2.47](https://github.com/Vettvangur/Ekom/compare/Ekom.Algolia-v0.2.46...Ekom.Algolia-v0.2.47) (2026-09-02)
 

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -34,6 +34,7 @@ public sealed class AlgoliaIndexingOptions
     public bool Products { get; set; } = true;
     public bool Categories { get; set; } = true;
     public bool Variants { get; set; }
+    public bool EnableAvailabilityUpdates { get; set; }
 
     public int BatchSize { get; set; } = 1000;
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaAvailabilityUpdateService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaAvailabilityUpdateService.cs
@@ -1,0 +1,148 @@
+using Algolia.Search.Clients;
+using Ekom.Algolia.Services;
+using Ekom.API;
+using Ekom.Events;
+using Ekom.Models;
+using Ekom.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Ekom.Algolia.Indexing;
+
+internal sealed class AlgoliaAvailabilityUpdateService
+{
+    private readonly ISearchClient _client;
+    private readonly AlgoliaOptions _options;
+    private readonly AlgoliaStoreResolver _storeResolver;
+    private readonly IndexNameBuilder _indexNameBuilder;
+    private readonly AlgoliaSearchCacheVersionProvider _searchCacheVersions;
+    private readonly ILogger<AlgoliaAvailabilityUpdateService> _logger;
+
+    public AlgoliaAvailabilityUpdateService(
+        ISearchClient client,
+        IOptions<AlgoliaOptions> options,
+        AlgoliaStoreResolver storeResolver,
+        IndexNameBuilder indexNameBuilder,
+        AlgoliaSearchCacheVersionProvider searchCacheVersions,
+        ILogger<AlgoliaAvailabilityUpdateService> logger)
+    {
+        _client = client;
+        _options = options.Value;
+        _storeResolver = storeResolver;
+        _indexNameBuilder = indexNameBuilder;
+        _searchCacheVersions = searchCacheVersions;
+        _logger = logger;
+    }
+
+    public async Task UpdateAsync(StockChangedEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Products || !_options.Indexing.EnableAvailabilityUpdates)
+            return;
+
+        var storeAliases = string.IsNullOrWhiteSpace(args.StoreAlias)
+            ? _options.Stores.Select(store => store.Alias).Distinct(StringComparer.OrdinalIgnoreCase)
+            : [args.StoreAlias];
+
+        foreach (var storeAlias in storeAliases)
+        {
+            try
+            {
+                await UpdateStoreAsync(args, storeAlias, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Algolia availability update failed for stock item {Key} in store {Store}.", args.Key, storeAlias);
+            }
+        }
+    }
+
+    private async Task UpdateStoreAsync(StockChangedEventArgs args, string storeAlias, CancellationToken ct)
+    {
+        var store = _storeResolver.Resolve(storeAlias);
+        var product = await Catalog.Instance.GetProductAsync(args.Key, store.Alias, raiseEvent: false, ct: ct).ConfigureAwait(false);
+
+        if (product is not null)
+        {
+            var attributes = CreateProductAttributes(product, args, store.IncludeStock);
+            await PartialUpdateAsync(store, product.Key.ToString(), attributes, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var variant = await Catalog.Instance.GetVariantAsync(args.Key, store.Alias, ct).ConfigureAwait(false);
+        var parentProduct = variant?.Product;
+        if (variant is null || parentProduct is null)
+            return;
+
+        var variantWasAvailable = IsVariantAvailable(variant, parentProduct, args.OldValue);
+        var variantIsAvailable = variant.Available;
+        var productWasAvailable = WasProductAvailable(parentProduct, variant, variantWasAvailable);
+        var productIsAvailable = parentProduct.Available;
+
+        if (_options.Indexing.Variants)
+        {
+            var variantAttributes = new Dictionary<string, object?>();
+            if (store.IncludeStock)
+            {
+                variantAttributes["Stock"] = variant.Stock;
+                variantAttributes["variantStock"] = variant.Stock;
+            }
+
+            if (variantWasAvailable != variantIsAvailable)
+            {
+                var availability = variantIsAvailable ? 1 : 0;
+                variantAttributes["Available"] = availability;
+                variantAttributes["variantAvailable"] = availability;
+            }
+
+            await PartialUpdateAsync(store, $"{parentProduct.Key}_{variant.Key}", variantAttributes, ct).ConfigureAwait(false);
+        }
+
+        var productAttributes = new Dictionary<string, object?>();
+        if (productWasAvailable != productIsAvailable)
+            productAttributes["Available"] = productIsAvailable ? 1 : 0;
+
+        await PartialUpdateAsync(store, parentProduct.Key.ToString(), productAttributes, ct).ConfigureAwait(false);
+    }
+
+    private static Dictionary<string, object?> CreateProductAttributes(IProduct product, StockChangedEventArgs args, bool includeStock)
+    {
+        var attributes = new Dictionary<string, object?>();
+        var hasVariants = product.AllVariants.Any();
+        var wasAvailable = product.Backorder || StockBufferHelper.GetEffectiveStock(args.OldValue, product) > 0;
+
+        if (!hasVariants && wasAvailable != product.Available)
+            attributes["Available"] = product.Available ? 1 : 0;
+
+        if (includeStock)
+            attributes["Stock"] = product.Stock;
+
+        return attributes;
+    }
+
+    private static bool IsVariantAvailable(IVariant variant, IProduct product, decimal stock)
+        => variant.Backorder || StockBufferHelper.GetEffectiveStock(stock, product, variant) > 0;
+
+    private static bool WasProductAvailable(IProduct product, IVariant changedVariant, bool changedVariantWasAvailable)
+        => product.Backorder
+        || product.AllVariants.Any(variant => variant.Key == changedVariant.Key ? changedVariantWasAvailable : variant.Available);
+
+    private async Task PartialUpdateAsync(AlgoliaResolvedStore store, string objectId, IReadOnlyDictionary<string, object?> attributes, CancellationToken ct)
+    {
+        if (attributes.Count == 0)
+            return;
+
+        foreach (var target in store.ExpandIndexTargets())
+        {
+            var indexName = _indexNameBuilder.BuildPrimary("products", target);
+            await _client.PartialUpdateObjectAsync(
+                indexName,
+                objectId,
+                attributes,
+                createIfNotExists: false,
+                options: null,
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+
+        _searchCacheVersions.InvalidateStore(store.Alias);
+    }
+}

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -188,6 +188,7 @@ public sealed class ProductSearchController
 | `Indexing:Products` | `bool` | `true` | Enables product indexing. |
 | `Indexing:Categories` | `bool` | `true` | Enables category indexing. |
 | `Indexing:Variants` | `bool` | `false` | Indexes product variants as separate product records so variant SKUs can be searched directly. |
+| `Indexing:EnableAvailabilityUpdates` | `bool` | `false` | Partially updates indexed availability after stock changes. When `Stores[*]:IncludeStock` is enabled, also updates the indexed stock amount. |
 | `Indexing:BatchSize` | `int` | `1000` | Batch size for Algolia save/replace/delete operations. |
 | `Indexing:ProductProperties` | `string[]` | `[]` | Additional product properties/metafields to include in product records. Supports modifiers documented below. |
 | `Indexing:AttributesForFaceting` | `string[]` | `[]` | Algolia facet expressions to preserve on product indexes, such as `filterOnly(categoryPageId)` or `searchable(brand)`. |
@@ -279,6 +280,24 @@ await fetch('/ekom/order/add', {
 ```
 
 The stored token is used for Ekom's add-to-cart, checkout, and purchase Insights events. Ekom also uses each persisted line query ID for the corresponding conversion event. The Order Info tracking view shows an Algolia subsection only when this data exists.
+
+### Stock availability updates
+
+Enable partial product-record updates when stock changes:
+
+```json
+{
+  "Ekom": {
+    "Algolia": {
+      "Indexing": {
+        "EnableAvailabilityUpdates": true
+      }
+    }
+  }
+}
+```
+
+Ekom updates `Available` only when effective sellable availability changes, including stock-buffer, backorder, and variant availability rules. For products with variants, the parent record becomes unavailable only when every variant is unavailable. If `Stores[*]:IncludeStock` is `true`, every stock change also partially updates `Stock`; indexed variant records additionally update `variantStock`. Existing records are updated only—stock changes never create incomplete Algolia records.
 
 ### Indexing triggers and API keys
 

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
@@ -1,4 +1,5 @@
 using Ekom.Events;
+using Ekom.Algolia.Indexing;
 using Ekom.Algolia.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -31,6 +32,7 @@ internal sealed class AlgoliaEkomEvents : IComponent
         //CatalogEvents.BeforeReturnProductAsync += OnBeforeReturnProductAsync;
         OrderEvents.AddedOrderlineAsync += OnAddedOrderlineAsync;
         OrderEvents.RemovedOrderlineAsync += OnRemovedOrderlineAsync;
+        StockEvents.StockChangedAsync += OnStockChangedAsync;
         OrderEvents.CustomerEmailAddedAsync += OnCustomerEmailAddedAsync;
         CheckoutEvents.CompleteCheckoutAsync += OnCompleteCheckoutAsync;
 #if UMBRACO_18
@@ -47,6 +49,7 @@ internal sealed class AlgoliaEkomEvents : IComponent
         //CatalogEvents.BeforeReturnProductAsync -= OnBeforeReturnProductAsync;
         OrderEvents.AddedOrderlineAsync -= OnAddedOrderlineAsync;
         OrderEvents.RemovedOrderlineAsync -= OnRemovedOrderlineAsync;
+        StockEvents.StockChangedAsync -= OnStockChangedAsync;
         OrderEvents.CustomerEmailAddedAsync -= OnCustomerEmailAddedAsync;
         CheckoutEvents.CompleteCheckoutAsync -= OnCompleteCheckoutAsync;
 #if UMBRACO_18
@@ -94,6 +97,17 @@ internal sealed class AlgoliaEkomEvents : IComponent
             args.OrderInfo.Tracking?.Algolia?.RemoveLine(args.OrderLine.Key);
 
         return Task.CompletedTask;
+    }
+
+    private async Task OnStockChangedAsync(object sender, StockChangedEventArgs args, CancellationToken ct)
+    {
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.EnableAvailabilityUpdates)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<AlgoliaAvailabilityUpdateService>();
+
+        await service.UpdateAsync(args, ct).ConfigureAwait(false);
     }
 
     private async Task OnCustomerEmailAddedAsync(object sender, CustomerEmailAddedEventArgs args, CancellationToken ct)


### PR DESCRIPTION
## Summary
- publish stock-change events after persisted stock mutations
- optionally partial-update Algolia product and variant availability, plus indexed stock where configured
- preserve effective stock-buffer, backorder, and aggregate variant availability rules
- document and verify the opt-in configuration binding

## Test Plan
- [x] `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaSearchTests"`
- [x] `dotnet build "Ekom/Ekom.Core/Ekom/Ekom.csproj" -c Release -v:q`
- [x] `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -c Release -v:q`