### PR TITLE
perf(cache): reduce variant cache startup work

### DIFF
--- a/Ekom/Ekom.Core/Ekom.Common/CacheInitializationScope.cs
+++ b/Ekom/Ekom.Core/Ekom.Common/CacheInitializationScope.cs
@@ -1,0 +1,30 @@
+namespace Ekom.Cache;
+
+public static class CacheInitializationScope
+{
+    private static readonly AsyncLocal<int> Depth = new();
+
+    public static bool IsActive => Depth.Value > 0;
+
+    public static IDisposable Begin()
+    {
+        Depth.Value++;
+        return new Scope();
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            Depth.Value--;
+        }
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Variant.cs
@@ -353,8 +353,11 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     /// <param name="store"></param>
     public Variant(UmbracoContent item, IStore store) : base(item, store)
     {
-        Product?.InvalidateCache();
-        PriceCache.InvalidateItem(Path);
+        if (!CacheInitializationScope.IsActive)
+        {
+            Product?.InvalidateCache();
+            PriceCache.InvalidateItem(Path);
+        }
 
         _priceValue = GetValue("price", Store.Alias) ?? string.Empty;
         OriginalPrice = CreateOriginalPrice();

--- a/Ekom/Ekom.Core/Ekom/Models/VariantGroup.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/VariantGroup.cs
@@ -1,4 +1,5 @@
 using Ekom.API;
+using Ekom.Cache;
 using Ekom.Utilities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -123,6 +124,9 @@ public class VariantGroup : PerStoreNodeEntity, IVariantGroup
     {
         storeAlias = store.Alias;
 
-        Product?.InvalidateCache();
+        if (!CacheInitializationScope.IsActive)
+        {
+            Product?.InvalidateCache();
+        }
     }
 }

--- a/Ekom/Ekom.Core/Ekom/Utilities/LoopTimer.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/LoopTimer.cs
@@ -5,7 +5,8 @@ namespace Ekom.Utilities
 {
     public class LoopTimer
     {
-        private const int SampleSize = 100;  // Number of iterations to sample
+        private const int WarmupIterations = 100;
+        private const int SampleSize = 100;
         private const double Threshold = 0.005; // Time threshold in seconds (5ms)
 
         private readonly int _totalIterations;
@@ -13,6 +14,7 @@ namespace Ekom.Utilities
         private readonly Stopwatch _stopwatch = new();
         private readonly ILogger _logger;
         private readonly string _nodeAlias;
+        private int _iterations;
 
         public LoopTimer(int totalIterations, ILogger logger, string nodeAlias)
         {
@@ -35,7 +37,13 @@ namespace Ekom.Utilities
                 return;
             }
 
-            if (_sampleTimes.Count > SampleSize)
+            _iterations++;
+            if (_iterations <= WarmupIterations)
+            {
+                return;
+            }
+
+            if (_sampleTimes.Count >= SampleSize)
             {
                 return;
             }
@@ -55,7 +63,7 @@ namespace Ekom.Utilities
             if (averageTime > Threshold)
             {
                 _logger.LogWarning(
-                    $"WARNING: Estimated total time for {_totalIterations} iterations of {_nodeAlias}: {estimatedTotalTime} seconds. Average loop time for first {SampleSize} iterations is {averageTime * 1000} milliseconds, which exceeds the threshold of {Threshold * 1000} milliseconds.");
+                    $"WARNING: Estimated total time for {_totalIterations} iterations of {_nodeAlias}: {estimatedTotalTime} seconds. Average loop time for {SampleSize} iterations after a {WarmupIterations} iteration warmup is {averageTime * 1000} milliseconds, which exceeds the threshold of {Threshold * 1000} milliseconds.");
             }
 
 

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
@@ -184,6 +184,7 @@ class EkomStartup : IComponent
 
             orderRepo?.MigrateOrderTableAsync();
             orderRepo?.MigrateStockToDecimalAsync();
+            using var cacheInitializationScope = CacheInitializationScope.Begin();
             using var priceCacheScope = PriceCache.BeginBulkInvalidation();
 
             foreach (var cacheEntry in _config.CacheList.Value)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializer.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializer.cs
@@ -60,6 +60,7 @@ internal sealed class EkomCacheInitializer
                 .Concat(rootNode.Descendants())
                 .ToList();
             using var cacheBuildScope = _cacheBuildContext.Begin(allNodes);
+            using var cacheInitializationScope = CacheInitializationScope.Begin();
             using var priceCacheScope = PriceCache.BeginBulkInvalidation();
 
             foreach (var cacheEntry in _config.CacheList.Value)

--- a/Ekom/Tests/Ekom.Tests/Tests/CacheInitializationScopeTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/CacheInitializationScopeTests.cs
@@ -1,0 +1,27 @@
+using Ekom.Cache;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class CacheInitializationScopeTests
+{
+    [Fact]
+    public void Begin_SetsIsActiveUntilTheOutermostScopeIsDisposed()
+    {
+        Assert.False(CacheInitializationScope.IsActive);
+
+        using (CacheInitializationScope.Begin())
+        {
+            Assert.True(CacheInitializationScope.IsActive);
+
+            using (CacheInitializationScope.Begin())
+            {
+                Assert.True(CacheInitializationScope.IsActive);
+            }
+
+            Assert.True(CacheInitializationScope.IsActive);
+        }
+
+        Assert.False(CacheInitializationScope.IsActive);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid per-variant and per-group cache invalidations while the startup cache is built
- sample LoopTimer warnings after its warmup period

## Validation
- dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~CacheInitializationScopeTests|FullyQualifiedName~PriceCacheTests" -v:q
- dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -v:q