### PR TITLE
chore(release): ignore Ekom test-only changes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
+      "exclude-paths": ["Ekom/Tests"],
       "bootstrap-sha": "135a8af01a63f7a55f4a730c82b8c1005d362d41",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary
- configure Release Please to exclude `Ekom/Tests` from Ekom package release detection
- keep Ekom releases for commits that also change package source

## Test Plan
- [x] `jq empty release-please-config.json`