### PR TITLE
fix(algolia): configure availability updates per store

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaSearchTests.cs
@@ -32,12 +32,12 @@ public class AlgoliaSearchTests
                 ["Ekom:Algolia:Search:Cache:Enabled"] = "true",
                 ["Ekom:Algolia:Search:Cache:DurationMinutes"] = "15",
                 ["Ekom:Algolia:Search:Cache:CacheEmptyResults"] = "false",
-                ["Ekom:Algolia:Indexing:EnableAvailabilityUpdates"] = "true",
                 ["Ekom:Algolia:Indexing:AttributesForFaceting:0"] = "filterOnly(categoryPageId)",
                 ["Ekom:Algolia:Indexing:FacetAttributes:0"] = "metafield:material",
                 ["Ekom:Algolia:Indexing:VariantFacetAttributes:color"] = "variantGroup:title",
                 ["Ekom:Algolia:Indexing:VariantFacetAttributes:size"] = "variant:title",
                 ["Ekom:Algolia:Stores:0:Alias"] = "Store",
+                ["Ekom:Algolia:Stores:0:EnableAvailabilityUpdates"] = "true",
                 ["Ekom:Algolia:Stores:0:LanguageSettings:QueryLanguages:0"] = "is",
                 ["Ekom:Algolia:Stores:0:LanguageSettings:IndexLanguages:0"] = "is",
                 ["Ekom:Algolia:Stores:0:LanguageSettings:RemoveStopWords"] = "true",
@@ -68,12 +68,12 @@ public class AlgoliaSearchTests
         Assert.Equal(50, options.Search.MaxHitsPerPage);
         Assert.Equal(15, options.Search.Cache.DurationMinutes);
         Assert.False(options.Search.Cache.CacheEmptyResults);
-        Assert.True(options.Indexing.EnableAvailabilityUpdates);
         Assert.Equal(["filterOnly(categoryPageId)"], options.Indexing.AttributesForFaceting);
         Assert.Equal(["metafield:material"], options.Indexing.FacetAttributes);
         Assert.Equal("variantGroup:title", options.Indexing.VariantFacetAttributes["color"]);
         Assert.Equal("variant:title", options.Indexing.VariantFacetAttributes["size"]);
         var store = Assert.Single(options.Stores);
+        Assert.True(store.EnableAvailabilityUpdates);
         Assert.Equal(["is"], store.LanguageSettings.QueryLanguages);
         Assert.Equal(["is"], store.LanguageSettings.IndexLanguages);
         Assert.True(store.LanguageSettings.RemoveStopWords);

--- a/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
+++ b/Plugins/Ekom.Algolia/Config/AlgoliaOptions.cs
@@ -34,7 +34,6 @@ public sealed class AlgoliaIndexingOptions
     public bool Products { get; set; } = true;
     public bool Categories { get; set; } = true;
     public bool Variants { get; set; }
-    public bool EnableAvailabilityUpdates { get; set; }
 
     public int BatchSize { get; set; } = 1000;
 
@@ -143,6 +142,7 @@ public sealed class AlgoliaStoreOptions
 {
     public required string Alias { get; set; }
     public bool IncludeStock { get; set; }
+    public bool EnableAvailabilityUpdates { get; set; }
     public AlgoliaLanguageSettingsOptions LanguageSettings { get; init; } = new();
 }
 
@@ -160,6 +160,7 @@ public sealed class AlgoliaResolvedStore
     public string? Locale { get; init; }
     public string? Currency { get; init; }
     public bool IncludeStock { get; init; }
+    public bool EnableAvailabilityUpdates { get; init; }
     public IReadOnlyList<string> Locales { get; init; } = [];
     public IReadOnlyList<string> Currencies { get; init; } = [];
     public AlgoliaLanguageSettingsOptions LanguageSettings { get; init; } = new();
@@ -186,6 +187,7 @@ public sealed class AlgoliaResolvedStore
             Locale = locale,
             Currency = currency,
             IncludeStock = IncludeStock,
+            EnableAvailabilityUpdates = EnableAvailabilityUpdates,
             Locales = Locales,
             Currencies = Currencies,
             LanguageSettings = LanguageSettings,

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaAvailabilityUpdateService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaAvailabilityUpdateService.cs
@@ -36,12 +36,17 @@ internal sealed class AlgoliaAvailabilityUpdateService
 
     public async Task UpdateAsync(StockChangedEventArgs args, CancellationToken ct)
     {
-        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Products || !_options.Indexing.EnableAvailabilityUpdates)
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Products)
             return;
 
         var storeAliases = string.IsNullOrWhiteSpace(args.StoreAlias)
-            ? _options.Stores.Select(store => store.Alias).Distinct(StringComparer.OrdinalIgnoreCase)
-            : [args.StoreAlias];
+            ? _options.Stores
+                .Where(store => store.EnableAvailabilityUpdates)
+                .Select(store => store.Alias)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+            : _options.Stores
+                .Where(store => store.EnableAvailabilityUpdates && store.Alias.Equals(args.StoreAlias, StringComparison.OrdinalIgnoreCase))
+                .Select(store => store.Alias);
 
         foreach (var storeAlias in storeAliases)
         {
@@ -59,6 +64,9 @@ internal sealed class AlgoliaAvailabilityUpdateService
     private async Task UpdateStoreAsync(StockChangedEventArgs args, string storeAlias, CancellationToken ct)
     {
         var store = _storeResolver.Resolve(storeAlias);
+        if (!store.EnableAvailabilityUpdates)
+            return;
+
         var product = await Catalog.Instance.GetProductAsync(args.Key, store.Alias, raiseEvent: false, ct: ct).ConfigureAwait(false);
 
         if (product is not null)

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -188,7 +188,6 @@ public sealed class ProductSearchController
 | `Indexing:Products` | `bool` | `true` | Enables product indexing. |
 | `Indexing:Categories` | `bool` | `true` | Enables category indexing. |
 | `Indexing:Variants` | `bool` | `false` | Indexes product variants as separate product records so variant SKUs can be searched directly. |
-| `Indexing:EnableAvailabilityUpdates` | `bool` | `false` | Partially updates indexed availability after stock changes. When `Stores[*]:IncludeStock` is enabled, also updates the indexed stock amount. |
 | `Indexing:BatchSize` | `int` | `1000` | Batch size for Algolia save/replace/delete operations. |
 | `Indexing:ProductProperties` | `string[]` | `[]` | Additional product properties/metafields to include in product records. Supports modifiers documented below. |
 | `Indexing:AttributesForFaceting` | `string[]` | `[]` | Algolia facet expressions to preserve on product indexes, such as `filterOnly(categoryPageId)` or `searchable(brand)`. |
@@ -233,6 +232,7 @@ public sealed class ProductSearchController
 | `Stores` | `object[]` | `[]` | Store aliases supported by the plugin. Locale/currency are resolved from Ekom store data. |
 | `Stores[*]:Alias` | `string` | required | Ekom store alias. |
 | `Stores[*]:IncludeStock` | `bool` | `false` | Includes product stock in indexed records for this store. |
+| `Stores[*]:EnableAvailabilityUpdates` | `bool` | `false` | Partially updates indexed availability after stock changes for this store. When `IncludeStock` is enabled, also updates the indexed stock amount. |
 | `Stores[*]:LanguageSettings:QueryLanguages` | `string[]` | `[]` | ISO 639-1 languages used for language-specific query processing. |
 | `Stores[*]:LanguageSettings:IndexLanguages` | `string[]` | `[]` | ISO 639-1 languages used for language-specific indexing. |
 | `Stores[*]:LanguageSettings:RemoveStopWords` | `bool` | `null` | Enables or disables stop-word removal for this store's product indexes. |
@@ -289,15 +289,18 @@ Enable partial product-record updates when stock changes:
 {
   "Ekom": {
     "Algolia": {
-      "Indexing": {
-        "EnableAvailabilityUpdates": true
-      }
+      "Stores": [
+        {
+          "Alias": "Store",
+          "EnableAvailabilityUpdates": true
+        }
+      ]
     }
   }
 }
 ```
 
-Ekom updates `Available` only when effective sellable availability changes, including stock-buffer, backorder, and variant availability rules. For products with variants, the parent record becomes unavailable only when every variant is unavailable. If `Stores[*]:IncludeStock` is `true`, every stock change also partially updates `Stock`; indexed variant records additionally update `variantStock`. Existing records are updated only—stock changes never create incomplete Algolia records.
+Ekom updates `Available` only for stores with `Stores[*]:EnableAvailabilityUpdates` enabled, and only when effective sellable availability changes, including stock-buffer, backorder, and variant availability rules. For products with variants, the parent record becomes unavailable only when every variant is unavailable. If `Stores[*]:IncludeStock` is `true`, every stock change also partially updates `Stock`; indexed variant records additionally update `variantStock`. Existing records are updated only—stock changes never create incomplete Algolia records.
 
 ### Indexing triggers and API keys
 

--- a/Plugins/Ekom.Algolia/Services/AlgoliaStoreResolver.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaStoreResolver.cs
@@ -46,6 +46,7 @@ internal sealed class AlgoliaStoreResolver
             Locale = ekomStore?.Culture?.Name,
             Currency = ekomStore?.Currency?.CurrencyValue,
             IncludeStock = configuredStore?.IncludeStock ?? false,
+            EnableAvailabilityUpdates = configuredStore?.EnableAvailabilityUpdates ?? false,
             Locales = locales,
             Currencies = currencies,
             LanguageSettings = configuredStore?.LanguageSettings ?? new(),

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
@@ -101,7 +101,7 @@ internal sealed class AlgoliaEkomEvents : IComponent
 
     private async Task OnStockChangedAsync(object sender, StockChangedEventArgs args, CancellationToken ct)
     {
-        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.EnableAvailabilityUpdates)
+        if (!_options.Enabled || !_options.Indexing.Enabled)
             return;
 
         using var scope = _scopeFactory.CreateScope();


### PR DESCRIPTION
## Summary
- move `EnableAvailabilityUpdates` from the global indexing settings to each Algolia store
- update only stores that explicitly enable availability updates
- document the store-scoped configuration and verify its options binding

## Test Plan
- [x] `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaSearchTests"`
- [x] `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -c Release -v:q`