### PR TITLE
fix(umbraco): improve cache fill and string values

### DIFF
--- a/Ekom/Ekom.Core/Ekom.Common/PriceCache.cs
+++ b/Ekom/Ekom.Core/Ekom.Common/PriceCache.cs
@@ -6,6 +6,8 @@ namespace Ekom.Cache;
 public static class PriceCache
 {
     private static readonly object _lock = new();
+    private static int _bulkInvalidationDepth;
+    private static bool _compactionPending;
 
     private static IMemoryCache? _cache;
 
@@ -62,7 +64,22 @@ public static class PriceCache
             new PriceGenerationEventArgs(itemKey, newGen)
         );
 
-        (Cache as MemoryCache)?.Compact(0.05);
+        if (DeferCompaction())
+        {
+            return;
+        }
+
+        CompactCache();
+    }
+
+    public static IDisposable BeginBulkInvalidation()
+    {
+        lock (_lock)
+        {
+            _bulkInvalidationDepth++;
+        }
+
+        return new BulkInvalidationScope();
     }
 
     public static void InvalidateAll()
@@ -78,6 +95,53 @@ public static class PriceCache
 
     public static event Func<PriceGenerationEventArgs, CancellationToken, ValueTask>? OnGenerationCreatedAsync;
     public static event EventHandler<PriceGenerationEventArgs>? OnGenerationInvalidated;
+
+    private static bool DeferCompaction()
+    {
+        lock (_lock)
+        {
+            if (_bulkInvalidationDepth == 0)
+            {
+                return false;
+            }
+
+            _compactionPending = true;
+            return true;
+        }
+    }
+
+    private static void CompactCache() => (_cache as MemoryCache)?.Compact(0.05);
+
+    private sealed class BulkInvalidationScope : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            var compact = false;
+            lock (_lock)
+            {
+                _bulkInvalidationDepth--;
+                if (_bulkInvalidationDepth == 0 && _compactionPending)
+                {
+                    _compactionPending = false;
+                    compact = true;
+                }
+            }
+
+            if (compact)
+            {
+                CompactCache();
+            }
+        }
+    }
 
     private static async ValueTask<string> RaiseGenerationCreatedAsync(string itemKey, string gen, CancellationToken ct)
     {

--- a/Ekom/Ekom.Core/Ekom/Cache/Base/PerStoreCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/Base/PerStoreCache.cs
@@ -301,6 +301,8 @@ abstract class PerStoreCache<TItem> : ICache, IClearableCache, IPerStoreCache, I
                         curRouteIndex![norm] = r.Key;
                     }
                 }
+
+                OnStoreCacheItemAdded(store, r.Key, item);
             }
             catch (Exception ex)
             {
@@ -316,6 +318,10 @@ abstract class PerStoreCache<TItem> : ICache, IClearableCache, IPerStoreCache, I
         }
 
         return count;
+    }
+
+    protected virtual void OnStoreCacheItemAdded(IStore store, Guid key, TItem item)
+    {
     }
 
     // -----------------------------

--- a/Ekom/Ekom.Core/Ekom/Cache/VariantCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/VariantCache.cs
@@ -46,29 +46,21 @@ class VariantCache : PerStoreCache<IVariant>
 
     protected override int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
     {
-        // base builds: Cache[store], IdIndex, SkuIndex
-        var count = base.FillStoreCache(store, results, nodeAlias);
+        _groupIndex[store.Alias] = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
+        _productIndex[store.Alias] = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
 
-        // rebuild group + product indexes for the store from the freshly built store cache
-        var gi = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
-        var pi = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
+        return base.FillStoreCache(store, results, nodeAlias);
+    }
 
-        if (Cache.TryGetValue(store.Alias, out var storeCache))
-        {
-            foreach (var kv in storeCache)
-            {
-                var key = kv.Key;
-                var v = kv.Value;
+    protected override void OnStoreCacheItemAdded(IStore store, Guid key, IVariant item)
+    {
+        GetStoreGroupIndex(store.Alias)
+            .GetOrAdd(item.VariantGroupId, _ => new ConcurrentDictionary<Guid, byte>())
+            .TryAdd(key, 0);
 
-                gi.GetOrAdd(v.VariantGroupId, _ => new ConcurrentDictionary<Guid, byte>()).TryAdd(key, 0);
-                pi.GetOrAdd(v.ProductId, _ => new ConcurrentDictionary<Guid, byte>()).TryAdd(key, 0);
-            }
-        }
-
-        _groupIndex[store.Alias] = gi;
-        _productIndex[store.Alias] = pi;
-
-        return count;
+        GetStoreProductIndex(store.Alias)
+            .GetOrAdd(item.ProductId, _ => new ConcurrentDictionary<Guid, byte>())
+            .TryAdd(key, 0);
     }
 
     public override void ClearCache()

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
@@ -184,6 +184,7 @@ class EkomStartup : IComponent
 
             orderRepo?.MigrateOrderTableAsync();
             orderRepo?.MigrateStockToDecimalAsync();
+            using var priceCacheScope = PriceCache.BeginBulkInvalidation();
 
             foreach (var cacheEntry in _config.CacheList.Value)
             {

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/NodeEntityExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/NodeEntityExtensions.cs
@@ -80,35 +80,50 @@ public static class NodeEntityExtensions
         {
             return (T)(object)ProductHelper.GetProducts(val);
         }
-        if (typeof(T) == typeof(IEnumerable<string>) || typeof(T) == typeof(List<string>))
+        if (IsStringCollectionType<T>())
         {
-            if (string.IsNullOrWhiteSpace(val))
-            {
-                return (T)(object)Enumerable.Empty<string>();
-            }
-
-            IEnumerable<string> result;
-
-            // Try to detect JSON array
-            if (val.TrimStart().StartsWith("["))
-            {
-                result = JsonConvert.DeserializeObject<List<string>>(val) ?? Enumerable.Empty<string>();
-            }
-            else
-            {
-                // Assume comma-separated string
-                result = val.Split(',').Select(x => x.Trim()).Where(x => !string.IsNullOrWhiteSpace(x));
-            }
-
-            if (typeof(T) == typeof(List<string>))
-            {
-                return (T)(object)result.ToList();
-            }
-
-            return (T)(object)result;
+            return (T)(object)GetStringCollection(val, typeof(T));
         }
 
         return (T)(object)val;
+    }
+
+    private static bool IsStringCollectionType<T>()
+    {
+        var type = typeof(T);
+        return type == typeof(IEnumerable<string>)
+            || type == typeof(IReadOnlyCollection<string>)
+            || type == typeof(IReadOnlyList<string>)
+            || type == typeof(List<string>)
+            || type == typeof(string[]);
+    }
+
+    private static object GetStringCollection(string value, Type targetType)
+    {
+        List<string> values;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            values = [];
+        }
+        else if (value.TrimStart().StartsWith("[", StringComparison.Ordinal))
+        {
+            try
+            {
+                values = JsonConvert.DeserializeObject<List<string>>(value) ?? [];
+            }
+            catch (Newtonsoft.Json.JsonException)
+            {
+                values = [];
+            }
+        }
+        else
+        {
+            values = value
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+
+        return targetType == typeof(string[]) ? values.ToArray() : values;
     }
 
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializer.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializer.cs
@@ -60,6 +60,7 @@ internal sealed class EkomCacheInitializer
                 .Concat(rootNode.Descendants())
                 .ToList();
             using var cacheBuildScope = _cacheBuildContext.Begin(allNodes);
+            using var priceCacheScope = PriceCache.BeginBulkInvalidation();
 
             foreach (var cacheEntry in _config.CacheList.Value)
             {

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/NodeEntityExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/NodeEntityExtensions.cs
@@ -29,6 +29,11 @@ public static class NodeEntityExtensions
             throw new ArgumentException("A property alias is required.", nameof(propertyAlias));
         }
 
+        if (IsStringCollectionType<T>())
+        {
+            return ConvertRawValue<T>(node.GetValue(propertyAlias, alias));
+        }
+
         if (string.IsNullOrWhiteSpace(alias))
         {
             var content = GetPublishedContent(node.Key);
@@ -68,7 +73,50 @@ public static class NodeEntityExtensions
             return (T)(object)GetLinks(value);
         }
 
+        if (IsStringCollectionType<T>())
+        {
+            return (T)(object)GetStringCollection(value, typeof(T));
+        }
+
         return default;
+    }
+
+    private static bool IsStringCollectionType<T>()
+    {
+        var type = typeof(T);
+        return type == typeof(IEnumerable<string>)
+            || type == typeof(IReadOnlyCollection<string>)
+            || type == typeof(IReadOnlyList<string>)
+            || type == typeof(List<string>)
+            || type == typeof(string[]);
+    }
+
+    private static object GetStringCollection(string value, Type targetType)
+    {
+        List<string> values;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            values = [];
+        }
+        else if (value.TrimStart().StartsWith("[", StringComparison.Ordinal))
+        {
+            try
+            {
+                values = JsonConvert.DeserializeObject<List<string>>(value) ?? [];
+            }
+            catch (JsonException)
+            {
+                values = [];
+            }
+        }
+        else
+        {
+            values = value
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+
+        return targetType == typeof(string[]) ? values.ToArray() : values;
     }
 
     private static IPublishedContent? GetPublishedContent(Guid key)

--- a/Ekom/Tests/Ekom.Tests/Tests/PriceCacheTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/PriceCacheTests.cs
@@ -155,5 +155,37 @@ public class PriceCacheTests
         }
     }
 
+    [Fact]
+    public void BeginBulkInvalidation_PreservesItemInvalidationEvents()
+    {
+        var itemKey = CreateItemKey();
+        var invalidatedGenerations = new List<string>();
+
+        void Handler(object? sender, PriceCache.PriceGenerationEventArgs args)
+        {
+            if (args.ItemKey == itemKey)
+            {
+                invalidatedGenerations.Add(args.Generation);
+            }
+        }
+
+        PriceCache.OnGenerationInvalidated += Handler;
+        try
+        {
+            using (PriceCache.BeginBulkInvalidation())
+            {
+                PriceCache.InvalidateItem(itemKey);
+                PriceCache.InvalidateItem(itemKey);
+            }
+
+            Assert.Equal(2, invalidatedGenerations.Count);
+            Assert.NotEqual(invalidatedGenerations[0], invalidatedGenerations[1]);
+        }
+        finally
+        {
+            PriceCache.OnGenerationInvalidated -= Handler;
+        }
+    }
+
     private static string CreateItemKey() => $"test-{Guid.NewGuid():N}";
 }


### PR DESCRIPTION
## Summary
- Batch price-cache compaction while startup caches are populated and build variant indexes in the primary cache pass.
- Parse JSON and comma-separated string collections through `GetValue` for Umbraco 10 and 17, including array and read-only collection targets.

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~PriceCacheTests" -v:q`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -v:q`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -v:q`
