### PR TITLE
fix(algolia): send ecommerce conversion object data

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaInsightsClientTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaInsightsClientTests.cs
@@ -1,6 +1,8 @@
 using Ekom.Algolia.Models.Events;
 using Ekom.Algolia.Services;
+using Ekom.Models;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using System.Net;
 using System.Text.Json;
 using Xunit;
@@ -13,7 +15,7 @@ public class AlgoliaInsightsClientTests
     [InlineData("Added To Cart")]
     [InlineData("Started Checkout")]
     [InlineData("Purchased")]
-    public async Task Sends_Conversion_Object_Data_As_Array(string eventName)
+    public async Task Sends_Ecommerce_Conversion_Object_Data_As_Array(string eventName)
     {
         using var handler = new CapturingHandler();
         using var httpClient = new HttpClient(handler)
@@ -28,12 +30,15 @@ public class AlgoliaInsightsClientTests
             Index = "products",
             UserToken = "user-token",
             ObjectIds = ["product-1"],
+            Currency = "USD",
             ObjectData =
             [
                 new Dictionary<string, object?>
                 {
-                    ["value"] = 10m,
-                    ["currency"] = "USD"
+                    ["queryID"] = "query-id",
+                    ["price"] = 10m,
+                    ["discount"] = 2m,
+                    ["quantity"] = 3m
                 }
             ]
         };
@@ -46,8 +51,13 @@ public class AlgoliaInsightsClientTests
             .GetProperty("objectData");
 
         Assert.Equal(JsonValueKind.Array, objectData.ValueKind);
-        Assert.Equal(10m, objectData[0].GetProperty("value").GetDecimal());
-        Assert.Equal("USD", objectData[0].GetProperty("currency").GetString());
+        Assert.Equal("query-id", objectData[0].GetProperty("queryID").GetString());
+        Assert.Equal(10m, objectData[0].GetProperty("price").GetDecimal());
+        Assert.Equal(2m, objectData[0].GetProperty("discount").GetDecimal());
+        Assert.Equal(3m, objectData[0].GetProperty("quantity").GetDecimal());
+        var sentEvent = document.RootElement.GetProperty("events")[0];
+        Assert.Equal("USD", sentEvent.GetProperty("currency").GetString());
+        Assert.False(sentEvent.TryGetProperty("queryID", out _));
     }
 
     [Fact]
@@ -74,6 +84,36 @@ public class AlgoliaInsightsClientTests
         using var document = JsonDocument.Parse(handler.RequestBody);
         var sentEvent = document.RootElement.GetProperty("events")[0];
         Assert.Equal("query-id", sentEvent.GetProperty("queryID").GetString());
+    }
+
+    [Fact]
+    public void Creates_Ecommerce_Object_Data_With_Per_Unit_Price_And_Discount()
+    {
+        var orderLineKey = Guid.NewGuid();
+        var tracking = new OrderTracking();
+        tracking.Algolia.AddLine(orderLineKey, "query-id");
+
+        var orderInfo = new Mock<IOrderInfo>();
+        orderInfo.SetupGet(order => order.Tracking).Returns(tracking);
+
+        var discountAmount = new Mock<ICalculatedPrice>();
+        discountAmount.SetupGet(amount => amount.Value).Returns(3.99m);
+
+        var amount = new Mock<IPrice>();
+        amount.SetupGet(price => price.Value).Returns(59.97m);
+        amount.SetupGet(price => price.DiscountAmount).Returns(discountAmount.Object);
+
+        var orderLine = new Mock<IOrderLine>();
+        orderLine.SetupGet(line => line.Key).Returns(orderLineKey);
+        orderLine.SetupGet(line => line.Quantity).Returns(3m);
+        orderLine.SetupGet(line => line.Amount).Returns(amount.Object);
+
+        var objectData = AlgoliaEventService.CreateObjectData(orderInfo.Object, orderLine.Object);
+
+        Assert.Equal("query-id", objectData["queryID"]);
+        Assert.Equal(19.99m, objectData["price"]);
+        Assert.Equal(1.33m, objectData["discount"]);
+        Assert.Equal(3m, objectData["quantity"]);
     }
 
     private sealed class CapturingHandler : HttpMessageHandler

--- a/Plugins/Ekom.Algolia/CHANGELOG.md
+++ b/Plugins/Ekom.Algolia/CHANGELOG.md
@@ -7,6 +7,10 @@
 * **algolia:** add optional variant-level product indexing for SKU search.
 * **algolia:** optionally update indexed availability and stock after stock changes.
 
+### Bug Fixes
+
+* **algolia:** send ecommerce conversion object data using Algolia's per-item schema.
+
 ## [0.2.49](https://github.com/Vettvangur/Ekom/compare/Ekom.Algolia-v0.2.48...Ekom.Algolia-v0.2.49) (2026-09-03)
 
 

--- a/Plugins/Ekom.Algolia/Models/Events/AlgoliaInsightsEvent.cs
+++ b/Plugins/Ekom.Algolia/Models/Events/AlgoliaInsightsEvent.cs
@@ -9,6 +9,7 @@ public sealed class AlgoliaInsightsEvent
     public required IReadOnlyList<string> ObjectIds { get; init; }
 
     public string? QueryId { get; init; }
+    public string? Currency { get; init; }
     public DateTimeOffset? Timestamp { get; init; }
     public IReadOnlyList<IReadOnlyDictionary<string, object?>>? ObjectData { get; init; }
 }

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -279,7 +279,7 @@ await fetch('/ekom/order/add', {
 });
 ```
 
-The stored token is used for Ekom's add-to-cart, checkout, and purchase Insights events. Ekom also uses each persisted line query ID for the corresponding conversion event. The Order Info tracking view shows an Algolia subsection only when this data exists.
+The stored token is used for Ekom's add-to-cart, checkout, and purchase Insights events. Ekom sends the persisted query ID with its matching order-line object data, together with VAT-inclusive unit price, optional unit discount, quantity, and the order currency. Checkout and purchase events group up to 20 order lines per Algolia event. The Order Info tracking view shows an Algolia subsection only when this data exists.
 
 ### Stock availability updates
 

--- a/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
@@ -65,6 +65,9 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
         if (!_options.Enabled || !_options.Events.Enabled || !_options.Events.AddedToCart)
             return Task.CompletedTask;
 
+        if (orderLine.Quantity <= 0)
+            return Task.CompletedTask;
+
         var userToken = GetUserToken(orderInfo);
         if (string.IsNullOrWhiteSpace(userToken))
             return Task.CompletedTask;
@@ -85,16 +88,8 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             Index = indexName,
             UserToken = userToken,
             ObjectIds = new[] { orderLine.ProductKey.ToString() },
-            QueryId = orderInfo.Tracking?.Algolia?.GetQueryId(orderLine.Key),
-            ObjectData =
-            [
-                new Dictionary<string, object?>
-                {
-                    ["quantity"] = orderLine.Quantity,
-                    ["value"] = orderLine.Amount.Value,
-                    ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-                }
-            ]
+            Currency = orderInfo.StoreInfo.Currency.CurrencyValue,
+            ObjectData = [CreateObjectData(orderInfo, orderLine)]
         };
 
         return _insightsClient.SendEventsAsync(new[] { evt }, ct);
@@ -118,7 +113,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             localeOverride: orderInfo.StoreInfo.Culture,
             currencyOverride: orderInfo.StoreInfo.Currency.CurrencyValue);
 
-        var events = CreateOrderLineConversionEvents(orderInfo, userToken, indexName, "Started Checkout");
+        var events = CreateOrderConversionEvents(orderInfo, userToken, indexName, "Started Checkout");
         if (events.Count == 0)
             return Task.CompletedTask;
 
@@ -143,7 +138,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             localeOverride: orderInfo.StoreInfo.Culture,
             currencyOverride: orderInfo.StoreInfo.Currency.CurrencyValue);
 
-        var events = CreateOrderLineConversionEvents(orderInfo, userToken, indexName, "Purchased");
+        var events = CreateOrderConversionEvents(orderInfo, userToken, indexName, "Purchased");
         if (events.Count == 0)
             return Task.CompletedTask;
 
@@ -153,30 +148,43 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
     private string? GetUserToken(IOrderInfo orderInfo)
         => orderInfo.Tracking?.Algolia?.UserToken ?? _userTokenProvider.GetOrCreateUserToken();
 
-    private static IReadOnlyList<AlgoliaInsightsEvent> CreateOrderLineConversionEvents(
+    private static IReadOnlyList<AlgoliaInsightsEvent> CreateOrderConversionEvents(
         IOrderInfo orderInfo,
         string userToken,
         string indexName,
         string eventName)
         => orderInfo.OrderLines
-            .Select(orderLine => new AlgoliaInsightsEvent
+            .Where(orderLine => orderLine.Quantity > 0)
+            .Chunk(20)
+            .Select(orderLines => new AlgoliaInsightsEvent
             {
                 EventType = "conversion",
                 EventName = eventName,
                 Index = indexName,
                 UserToken = userToken,
-                ObjectIds = new[] { orderLine.ProductKey.ToString() },
-                QueryId = orderInfo.Tracking?.Algolia?.GetQueryId(orderLine.Key),
-                ObjectData =
-                [
-                    new Dictionary<string, object?>
-                    {
-                        ["quantity"] = orderLine.Quantity,
-                        ["value"] = orderLine.Amount.Value,
-                        ["currency"] = orderInfo.StoreInfo.Currency.CurrencyValue
-                    }
-                ]
+                ObjectIds = orderLines.Select(orderLine => orderLine.ProductKey.ToString()).ToList(),
+                Currency = orderInfo.StoreInfo.Currency.CurrencyValue,
+                ObjectData = orderLines.Select(orderLine => CreateObjectData(orderInfo, orderLine)).ToList()
             })
             .ToList();
+
+    internal static IReadOnlyDictionary<string, object?> CreateObjectData(IOrderInfo orderInfo, IOrderLine orderLine)
+    {
+        var quantity = orderLine.Quantity;
+        var amount = orderLine.Amount;
+        var objectData = new Dictionary<string, object?>();
+        var queryId = orderInfo.Tracking?.Algolia?.GetQueryId(orderLine.Key);
+        if (!string.IsNullOrWhiteSpace(queryId))
+            objectData["queryID"] = queryId;
+
+        objectData["price"] = amount.Value / quantity;
+
+        var discount = amount.DiscountAmount.Value / quantity;
+        if (discount > 0)
+            objectData["discount"] = discount;
+
+        objectData["quantity"] = quantity;
+        return objectData;
+    }
 
 }

--- a/Plugins/Ekom.Algolia/Services/AlgoliaInsightsClient.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaInsightsClient.cs
@@ -72,6 +72,9 @@ internal sealed class AlgoliaInsightsClient : IAlgoliaInsightsClient
         if (!string.IsNullOrWhiteSpace(evt.QueryId))
             json["queryID"] = evt.QueryId;
 
+        if (!string.IsNullOrWhiteSpace(evt.Currency))
+            json["currency"] = evt.Currency;
+
         if (evt.ObjectData != null && evt.ObjectData.Count > 0)
         {
             var data = new JsonArray();


### PR DESCRIPTION
## Summary
- align add-to-cart, checkout, and purchase payloads with Algolia ecommerce object-data requirements
- send VAT-inclusive unit price, optional unit discount, item quantity, and per-item query IDs
- group order-line conversions into index events of up to 20 object IDs and send currency at event level

## Test Plan
- [x] `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaInsightsClientTests"`
- [x] `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -c Release -v:q`