### PR TITLE
fix(cache): rebuild on manual refresh

### DIFF
--- a/Ekom/Ekom.Core/Ekom.AspNetCore/Registrations.cs
+++ b/Ekom/Ekom.Core/Ekom.AspNetCore/Registrations.cs
@@ -207,7 +207,7 @@ static class Registrations
         services.AddTransient<Ekom.API.Store>(f =>
             new Ekom.API.Store(
                 f.GetService<IStoreService>(),
-                f.GetService<Configuration>()
+                f.GetRequiredService<ICacheRefreshService>()
             )
         );
         services.AddTransient<Discounts>(f =>

--- a/Ekom/Ekom.Core/Ekom/API/Store.cs
+++ b/Ekom/Ekom.Core/Ekom/API/Store.cs
@@ -1,4 +1,3 @@
-using Ekom.Cache;
 using Ekom.Interfaces;
 using Ekom.Models;
 using Ekom.Services;
@@ -18,16 +17,16 @@ public class Store
     public static Store Instance => Configuration.Resolver.GetService<Store>();
 
     readonly IStoreService _storeSvc;
-    readonly Configuration _config;
+    readonly ICacheRefreshService _cacheRefreshService;
     /// <summary>
     /// ctor
     /// </summary>
     internal Store(
         IStoreService storeService,
-        Configuration config)
+        ICacheRefreshService cacheRefreshService)
     {
         _storeSvc = storeService;
-        _config = config;
+        _cacheRefreshService = cacheRefreshService;
     }
 
     /// <summary>
@@ -88,20 +87,7 @@ public class Store
 
     public void RefreshCache()
     {
-        foreach (ICache cacheEntry in _config.CacheList.Value)
-        {
-            cacheEntry.FillCache();
-        }
-
-        ICache? stockCache = _config.PerStoreStock
-            ? Configuration.Resolver.GetService<IPerStoreCache<StockData>>()
-            : Configuration.Resolver.GetService<IBaseCache<StockData>>()
-                as ICache;
-
-        stockCache?.FillCache();
-
-        Configuration.Resolver.GetService<ICouponCache>()?
-            .FillCache();
+        _cacheRefreshService.RefreshCache();
     }
 
 }

--- a/Ekom/Ekom.Core/Ekom/Interfaces/ICacheRefreshService.cs
+++ b/Ekom/Ekom.Core/Ekom/Interfaces/ICacheRefreshService.cs
@@ -1,0 +1,6 @@
+namespace Ekom.Interfaces;
+
+public interface ICacheRefreshService
+{
+    void RefreshCache();
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Ekom.AspNetCore;
+using Ekom.Interfaces;
 using Ekom.Services;
 using Ekom.Tracking;
 using Ekom.Umb.Services;
@@ -25,6 +26,8 @@ public static class ApplicationBuilderExtensions
         services.AddHttpClient();
 
         services.AddTransient<IMemberService, MemberService>();
+        services.AddTransient<EkomCacheInitializer>();
+        services.AddSingleton<ICacheRefreshService, EkomCacheRefreshService>();
         services.AddTransient<INodeService, NodeService>();
         services.AddTransient<IImportService, ImportService>();
         services.AddTransient<ImportMediaService>();

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomCacheInitializer.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomCacheInitializer.cs
@@ -1,12 +1,8 @@
 using Ekom.Cache;
 using Ekom.Interfaces;
 using Ekom.Models;
-using Ekom.Umb.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Web;
-using Umbraco.Extensions;
 
 namespace Ekom.Umb;
 
@@ -15,27 +11,15 @@ internal sealed class EkomCacheInitializer
     private static readonly object InitializationLock = new();
     private readonly Configuration _config;
     private readonly IServiceProvider _factory;
-    private readonly IUmbracoContextFactory _contextFactory;
-    private readonly IPublishedContentQuery _publishedContentQuery;
-    private readonly EkomCacheBuildContext _cacheBuildContext;
-    private readonly Umbraco17ContentCache _contentCache;
     private readonly ILogger<EkomCacheInitializer> _logger;
 
     public EkomCacheInitializer(
         Configuration config,
         IServiceProvider factory,
-        IUmbracoContextFactory contextFactory,
-        IPublishedContentQuery publishedContentQuery,
-        EkomCacheBuildContext cacheBuildContext,
-        Umbraco17ContentCache contentCache,
         ILogger<EkomCacheInitializer> logger)
     {
         _config = config;
         _factory = factory;
-        _contextFactory = contextFactory;
-        _publishedContentQuery = publishedContentQuery;
-        _cacheBuildContext = cacheBuildContext;
-        _contentCache = contentCache;
         _logger = logger;
     }
 
@@ -50,19 +34,6 @@ internal sealed class EkomCacheInitializer
                     ClearCaches();
                 }
 
-                using var contextReference = _contextFactory.EnsureUmbracoContext();
-                var rootNode = _publishedContentQuery.ContentAtRoot()
-                    .FirstOrDefault(x => x.IsDocumentType("ekom"));
-
-                if (rootNode == null)
-                {
-                    throw new InvalidOperationException("Ekom root node not found.");
-                }
-
-                var allNodes = rootNode.AncestorsOrSelf()
-                    .Concat(rootNode.Descendants())
-                    .ToList();
-                using var cacheBuildScope = _cacheBuildContext.Begin(allNodes);
                 using var cacheInitializationScope = CacheInitializationScope.Begin();
                 using var priceCacheScope = PriceCache.BeginBulkInvalidation();
 
@@ -76,7 +47,6 @@ internal sealed class EkomCacheInitializer
                     : _factory.GetService<IBaseCache<StockData>>() as ICache;
 
                 stockCache?.FillCache();
-
                 _factory.GetService<ICouponCache>()?.FillCache();
             }
             catch (Exception ex)
@@ -88,7 +58,6 @@ internal sealed class EkomCacheInitializer
 
     private void ClearCaches()
     {
-        _contentCache.Clear();
         PriceCache.InvalidateAll();
 
         foreach (var cacheEntry in _config.CacheList.Value.OfType<IClearableCache>())

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomCacheRefreshService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomCacheRefreshService.cs
@@ -1,0 +1,20 @@
+using Ekom.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ekom.Umb;
+
+internal sealed class EkomCacheRefreshService : ICacheRefreshService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public EkomCacheRefreshService(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void RefreshCache()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        scope.ServiceProvider.GetRequiredService<EkomCacheInitializer>().Initialize(true);
+    }
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomStartup.cs
@@ -1,8 +1,6 @@
 using Ekom.App_Start;
 using Ekom.Cache;
 using Ekom.Exceptions;
-using Ekom.Interfaces;
-using Ekom.Models;
 using Ekom.Payments;
 using Ekom.Repositories;
 using Ekom.Services;
@@ -133,7 +131,6 @@ public class RemoveCoreMemberSearchableTreeComposer : IComposer
 class EkomStartup : IComponent
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
 {
-    readonly Configuration _config;
     readonly ILogger _logger;
     readonly IServiceProvider _factory;
     readonly IMemoryCache _cache;
@@ -144,14 +141,12 @@ class EkomStartup : IComponent
     /// 
     /// </summary>
     public EkomStartup(
-        Configuration config,
         ILogger<EkomStartup> logger,
         IServiceProvider factory,
         IMemoryCache cache,
         IRuntimeState runtimeState,
         IOptions<RequestLocalizationOptions> requestLocalizationOptions)
     {
-        _config = config;
         _logger = logger;
         _factory = factory;
         _cache = cache;
@@ -184,24 +179,7 @@ class EkomStartup : IComponent
 
             orderRepo?.MigrateOrderTableAsync();
             orderRepo?.MigrateStockToDecimalAsync();
-            using var cacheInitializationScope = CacheInitializationScope.Begin();
-            using var priceCacheScope = PriceCache.BeginBulkInvalidation();
-
-            foreach (var cacheEntry in _config.CacheList.Value)
-            {
-                cacheEntry.FillCache();
-            }
-
-            // Controls which stock cache will be populated
-            var stockCache = _config.PerStoreStock
-                ? _factory.GetService<IPerStoreCache<StockData>>()
-                : _factory.GetService<IBaseCache<StockData>>()
-                as ICache;
-
-            stockCache?.FillCache();
-            
-            _factory.GetService<ICouponCache>()?
-                .FillCache();
+            _factory.GetRequiredService<EkomCacheInitializer>().Initialize(false);
 
             Payments.Events.SuccessAsync += CompleteCheckoutAsync;
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Ekom.AspNetCore;
+using Ekom.Interfaces;
 using Ekom.Services;
 using Ekom.Tracking;
 using Ekom.Umb.CatalogCollection.Services;
@@ -26,6 +27,7 @@ public static class ApplicationBuilderExtensions
 
         services.AddTransient<IMemberService, MemberService>();
         services.AddScoped<EkomCacheInitializer>();
+        services.AddSingleton<ICacheRefreshService, EkomCacheRefreshService>();
         services.AddSingleton<EkomCacheBuildContext>();
         services.AddSingleton<Umbraco17ContentCache>();
         services.AddTransient<INodeService, NodeService>();

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializationHandler.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializationHandler.cs
@@ -5,7 +5,6 @@ namespace Ekom.Umb;
 
 internal sealed class EkomCacheInitializationHandler : INotificationHandler<UmbracoApplicationStartedNotification>
 {
-    private static readonly object InitializationLock = new();
     private readonly EkomCacheInitializer _cacheInitializer;
 
     public EkomCacheInitializationHandler(EkomCacheInitializer cacheInitializer)
@@ -15,9 +14,6 @@ internal sealed class EkomCacheInitializationHandler : INotificationHandler<Umbr
 
     public void Handle(UmbracoApplicationStartedNotification notification)
     {
-        lock (InitializationLock)
-        {
-            _cacheInitializer.Initialize(notification.IsRestarting);
-        }
+        _cacheInitializer.Initialize(notification.IsRestarting);
     }
 }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheRefreshService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheRefreshService.cs
@@ -1,0 +1,20 @@
+using Ekom.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ekom.Umb;
+
+internal sealed class EkomCacheRefreshService : ICacheRefreshService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public EkomCacheRefreshService(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void RefreshCache()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        scope.ServiceProvider.GetRequiredService<EkomCacheInitializer>().Initialize(true);
+    }
+}


### PR DESCRIPTION
## Summary
- route manual cache refreshes through host-specific restart rebuilds
- clear cached entities and price generations before refilling caches
- reuse startup cache scopes and the U17/18 node-build context
- serialize startup and manual cache initialization

## Test Plan
- dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -v:q
- dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -v:q
- dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~CacheInitializationScopeTests|FullyQualifiedName~PriceCacheTests" -v:q