### PR TITLE
feat(cache): expose store aliases in price events

### DIFF
--- a/Ekom/Ekom.Core/Ekom.Common/PriceCache.cs
+++ b/Ekom/Ekom.Core/Ekom.Common/PriceCache.cs
@@ -32,27 +32,34 @@ public static class PriceCache
 
     private static readonly ConcurrentDictionary<string, string> _itemGenerations = new();
 
-    public static string GetItemGeneration(string itemKey)
+    public static string GetItemGeneration(string itemKey) => GetItemGeneration(itemKey, null);
+
+    public static string GetItemGeneration(string itemKey, string? storeAlias)
     {
         var gen = _itemGenerations.GetOrAdd(itemKey, _ => Guid.NewGuid().ToString("N"));
 
-        gen = RaiseGenerationCreatedAsync(itemKey, gen, CancellationToken.None).GetAwaiter().GetResult();
+        gen = RaiseGenerationCreatedAsync(itemKey, gen, storeAlias, CancellationToken.None).GetAwaiter().GetResult();
 
         return gen;
     }
 
-    public static async ValueTask<string> GetItemGenerationAsync(string itemKey, CancellationToken ct = default)
+    public static ValueTask<string> GetItemGenerationAsync(string itemKey, CancellationToken ct = default)
+        => GetItemGenerationAsync(itemKey, null, ct);
+
+    public static async ValueTask<string> GetItemGenerationAsync(string itemKey, string? storeAlias, CancellationToken ct)
     {
         ct.ThrowIfCancellationRequested();
 
         var gen = _itemGenerations.GetOrAdd(itemKey, _ => Guid.NewGuid().ToString("N"));
 
-        gen = await RaiseGenerationCreatedAsync(itemKey, gen, ct).ConfigureAwait(false);
+        gen = await RaiseGenerationCreatedAsync(itemKey, gen, storeAlias, ct).ConfigureAwait(false);
 
         return gen;
     }
 
-    public static void InvalidateItem(string itemKey)
+    public static void InvalidateItem(string itemKey) => InvalidateItem(itemKey, null);
+
+    public static void InvalidateItem(string itemKey, string? storeAlias)
     {
         var newGen = Guid.NewGuid().ToString("N");
 
@@ -61,7 +68,7 @@ public static class PriceCache
 
         OnGenerationInvalidated?.Invoke(
             null,
-            new PriceGenerationEventArgs(itemKey, newGen)
+            new PriceGenerationEventArgs(itemKey, newGen, storeAlias)
         );
 
         if (DeferCompaction())
@@ -143,9 +150,13 @@ public static class PriceCache
         }
     }
 
-    private static async ValueTask<string> RaiseGenerationCreatedAsync(string itemKey, string gen, CancellationToken ct)
+    private static async ValueTask<string> RaiseGenerationCreatedAsync(
+        string itemKey,
+        string gen,
+        string? storeAlias,
+        CancellationToken ct)
     {
-        var args = new PriceGenerationEventArgs(itemKey, gen);
+        var args = new PriceGenerationEventArgs(itemKey, gen, storeAlias);
         var handlers = OnGenerationCreatedAsync;
 
         if (handlers is null)
@@ -163,6 +174,11 @@ public static class PriceCache
     public class PriceGenerationEventArgs : EventArgs
     {
         public string ItemKey { get; }
+
+        /// <summary>
+        /// Store alias associated with the price operation, or null when the store is unknown.
+        /// </summary>
+        public string? StoreAlias { get; }
         public string Generation { get; set; }
 
         /// <summary>
@@ -174,9 +190,15 @@ public static class PriceCache
         public IReadOnlyDictionary<string, string> PricingContext { get; }
 
         public PriceGenerationEventArgs(string itemKey, string generation)
+            : this(itemKey, generation, null)
+        {
+        }
+
+        public PriceGenerationEventArgs(string itemKey, string generation, string? storeAlias)
         {
             ItemKey = itemKey;
             Generation = generation;
+            StoreAlias = storeAlias;
             PricingContext = Ekom.PricingContext.CurrentOrEmpty;
         }
     }

--- a/Ekom/Ekom.Core/Ekom/Models/Product.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Product.cs
@@ -365,7 +365,7 @@ public class Product : PerStoreNodeEntity, IProduct
             string productKey = Path;
 
             string globalGen = PriceCache.GlobalGeneration;
-            string productGen = PriceCache.GetItemGeneration(productKey);
+            string productGen = PriceCache.GetItemGeneration(productKey, Store.Alias);
 
             var key = $"prices:g={globalGen}:p={productGen}:store={Store.Alias}:prod={productKey}:cats={string.Join('|', categories)}:hash={CacheHelpers.Sha256(_priceValue)}";
 
@@ -583,7 +583,7 @@ public class Product : PerStoreNodeEntity, IProduct
 
     public void InvalidateCache()
     {
-        PriceCache.InvalidateItem(Path);
+        PriceCache.InvalidateItem(Path, Store.Alias);
         _cache.Clear();
     }
 

--- a/Ekom/Ekom.Core/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Variant.cs
@@ -214,7 +214,7 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
             string itemKey = Path;
 
             string globalGen = PriceCache.GlobalGeneration;
-            string productGen = PriceCache.GetItemGeneration(itemKey);
+            string productGen = PriceCache.GetItemGeneration(itemKey, Store.Alias);
 
             string cacheKey =
                 $"prices:g={globalGen}:p={productGen}:store={Store.Alias}:prod={itemKey}:cats={string.Join('|', categories)}:hash={CacheHelpers.Sha256(_priceValue)}";
@@ -356,7 +356,7 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
         if (!CacheInitializationScope.IsActive)
         {
             Product?.InvalidateCache();
-            PriceCache.InvalidateItem(Path);
+            PriceCache.InvalidateItem(Path, Store.Alias);
         }
 
         _priceValue = GetValue("price", Store.Alias) ?? string.Empty;

--- a/Ekom/Tests/Ekom.Tests/Tests/PriceCacheTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/PriceCacheTests.cs
@@ -13,6 +13,7 @@ public class PriceCacheTests
 
         ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
         {
+            Assert.Null(args.StoreAlias);
             args.Generation = expectedGeneration;
             return ValueTask.CompletedTask;
         }
@@ -24,6 +25,32 @@ public class PriceCacheTests
             var generation = PriceCache.GetItemGeneration(itemKey);
 
             Assert.Equal(expectedGeneration, generation);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    [Fact]
+    public void GetItemGeneration_PassesStoreAliasToHandler()
+    {
+        var itemKey = CreateItemKey();
+        const string storeAlias = "store-a";
+        string? receivedStoreAlias = null;
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            receivedStoreAlias = args.StoreAlias;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+        try
+        {
+            PriceCache.GetItemGeneration(itemKey, storeAlias);
+
+            Assert.Equal(storeAlias, receivedStoreAlias);
         }
         finally
         {
@@ -73,6 +100,7 @@ public class PriceCacheTests
 
         ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
         {
+            Assert.Null(args.StoreAlias);
             args.Generation = expectedGeneration;
             return ValueTask.CompletedTask;
         }
@@ -84,6 +112,32 @@ public class PriceCacheTests
             var generation = await PriceCache.GetItemGenerationAsync(itemKey);
 
             Assert.Equal(expectedGeneration, generation);
+        }
+        finally
+        {
+            PriceCache.OnGenerationCreatedAsync -= Handler;
+        }
+    }
+
+    [Fact]
+    public async Task GetItemGenerationAsync_PassesStoreAliasToHandler()
+    {
+        var itemKey = CreateItemKey();
+        const string storeAlias = "store-a";
+        string? receivedStoreAlias = null;
+
+        ValueTask Handler(PriceCache.PriceGenerationEventArgs args, CancellationToken ct)
+        {
+            receivedStoreAlias = args.StoreAlias;
+            return ValueTask.CompletedTask;
+        }
+
+        PriceCache.OnGenerationCreatedAsync += Handler;
+        try
+        {
+            await PriceCache.GetItemGenerationAsync(itemKey, storeAlias, CancellationToken.None);
+
+            Assert.Equal(storeAlias, receivedStoreAlias);
         }
         finally
         {
@@ -180,6 +234,31 @@ public class PriceCacheTests
 
             Assert.Equal(2, invalidatedGenerations.Count);
             Assert.NotEqual(invalidatedGenerations[0], invalidatedGenerations[1]);
+        }
+        finally
+        {
+            PriceCache.OnGenerationInvalidated -= Handler;
+        }
+    }
+
+    [Fact]
+    public void InvalidateItem_PassesStoreAliasToHandler()
+    {
+        var itemKey = CreateItemKey();
+        const string storeAlias = "store-a";
+        string? receivedStoreAlias = null;
+
+        void Handler(object? sender, PriceCache.PriceGenerationEventArgs args)
+        {
+            receivedStoreAlias = args.StoreAlias;
+        }
+
+        PriceCache.OnGenerationInvalidated += Handler;
+        try
+        {
+            PriceCache.InvalidateItem(itemKey, storeAlias);
+
+            Assert.Equal(storeAlias, receivedStoreAlias);
         }
         finally
         {

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ X-Ekom-Api-Key: integration-secret
 `pricingContext` is an arbitrary string dictionary that is not interpreted by Ekom. While a line is priced, Ekom activates it as the ambient `Ekom.PricingContext` and forwards it into the pricing event args, so handlers in the site hosting Ekom can vary pricing per line:
 
 - `DiscountEvents.BeforeEvaluateDiscountsAsync` / `AfterApplicableDiscountsAsync` — `e.PricingContext` (e.g. drop discounts that do not apply to this audience)
-- `PriceCache.OnGenerationCreatedAsync` — `e.PricingContext` (fold context values into `e.Generation` so cached prices are partitioned per audience)
+- `PriceCache.OnGenerationCreatedAsync` — `e.PricingContext` and nullable `e.StoreAlias` (fold relevant values into `e.Generation` so cached prices are partitioned per audience)
 
 ```csharp
 discountEvents.AfterApplicableDiscountsAsync += (sender, e) =>
@@ -249,7 +249,8 @@ discountEvents.AfterApplicableDiscountsAsync += (sender, e) =>
 
 PriceCache.OnGenerationCreatedAsync += (e, ct) =>
 {
-    if (e.PricingContext.TryGetValue("customerGroup", out var group))
+    if (e.StoreAlias == "store-a" &&
+        e.PricingContext.TryGetValue("customerGroup", out var group))
     {
         e.Generation += $":{group}";
     }
@@ -259,6 +260,8 @@ PriceCache.OnGenerationCreatedAsync += (e, ct) =>
 ```
 
 Keys are matched case-insensitively and `PricingContext` is never null (empty when no context is active). Code that runs outside these events can inject `OrderDiscountCalculationContextAccessor` or read `Ekom.PricingContext.Current` directly.
+
+`StoreAlias` is supplied when product or variant pricing has a store context; it is null for legacy or cross-store cache operations.
 
 ### Tracking and consent
 


### PR DESCRIPTION
## Summary
- expose the nullable store alias on price-generation and invalidation event arguments
- propagate store aliases from product and variant price-cache operations
- retain legacy PriceCache overloads for callers without store context
- cover store-aware and legacy event behavior with focused tests

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~PriceCacheTests" --no-restore`
