### PR TITLE
feat(datatype): add store-aware folders

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Cache/Base/PerStoreCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/Base/PerStoreCache.cs
@@ -46,6 +46,7 @@ abstract class PerStoreCache<TItem> : ICache, IClearableCache, IPerStoreCache, I
     /// Umbraco Node Alias
     /// </summary>
     public abstract string NodeAlias { get; }
+    protected virtual string? StoreDisableFolderAlias => null;
 
     // -----------------------------
     // Primary per-store cache
@@ -194,16 +195,25 @@ abstract class PerStoreCache<TItem> : ICache, IClearableCache, IPerStoreCache, I
             var nodeService = scope.ServiceProvider.GetRequiredService<INodeService>();
 
             List<UmbracoContent> results = nodeService.NodesByTypes(NodeAlias).ToList();
+            IReadOnlyDictionary<int, IReadOnlyList<UmbracoContent>>? ancestorsByNodeId = null;
+
+            if (!string.IsNullOrEmpty(StoreDisableFolderAlias))
+            {
+                ancestorsByNodeId = results.ToDictionary(
+                    node => node.Id,
+                    node => (IReadOnlyList<UmbracoContent>)nodeService.NodeAncestors(node.Id.ToString()).ToList());
+            }
+
             _logger.LogInformation("Filling per store cache for {NodeAlias}... Nodes: {Count}", NodeAlias, results.Count);
 
             if (storeParam == null)
             {
                 foreach (IStore store in _storeCache.Cache.Select(x => x.Value))
-                    count += FillStoreCache(store, results, NodeAlias);
+                    count += FillStoreCache(store, results, NodeAlias, ancestorsByNodeId);
             }
             else
             {
-                count += FillStoreCache(storeParam, results, NodeAlias);
+                count += FillStoreCache(storeParam, results, NodeAlias, ancestorsByNodeId);
             }
         }
         catch (Exception ex)
@@ -231,7 +241,11 @@ abstract class PerStoreCache<TItem> : ICache, IClearableCache, IPerStoreCache, I
     /// <summary>
     /// Fill the given store's cache of TItem (and optional indexes).
     /// </summary>
-    protected virtual int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
+    protected virtual int FillStoreCache(
+        IStore store,
+        List<UmbracoContent> results,
+        string nodeAlias,
+        IReadOnlyDictionary<int, IReadOnlyList<UmbracoContent>>? ancestorsByNodeId)
     {
         int count = 0;
 
@@ -259,7 +273,11 @@ abstract class PerStoreCache<TItem> : ICache, IClearableCache, IPerStoreCache, I
 
             try
             {
-                if (r.IsItemDisabled(store))
+                var isDisabled = ancestorsByNodeId != null
+                    ? r.IsItemDisabled(store, ancestorsByNodeId[r.Id])
+                    : r.IsItemDisabled(store);
+
+                if (isDisabled)
                     continue;
 
                 TItem? item = _objFac?.Create(r, store)

--- a/Ekom/Ekom.Core/Ekom/Cache/CategoryCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/CategoryCache.cs
@@ -34,9 +34,13 @@ class CategoryCache : PerStoreCache<ICategory>
         => base.NormalizeRoute(route);
     protected override int GetId(ICategory item) => item.Id;
 
-    protected override int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
+    protected override int FillStoreCache(
+        IStore store,
+        List<UmbracoContent> results,
+        string nodeAlias,
+        IReadOnlyDictionary<int, IReadOnlyList<UmbracoContent>>? ancestorsByNodeId)
     {
-        var count = base.FillStoreCache(store, results, nodeAlias);
+        var count = base.FillStoreCache(store, results, nodeAlias, ancestorsByNodeId);
 
         RebuildIndexes(store.Alias);
 

--- a/Ekom/Ekom.Core/Ekom/Cache/DiscountCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/DiscountCache.cs
@@ -1,16 +1,13 @@
 using Ekom.Interfaces;
 using Ekom.Models;
-using Ekom.Services;
-using Ekom.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 
 namespace Ekom.Cache;
 
 class DiscountCache : PerStoreCache<IDiscount>
 {
     public override string NodeAlias { get; } = "ekmOrderDiscount";
+    protected override string? StoreDisableFolderAlias => "ekmOrderDiscountsFolder";
 
     /// <summary>
     /// ctor
@@ -25,48 +22,4 @@ class DiscountCache : PerStoreCache<IDiscount>
     {
     }
 
-    /// <summary>
-    /// Fill the given stores cache of TItem
-    /// </summary>
-    /// <param name="store">The current store being filled of TItem</param>
-    /// <param name="results">Examine search results</param>
-    /// <returns>Count of items added</returns>
-    protected override int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
-    {
-        int count = 0;
-
-        ConcurrentDictionary<Guid, IDiscount> curStoreCache
-            = Cache[store.Alias] = new ConcurrentDictionary<Guid, IDiscount>();
-
-        using var scope = _serviceScopeFactory.CreateScope();
-        var nodeService = scope.ServiceProvider.GetRequiredService<INodeService>();
-
-        foreach (UmbracoContent r in results)
-        {
-            try
-            {
-                IEnumerable<UmbracoContent> ancestors = nodeService.NodeAncestors(r.Id.ToString());
-
-                // Traverse up parent nodes, checking disabled status and published status
-                if (r.IsItemDisabled(store, ancestors)) continue;
-
-                IDiscount item = _objFac?.Create(r, store) ?? new Discount(r, store);
-
-                count++;
-
-                curStoreCache[r.Key] = item;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "Error on adding item with id: {Id} from Examine in Store: {Store}",
-                    r.Id,
-                    store.Alias
-                );
-            }
-        }
-
-        return count;
-    }
 }

--- a/Ekom/Ekom.Core/Ekom/Cache/PaymentProviderCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/PaymentProviderCache.cs
@@ -1,15 +1,13 @@
 using Ekom.Interfaces;
 using Ekom.Models;
-using Ekom.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 
 namespace Ekom.Cache;
 
 class PaymentProviderCache : PerStoreCache<IPaymentProvider>
 {
     public override string NodeAlias { get; } = "ekmPaymentProvider";
+    protected override string? StoreDisableFolderAlias => "ekmPaymentProvidersFolder";
 
     public PaymentProviderCache(
         Configuration config,
@@ -19,63 +17,5 @@ class PaymentProviderCache : PerStoreCache<IPaymentProvider>
         IServiceProvider serviceProvider
     ) : base(config, logger, storeCache, perStoreFactory, serviceProvider)
     {
-    }
-
-    public override void FillCache(IStore storeParam = null)
-    {
-        if (!string.IsNullOrEmpty(NodeAlias))
-        {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-
-            _logger.LogDebug("Starting to fill...");
-
-            int count = 0;
-
-            try
-            {
-                using var scope = _serviceScopeFactory.CreateScope();
-                var nodeService = scope.ServiceProvider.GetRequiredService<INodeService>();
-
-                UmbracoContent? paymentProviderRoot = nodeService.NodesByTypes("ekmPaymentProviders").FirstOrDefault();
-
-                if (paymentProviderRoot == null)
-                {
-                    throw new Exception("Ekom payment providers node not found.");
-                }
-
-                List<UmbracoContent> results = nodeService.NodeChildren(paymentProviderRoot.Id.ToString()).ToList();
-
-                if (storeParam == null) // Startup initialization
-                {
-                    foreach (IStore? store in _storeCache.Cache.Select(x => x.Value))
-                    {
-                        count += FillStoreCache(store, results, NodeAlias);
-                    }
-                }
-                else // Triggered with dynamic addition/removal of store
-                {
-                    count += FillStoreCache(storeParam, results, NodeAlias);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Filling per store cache Failed for {NodeAlias}!", NodeAlias);
-            }
-
-            stopwatch.Stop();
-            _logger.LogInformation(
-                "Finished filling per store cache with {Count} items for {NodeAlias}. Time it took to fill: {Elapsed}",
-                count,
-                NodeAlias,
-                stopwatch.Elapsed
-            );
-        }
-        else
-        {
-            _logger.LogError(
-                "No NodeAlias, Can not fill cache."
-            );
-        }
     }
 }

--- a/Ekom/Ekom.Core/Ekom/Cache/ProductCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/ProductCache.cs
@@ -41,9 +41,13 @@ class ProductCache : PerStoreCache<IProduct>
     /// <summary>
     /// Rebuild store cache + Id/Sku indexes (base) AND rebuild our category index for that store.
     /// </summary>
-    protected override int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
+    protected override int FillStoreCache(
+        IStore store,
+        List<UmbracoContent> results,
+        string nodeAlias,
+        IReadOnlyDictionary<int, IReadOnlyList<UmbracoContent>>? ancestorsByNodeId)
     {
-        var count = base.FillStoreCache(store, results, nodeAlias);
+        var count = base.FillStoreCache(store, results, nodeAlias, ancestorsByNodeId);
 
         var idx = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
 

--- a/Ekom/Ekom.Core/Ekom/Cache/ProductDiscountCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/ProductDiscountCache.cs
@@ -7,6 +7,7 @@ namespace Ekom.Cache;
 class ProductDiscountCache : PerStoreCache<IProductDiscount>
 {
     public override string NodeAlias { get; } = "ekmProductDiscount";
+    protected override string? StoreDisableFolderAlias => "ekmProductDiscountsFolder";
 
     public ProductDiscountCache(
         Configuration config,

--- a/Ekom/Ekom.Core/Ekom/Cache/ShippingProviderCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/ShippingProviderCache.cs
@@ -8,6 +8,7 @@ namespace Ekom.Cache;
 class ShippingProviderCache : PerStoreCache<IShippingProvider>
 {
     public override string NodeAlias { get; } = "ekmShippingProvider";
+    protected override string? StoreDisableFolderAlias => "ekmShippingProvidersFolder";
 
     public ShippingProviderCache(
         Configuration config,

--- a/Ekom/Ekom.Core/Ekom/Cache/VariantCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/VariantCache.cs
@@ -44,12 +44,16 @@ class VariantCache : PerStoreCache<IVariant>
     private ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>> GetStoreProductIndex(string storeAlias) =>
         _productIndex.GetOrAdd(storeAlias, _ => new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>());
 
-    protected override int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
+    protected override int FillStoreCache(
+        IStore store,
+        List<UmbracoContent> results,
+        string nodeAlias,
+        IReadOnlyDictionary<int, IReadOnlyList<UmbracoContent>>? ancestorsByNodeId)
     {
         _groupIndex[store.Alias] = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
         _productIndex[store.Alias] = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
 
-        return base.FillStoreCache(store, results, nodeAlias);
+        return base.FillStoreCache(store, results, nodeAlias, ancestorsByNodeId);
     }
 
     protected override void OnStoreCacheItemAdded(IStore store, Guid key, IVariant item)

--- a/Ekom/Ekom.Core/Ekom/Cache/VariantGroupCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/VariantGroupCache.cs
@@ -29,9 +29,13 @@ class VariantGroupCache : PerStoreCache<IVariantGroup>
     protected override bool EnableIdIndex => true;
     protected override int GetId(IVariantGroup item) => item.Id;
 
-    protected override int FillStoreCache(IStore store, List<UmbracoContent> results, string nodeAlias)
+    protected override int FillStoreCache(
+        IStore store,
+        List<UmbracoContent> results,
+        string nodeAlias,
+        IReadOnlyDictionary<int, IReadOnlyList<UmbracoContent>>? ancestorsByNodeId)
     {
-        var count = base.FillStoreCache(store, results, nodeAlias);
+        var count = base.FillStoreCache(store, results, nodeAlias, ancestorsByNodeId);
 
         var pi = new ConcurrentDictionary<int, ConcurrentDictionary<Guid, byte>>();
 

--- a/Ekom/Ekom.Core/Ekom/Utilities/ContentExtensions.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/ContentExtensions.cs
@@ -77,6 +77,30 @@ public static class ContentExtensions
             }
         }
 
+        var storeDisableFolderAlias = item.ContentTypeAlias switch
+        {
+            "ekmOrderDiscount" => "ekmOrderDiscountsFolder",
+            "ekmProductDiscount" => "ekmProductDiscountsFolder",
+            "ekmPaymentProvider" => "ekmPaymentProvidersFolder",
+            "ekmShippingProvider" => "ekmShippingProvidersFolder",
+            _ => null,
+        };
+
+        if (storeDisableFolderAlias != null)
+        {
+            foreach (var ancestor in ancestors.Where(x => x.IsDocumentType(storeDisableFolderAlias)))
+            {
+                var disableField = ancestor.GetValue("disable", store.Alias);
+
+                if (!string.IsNullOrEmpty(disableField) && disableField.ConvertToBool())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         if (item.ContentTypeAlias is not ("ekmProduct" or "ekmCategory" or "ekmProductVariantGroup"
             or "ekmProductVariant")) return false;
 

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EnsureNodesExist.cs
@@ -1458,6 +1458,8 @@ class EnsureNodesExist : IComponent
                 #endregion
             }
 
+            EnsureDiscountAndProviderFolderContentTypes();
+
             _logger.LogDebug("Done");
         }
 #pragma warning disable CA1031 // Should not kill startup
@@ -1504,6 +1506,92 @@ class EnsureNodesExist : IComponent
         }
 
         return textDt;
+    }
+
+    private void EnsureDiscountAndProviderFolderContentTypes()
+    {
+        var disableDataType = _dataTypeService.GetDataType("Ekom Property Editor - Boolean - Stores");
+        if (disableDataType == null)
+        {
+            _logger.LogWarning("Cannot create Ekom provider and discount folder document types because the store Disable data type is missing.");
+            return;
+        }
+
+        var ekomContainer = EnsureContainerExists("Ekom");
+        var discountsContainer = EnsureContainerExists("Discounts", 2, ekomContainer.Id);
+        var paymentProvidersContainer = EnsureContainerExists("Payment Providers", 2, ekomContainer.Id);
+        var shippingProvidersContainer = EnsureContainerExists("Shipping Providers", 2, ekomContainer.Id);
+
+        EnsureFolderContentType("Order Discounts Folder", "ekmOrderDiscountsFolder", discountsContainer.Id, "ekmOrderDiscounts", "ekmOrderDiscount", disableDataType);
+        EnsureFolderContentType("Product Discounts Folder", "ekmProductDiscountsFolder", discountsContainer.Id, "ekmProductDiscounts", "ekmProductDiscount", disableDataType);
+        EnsureFolderContentType("Payment Providers Folder", "ekmPaymentProvidersFolder", paymentProvidersContainer.Id, "ekmPaymentProviders", "ekmPaymentProvider", disableDataType);
+        EnsureFolderContentType("Shipping Providers Folder", "ekmShippingProvidersFolder", shippingProvidersContainer.Id, "ekmShippingProviders", "ekmShippingProvider", disableDataType);
+    }
+
+    private void EnsureFolderContentType(
+        string name,
+        string folderAlias,
+        int containerId,
+        string parentAlias,
+        string childAlias,
+        IDataType disableDataType)
+    {
+        var parentContentType = _contentTypeService.Get(parentAlias);
+        var childContentType = _contentTypeService.Get(childAlias);
+
+        if (parentContentType == null || childContentType == null)
+        {
+            _logger.LogWarning("Cannot create Ekom folder document type {FolderAlias} because {ParentAlias} or {ChildAlias} is missing.", folderAlias, parentAlias, childAlias);
+            return;
+        }
+
+        var folderContentType = EnsureContentTypeExists(new ContentType(_shortStringHelper, containerId)
+        {
+            Name = name,
+            Alias = folderAlias,
+            Icon = "icon-folder",
+            AllowedContentTypes = new List<ContentTypeSort>
+            {
+                new ContentTypeSort(childContentType.Id, 1),
+            },
+            PropertyGroups = new PropertyGroupCollection(
+                new List<PropertyGroup>
+                {
+                    new PropertyGroup(new PropertyTypeCollection(
+                        true,
+                        new List<PropertyType>
+                        {
+                            new PropertyType(_shortStringHelper, disableDataType, "disable")
+                            {
+                                Name = "Disable",
+                            },
+                        }))
+                    {
+                        Alias = "stores",
+                        Name = "Stores",
+                        Type = PropertyGroupType.Tab,
+                    },
+                }),
+        });
+
+        EnsureAllowedContentType(parentContentType, folderContentType);
+        EnsureAllowedContentType(folderContentType, childContentType);
+    }
+
+    private void EnsureAllowedContentType(IContentType parentContentType, IContentType childContentType)
+    {
+        if (parentContentType.AllowedContentTypes.Any(x => x.Alias == childContentType.Alias))
+        {
+            return;
+        }
+
+        var sortOrder = parentContentType.AllowedContentTypes.Any()
+            ? parentContentType.AllowedContentTypes.Max(x => x.SortOrder) + 1
+            : 1;
+
+        parentContentType.AllowedContentTypes = parentContentType.AllowedContentTypes.Append(
+            new ContentTypeSort(childContentType.Id, sortOrder));
+        _contentTypeService.Save(parentContentType);
     }
 
     private EntityContainer EnsureContainerExists(string name, int level = 1, int parentId = -1)

--- a/Ekom/Ekom.Umbraco/Ekom.U10/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/UmbracoEventListeners.cs
@@ -156,6 +156,13 @@ class UmbracoEventListeners :
         {
             if (node.ContentType.Alias.StartsWith("ekm"))
             {
+                if (IsStoreDisableFolder(node.ContentType.Alias))
+                {
+                    RefreshCacheForRelatedNodes(node.Id);
+                    RevalidateAsync(node, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
                 var cacheEntry = FindMatchingCache(node.ContentType.Alias);
 
                 var parentNode = _nodeService.NodeById(node.ParentId);
@@ -196,11 +203,11 @@ class UmbracoEventListeners :
 
                 cacheEntry?.Remove(node.Key);
 
-                var parentNode = _nodeService.NodeById(node.Id);
+                var parentNode = _nodeService.NodeById(node.ParentId);
 
                 cacheEntry?.AddReplace(new Umbraco10Content(node, parentNode != null ? parentNode.Key : Guid.Empty, _richTextResolver));
 
-                if (node.ContentType.Alias == "ekmCategory")
+                if (node.ContentType.Alias == "ekmCategory" || IsStoreDisableFolder(node.ContentType.Alias))
                 {
                     RefreshCacheForRelatedNodes(node.Id);
                 }
@@ -241,6 +248,11 @@ class UmbracoEventListeners :
     {
         foreach (var node in args.DeletedEntities)
         {
+            foreach (var cache in _config.CacheList.Value)
+            {
+                cache.RemoveDescendants(node.Id);
+            }
+
             if (node.ContentType.Alias.StartsWith("ekm"))
             {
                 ClearMemoryCache(node);
@@ -261,6 +273,11 @@ class UmbracoEventListeners :
     {
         foreach (var node in args.MoveInfoCollection)
         {
+            foreach (var cache in _config.CacheList.Value)
+            {
+                cache.RemoveDescendants(node.Entity.Id);
+            }
+
             if (node.Entity.ContentType.Alias.StartsWith("ekm"))
             {
                 var cacheEntry = FindMatchingCache(node.Entity.ContentType.Alias);
@@ -274,6 +291,11 @@ class UmbracoEventListeners :
 
     private ICache? FindMatchingCache(string contentTypeAlias)
     {
+        if (IsStoreDisableFolder(contentTypeAlias))
+        {
+            return null;
+        }
+
         if (contentTypeAlias.Contains("ekmpaymentprovider", StringComparison.InvariantCulture))
         {
             return _config.CacheList.Value.FirstOrDefault(x
@@ -286,6 +308,14 @@ class UmbracoEventListeners :
             => !string.IsNullOrEmpty(x.NodeAlias)
                && contentTypeAlias.Equals(x.NodeAlias, StringComparison.InvariantCulture)
         );
+    }
+
+    private static bool IsStoreDisableFolder(string contentTypeAlias)
+    {
+        return contentTypeAlias is "ekmOrderDiscountsFolder"
+            or "ekmProductDiscountsFolder"
+            or "ekmPaymentProvidersFolder"
+            or "ekmShippingProvidersFolder";
     }
 
     private async Task UpdatePropertiesDefaultValuesAsync(

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
@@ -1509,6 +1509,7 @@ class EnsureNodesExist : IAsyncComponent
                 #endregion
             }
 
+            EnsureDiscountAndProviderFolderContentTypes();
             EnsureSkuProductPickerDataType();
 
             _logger.LogDebug("Done");
@@ -1600,6 +1601,92 @@ class EnsureNodesExist : IAsyncComponent
         });
 
         SaveDataType(dataType);
+    }
+
+    private void EnsureDiscountAndProviderFolderContentTypes()
+    {
+        var disableDataType = GetDataType("Ekom Property Editor - Boolean - Stores");
+        if (disableDataType == null)
+        {
+            _logger.LogWarning("Cannot create Ekom provider and discount folder document types because the store Disable data type is missing.");
+            return;
+        }
+
+        var ekomContainer = EnsureContainerExists("Ekom");
+        var discountsContainer = EnsureContainerExists("Discounts", 2, ekomContainer.Id);
+        var paymentProvidersContainer = EnsureContainerExists("Payment Providers", 2, ekomContainer.Id);
+        var shippingProvidersContainer = EnsureContainerExists("Shipping Providers", 2, ekomContainer.Id);
+
+        EnsureFolderContentType("Order Discounts Folder", "ekmOrderDiscountsFolder", discountsContainer.Id, "ekmOrderDiscounts", "ekmOrderDiscount", disableDataType);
+        EnsureFolderContentType("Product Discounts Folder", "ekmProductDiscountsFolder", discountsContainer.Id, "ekmProductDiscounts", "ekmProductDiscount", disableDataType);
+        EnsureFolderContentType("Payment Providers Folder", "ekmPaymentProvidersFolder", paymentProvidersContainer.Id, "ekmPaymentProviders", "ekmPaymentProvider", disableDataType);
+        EnsureFolderContentType("Shipping Providers Folder", "ekmShippingProvidersFolder", shippingProvidersContainer.Id, "ekmShippingProviders", "ekmShippingProvider", disableDataType);
+    }
+
+    private void EnsureFolderContentType(
+        string name,
+        string folderAlias,
+        int containerId,
+        string parentAlias,
+        string childAlias,
+        IDataType disableDataType)
+    {
+        var parentContentType = _contentTypeService.Get(parentAlias);
+        var childContentType = _contentTypeService.Get(childAlias);
+
+        if (parentContentType == null || childContentType == null)
+        {
+            _logger.LogWarning("Cannot create Ekom folder document type {FolderAlias} because {ParentAlias} or {ChildAlias} is missing.", folderAlias, parentAlias, childAlias);
+            return;
+        }
+
+        var folderContentType = EnsureContentTypeExists(new ContentType(_shortStringHelper, containerId)
+        {
+            Name = name,
+            Alias = folderAlias,
+            Icon = "icon-folder",
+            AllowedContentTypes = new List<ContentTypeSort>
+            {
+                CreateContentTypeSort(childContentType, 1),
+            },
+            PropertyGroups = new PropertyGroupCollection(
+                new List<PropertyGroup>
+                {
+                    new PropertyGroup(new PropertyTypeCollection(
+                        true,
+                        new List<PropertyType>
+                        {
+                            new PropertyType(_shortStringHelper, disableDataType, "disable")
+                            {
+                                Name = "Disable",
+                            },
+                        }))
+                    {
+                        Alias = "stores",
+                        Name = "Stores",
+                        Type = PropertyGroupType.Tab,
+                    },
+                }),
+        });
+
+        EnsureAllowedContentType(parentContentType, folderContentType);
+        EnsureAllowedContentType(folderContentType, childContentType);
+    }
+
+    private void EnsureAllowedContentType(IContentType parentContentType, IContentType childContentType)
+    {
+        if (parentContentType.AllowedContentTypes.Any(x => x.Alias == childContentType.Alias))
+        {
+            return;
+        }
+
+        var sortOrder = parentContentType.AllowedContentTypes.Any()
+            ? parentContentType.AllowedContentTypes.Max(x => x.SortOrder) + 1
+            : 1;
+
+        parentContentType.AllowedContentTypes = parentContentType.AllowedContentTypes.Append(
+            CreateContentTypeSort(childContentType, sortOrder));
+        SaveContentType(parentContentType);
     }
 
     private IDataType GetDataType(Guid key)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
@@ -101,6 +101,13 @@ internal sealed class UmbracoEventListeners :
 
             ClearMemoryCache(node);
 
+            if (IsStoreDisableFolder(node.ContentType.Alias))
+            {
+                RefreshCacheForRelatedNodes(node.Id);
+                _ = RevalidateAsync(node, cancellationToken);
+                continue;
+            }
+
             var cacheEntry = FindMatchingCache(node.ContentType.Alias);
             var parentNode = _nodeService.NodeById(node.ParentId);
 
@@ -153,6 +160,8 @@ internal sealed class UmbracoEventListeners :
     {
         foreach (var node in notification.DeletedEntities)
         {
+            RemoveDescendantsFromCaches(node.Id);
+
             if (!node.ContentType.Alias.StartsWith("ekm", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
@@ -181,6 +190,12 @@ internal sealed class UmbracoEventListeners :
                 continue;
             }
 
+            if (IsStoreDisableFolder(node.ContentType.Alias))
+            {
+                RefreshCacheForRelatedNodes(node.Id);
+                continue;
+            }
+
             var cacheEntry = FindMatchingCache(node.ContentType.Alias);
             cacheEntry?.Remove(node.Key);
 
@@ -198,6 +213,8 @@ internal sealed class UmbracoEventListeners :
     {
         foreach (var node in notification.MoveInfoCollection)
         {
+            RemoveDescendantsFromCaches(node.Entity.Id);
+
             if (!node.Entity.ContentType.Alias.StartsWith("ekm", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
@@ -243,6 +260,11 @@ internal sealed class UmbracoEventListeners :
 
     private ICache? FindMatchingCache(string contentTypeAlias)
     {
+        if (IsStoreDisableFolder(contentTypeAlias))
+        {
+            return null;
+        }
+
         if (contentTypeAlias.Contains("ekmpaymentprovider", StringComparison.OrdinalIgnoreCase))
         {
             return _config.CacheList.Value.FirstOrDefault(x =>
@@ -253,6 +275,14 @@ internal sealed class UmbracoEventListeners :
         return _config.CacheList.Value.FirstOrDefault(x =>
             !string.IsNullOrEmpty(x.NodeAlias)
             && contentTypeAlias.Equals(x.NodeAlias, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsStoreDisableFolder(string contentTypeAlias)
+    {
+        return contentTypeAlias is "ekmOrderDiscountsFolder"
+            or "ekmProductDiscountsFolder"
+            or "ekmPaymentProvidersFolder"
+            or "ekmShippingProvidersFolder";
     }
 
     private void RefreshStoreForDomainRoot(int? rootContentId)

--- a/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/DataTypes/RangeEditor/ekmRange.controller.js
+++ b/Ekom/Ekom.Web/Ekom.Web/App_Plugins/Ekom/DataTypes/RangeEditor/ekmRange.controller.js
@@ -1,63 +1,98 @@
-angular.module("umbraco").controller("Ekom.Range", function ($scope, $http, $routeParams) {
+angular.module("umbraco").controller("Ekom.Range", function ($scope, ekmResources, $routeParams) {
 
   if ($routeParams.section !== 'content') { return; }
 
   $scope.model.hideLabel = false;
   $scope.fieldAlias = $scope.model.alias;
-
-  //$scope.currencies = [];
   $scope.stores = [];
+  $scope.ranges = {};
 
-  $http.get(Umbraco.Sys.ServerVariables.ekom.apiEndpoint + 'Stores').then(function (results) {
+  ekmResources.getStoresByNode($routeParams.id).then(function (stores) {
 
-    $scope.stores = results.data;
+    $scope.stores = stores;
+    var currentRanges = normalizeRanges($scope.model.value, stores);
 
-    // Set default ranges value from existing value
-    if (typeof $scope.model.value === 'object' && $scope.model.value !== null && $scope.model.value !== '') {
-      // If model value is json then return
+    stores.forEach(function (store) {
+      $scope.ranges[store.alias] = [];
 
-      if ($scope.model.value.hasOwnProperty('values')) {
+      store.currencies.forEach(function (currency) {
+        var range = getRange(currentRanges[store.alias], currency.currencyValue);
 
-        var temp1 = $scope.model.value.values;
-
-        Object.keys(temp1).forEach(key => temp1[key] = JSON.parse(temp1[key]));
-
-        $scope.ranges = temp1;
-
-      } else {
-        $scope.ranges = $scope.model.value;
-      }
-
-    } else {
-      // If model value is not json then return as decimal
-      if ($scope.model.value !== undefined) {
-        $scope.ranges = $scope.model.value.replace(/,/g, '.');
-      }
-    }
-
-    if ($scope.model.value === null || $scope.model.value === '' || $scope.model.value === undefined) {
-
-      $scope.ranges = {};
-
-      for (s = 0; $scope.stores.length > s; s += 1) {
-
-        let store = $scope.stores[s];
-
-        $scope.ranges[store.alias] = [];
-
-        for (c = 0; store.currencies.length > c; c += 1) {
-
-          $scope.ranges[store.alias].push({
-            currency: store.currencies[c].currencyValue,
-            value: 0
-          });
-
-        }
-
-      }
-
-    }
+        $scope.ranges[store.alias].push({
+          currency: currency.currencyValue,
+          value: range === undefined ? 0 : range
+        });
+      });
+    });
   });
+
+  function normalizeRanges(value, stores) {
+    if (value === null || value === undefined || value === '') {
+      return {};
+    }
+
+    if (typeof value !== 'object') {
+      var firstStore = stores[0];
+      var firstCurrency = firstStore && firstStore.currencies[0];
+
+      if (!firstStore || !firstCurrency) {
+        return {};
+      }
+
+      var primitiveRanges = {};
+      primitiveRanges[firstStore.alias] = [{
+        currency: firstCurrency.currencyValue,
+        value: parseRange(value)
+      }];
+      return primitiveRanges;
+    }
+
+    var source = value.values && typeof value.values === 'object'
+      ? value.values
+      : value;
+    var ranges = {};
+
+    Object.keys(source).forEach(function (storeAlias) {
+      var storeRanges = source[storeAlias];
+
+      if (typeof storeRanges === 'string') {
+        try {
+          storeRanges = JSON.parse(storeRanges);
+        } catch (error) {
+          storeRanges = [];
+        }
+      }
+
+      if (!Array.isArray(storeRanges)) {
+        return;
+      }
+
+      ranges[storeAlias] = storeRanges;
+    });
+
+    return ranges;
+  }
+
+  function getRange(ranges, currency) {
+    if (!Array.isArray(ranges)) {
+      return undefined;
+    }
+
+    var range = ranges.find(function (item) {
+      return item && (item.currency === currency || item.Currency === currency);
+    });
+
+    if (!range) {
+      return undefined;
+    }
+
+    return parseRange(range.value === undefined ? range.Value : range.value);
+  }
+
+  function parseRange(value) {
+    var parsed = parseFloat(String(value).replace(/,/g, '.'));
+    return isNaN(parsed) ? 0 : parsed;
+  }
 
   $scope.$on("formSubmitting", function () {
 

--- a/Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/RangeEditor/ekmRange.controller.js
+++ b/Samples/U10/Ekom.Site/App_Plugins/Ekom/DataTypes/RangeEditor/ekmRange.controller.js
@@ -1,63 +1,98 @@
-angular.module("umbraco").controller("Ekom.Range", function ($scope, $http, $routeParams) {
+angular.module("umbraco").controller("Ekom.Range", function ($scope, ekmResources, $routeParams) {
 
   if ($routeParams.section !== 'content') { return; }
 
   $scope.model.hideLabel = false;
   $scope.fieldAlias = $scope.model.alias;
-
-  //$scope.currencies = [];
   $scope.stores = [];
+  $scope.ranges = {};
 
-  $http.get(Umbraco.Sys.ServerVariables.ekom.apiEndpoint + 'Stores').then(function (results) {
+  ekmResources.getStoresByNode($routeParams.id).then(function (stores) {
 
-    $scope.stores = results.data;
+    $scope.stores = stores;
+    var currentRanges = normalizeRanges($scope.model.value, stores);
 
-    // Set default ranges value from existing value
-    if (typeof $scope.model.value === 'object' && $scope.model.value !== null && $scope.model.value !== '') {
-      // If model value is json then return
+    stores.forEach(function (store) {
+      $scope.ranges[store.alias] = [];
 
-      if ($scope.model.value.hasOwnProperty('values')) {
+      store.currencies.forEach(function (currency) {
+        var range = getRange(currentRanges[store.alias], currency.currencyValue);
 
-        var temp1 = $scope.model.value.values;
-
-        Object.keys(temp1).forEach(key => temp1[key] = JSON.parse(temp1[key]));
-
-        $scope.ranges = temp1;
-
-      } else {
-        $scope.ranges = $scope.model.value;
-      }
-
-    } else {
-      // If model value is not json then return as decimal
-      if ($scope.model.value !== undefined) {
-        $scope.ranges = $scope.model.value.replace(/,/g, '.');
-      }
-    }
-
-    if ($scope.model.value === null || $scope.model.value === '' || $scope.model.value === undefined) {
-
-      $scope.ranges = {};
-
-      for (s = 0; $scope.stores.length > s; s += 1) {
-
-        let store = $scope.stores[s];
-
-        $scope.ranges[store.alias] = [];
-
-        for (c = 0; store.currencies.length > c; c += 1) {
-
-          $scope.ranges[store.alias].push({
-            currency: store.currencies[c].currencyValue,
-            value: 0
-          });
-
-        }
-
-      }
-
-    }
+        $scope.ranges[store.alias].push({
+          currency: currency.currencyValue,
+          value: range === undefined ? 0 : range
+        });
+      });
+    });
   });
+
+  function normalizeRanges(value, stores) {
+    if (value === null || value === undefined || value === '') {
+      return {};
+    }
+
+    if (typeof value !== 'object') {
+      var firstStore = stores[0];
+      var firstCurrency = firstStore && firstStore.currencies[0];
+
+      if (!firstStore || !firstCurrency) {
+        return {};
+      }
+
+      var primitiveRanges = {};
+      primitiveRanges[firstStore.alias] = [{
+        currency: firstCurrency.currencyValue,
+        value: parseRange(value)
+      }];
+      return primitiveRanges;
+    }
+
+    var source = value.values && typeof value.values === 'object'
+      ? value.values
+      : value;
+    var ranges = {};
+
+    Object.keys(source).forEach(function (storeAlias) {
+      var storeRanges = source[storeAlias];
+
+      if (typeof storeRanges === 'string') {
+        try {
+          storeRanges = JSON.parse(storeRanges);
+        } catch (error) {
+          storeRanges = [];
+        }
+      }
+
+      if (!Array.isArray(storeRanges)) {
+        return;
+      }
+
+      ranges[storeAlias] = storeRanges;
+    });
+
+    return ranges;
+  }
+
+  function getRange(ranges, currency) {
+    if (!Array.isArray(ranges)) {
+      return undefined;
+    }
+
+    var range = ranges.find(function (item) {
+      return item && (item.currency === currency || item.Currency === currency);
+    });
+
+    if (!range) {
+      return undefined;
+    }
+
+    return parseRange(range.value === undefined ? range.Value : range.value);
+  }
+
+  function parseRange(value) {
+    var parsed = parseFloat(String(value).replace(/,/g, '.'));
+    return isNaN(parsed) ? 0 : parsed;
+  }
 
   $scope.$on("formSubmitting", function () {
 


### PR DESCRIPTION
## Summary
- filter the Umbraco 10 Range editor to stores enabled for the edited node
- add store-aware folders for discounts and payment/shipping providers on new and existing installations
- exclude provider and discount descendants when their matching folder is disabled for a store
- load payment providers recursively so providers within folders are available

## Test Plan
- `dotnet build "Ekom/Ekom.Core/Ekom/Ekom.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" --no-restore`
- `dotnet build "Ekom/Ekom.Umbraco/Ekom.U18/Ekom.U18.csproj" --no-restore`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --no-restore` (4 existing failures in configuration, price, and discount tests)
