### PR TITLE
fix(algolia): send ISO currency for insights events

### DIFF
--- a/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
+++ b/Plugins/Ekom.Algolia/Services/AlgoliaEventService.cs
@@ -88,7 +88,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
             Index = indexName,
             UserToken = userToken,
             ObjectIds = new[] { orderLine.ProductKey.ToString() },
-            Currency = orderInfo.StoreInfo.Currency.CurrencyValue,
+            Currency = orderInfo.StoreInfo.Currency.ISOCurrencySymbol,
             ObjectData = [CreateObjectData(orderInfo, orderLine)]
         };
 
@@ -163,7 +163,7 @@ internal sealed class AlgoliaEventService : IAlgoliaEventService
                 Index = indexName,
                 UserToken = userToken,
                 ObjectIds = orderLines.Select(orderLine => orderLine.ProductKey.ToString()).ToList(),
-                Currency = orderInfo.StoreInfo.Currency.CurrencyValue,
+                Currency = orderInfo.StoreInfo.Currency.ISOCurrencySymbol,
                 ObjectData = orderLines.Select(orderLine => CreateObjectData(orderInfo, orderLine)).ToList()
             })
             .ToList();


### PR DESCRIPTION
## Summary
- use the store ISO-4217 currency symbol for Algolia Insights ecommerce events
- retain the configured locale currency value for Algolia index naming

## Test Plan
- [x] `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaInsightsClientTests"`
- [x] `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" -c Release -v:q`