### PR TITLE
feat(algolia): coordinate full index rebuilds

### DIFF
--- a/Ekom/Ekom.Core/Ekom/Utilities/PriceHelper.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/PriceHelper.cs
@@ -1,0 +1,43 @@
+using Ekom.Models;
+using Newtonsoft.Json;
+
+namespace Ekom.Utilities;
+
+public static class PriceHelper
+{
+    public static string SetPrice(string? currentValue, decimal price, string currency, string storeAlias)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(currency);
+        ArgumentException.ThrowIfNullOrWhiteSpace(storeAlias);
+
+        var prices = string.IsNullOrWhiteSpace(currentValue)
+            ? new CurrencyPriceRoot()
+            : JsonConvert.DeserializeObject<CurrencyPriceRoot>(currentValue) ?? new CurrencyPriceRoot();
+
+        var storePrices = prices
+            .Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(x => x.Value)
+            .GroupBy(x => x.Currency, StringComparer.OrdinalIgnoreCase)
+            .Select(x => x.Last())
+            .ToList();
+
+        foreach (var key in prices.Keys.Where(x => x.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)).ToList())
+        {
+            prices.Remove(key);
+        }
+
+        var currencyPrice = storePrices.FirstOrDefault(x => x.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase));
+        if (currencyPrice is null)
+        {
+            storePrices.Add(new CurrencyPrice(price, currency));
+        }
+        else
+        {
+            currencyPrice.Price = price;
+        }
+
+        prices.Add(storeAlias, storePrices);
+
+        return JsonConvert.SerializeObject(prices);
+    }
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/ContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/Utilities/ContentExtensions.cs
@@ -371,69 +371,38 @@ public static class ContentExtensions
     /// <param name="currency">Currency (is-IS, en-US)</param>
     /// <param name="price">Price as decimal</param>
     public static void SetPrice(this IContent content, string storeAlias, string currency, decimal price)
+        => SetPrice(content, "price", storeAlias, currency, price);
+
+    /// <summary>
+    /// Set price on an Ekom.Price property.
+    /// </summary>
+    /// <param name="content">IContent</param>
+    /// <param name="propertyAlias">Ekom.Price property alias</param>
+    /// <param name="storeAlias">Store alias</param>
+    /// <param name="currency">Currency (is-IS, en-US)</param>
+    /// <param name="price">Price as decimal</param>
+    public static void SetPrice(this IContent content, string propertyAlias, string storeAlias, string currency, decimal price)
     {
         if (content == null)
         {
             throw new ArgumentNullException(nameof(content));
         }
 
-        if (content.HasProperty("price"))
+        if (string.IsNullOrEmpty(propertyAlias))
+        {
+            throw new ArgumentNullException(nameof(propertyAlias));
+        }
+
+        if (content.HasProperty(propertyAlias))
         {
 
-            var fieldValue = content.GetValue<string>("price");
+            var fieldValue = content.GetValue<string>(propertyAlias);
 
-            CurrencyPrice priceObject = null;
             CurrencyPriceRoot currencyPriceRoot = new CurrencyPriceRoot();
 
             try
             {
-                currencyPriceRoot = string.IsNullOrEmpty(fieldValue) ? currencyPriceRoot : JsonConvert.DeserializeObject<CurrencyPriceRoot>(fieldValue);
-                var storeItems = currencyPriceRoot
-                    .Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase))
-                    .SelectMany(x => x.Value)
-                    .GroupBy(x => x.Currency, StringComparer.OrdinalIgnoreCase)
-                    .Select(x => x.Last())
-                    .ToList();
-
-                foreach (var key in currencyPriceRoot.Keys.Where(x => x.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)).ToList())
-                {
-                    currencyPriceRoot.Remove(key);
-                }
-
-                if (storeItems.Count > 0)
-                {
-                    // Ensure the storeItems list is not null and has elements
-                    if (storeItems.Any())
-                    {
-                        // Find the first item with the specified currency
-                        priceObject = storeItems.FirstOrDefault(z => z.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase));
-
-                        if (priceObject != null)
-                        {
-                            priceObject.Price = price;
-                        }
-                        else
-                        {
-                            storeItems.Add(new CurrencyPrice(price, currency));
-                        }
-                    }
-                    else
-                    {
-                        storeItems.Add(new CurrencyPrice(price, currency));
-                    }
-
-                    currencyPriceRoot.Add(storeAlias, storeItems);
-                }
-                else
-                {
-                    currencyPriceRoot.Add(storeAlias,
-                        new List<CurrencyPrice>()
-                        {
-                            new(price, currency)
-                        });
-                }
-
-                content.SetValue("price", JsonConvert.SerializeObject(currencyPriceRoot));
+                content.SetValue(propertyAlias, PriceHelper.SetPrice(fieldValue, price, currency, storeAlias));
 
                 return;
 
@@ -482,7 +451,7 @@ public static class ContentExtensions
                 currencyPriceRoot.Add(store.Alias, currencyPrices);
             }
 
-            content.SetValue("price", JsonConvert.SerializeObject(currencyPriceRoot));
+            content.SetValue(propertyAlias, JsonConvert.SerializeObject(currencyPriceRoot));
         }
 
     }

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Utilities/ImportContentExtensions.cs
@@ -189,62 +189,29 @@ public static class ImportContentExtensions
     }
 
     public static void SetPrice(this IContent content, string storeAlias, string currency, decimal price)
+        => SetPrice(content, "price", storeAlias, currency, price);
+
+    public static void SetPrice(this IContent content, string propertyAlias, string storeAlias, string currency, decimal price)
     {
         ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrEmpty(propertyAlias);
 
-        if (!content.HasProperty("price"))
+        if (!content.HasProperty(propertyAlias))
         {
             return;
         }
 
-        var fieldValue = content.GetValue<string>("price");
-        var currencyPriceRoot = new CurrencyPriceRoot();
-
+        var fieldValue = content.GetValue<string>(propertyAlias);
         try
         {
-            currencyPriceRoot = string.IsNullOrEmpty(fieldValue)
-                ? currencyPriceRoot
-                : JsonConvert.DeserializeObject<CurrencyPriceRoot>(fieldValue) ?? currencyPriceRoot;
-
-            var storeItems = currencyPriceRoot
-                .Where(x => x.Key.Equals(storeAlias, StringComparison.OrdinalIgnoreCase))
-                .SelectMany(x => x.Value)
-                .GroupBy(x => x.Currency, StringComparer.OrdinalIgnoreCase)
-                .Select(x => x.Last())
-                .ToList();
-
-            foreach (var key in currencyPriceRoot.Keys.Where(x => x.Equals(storeAlias, StringComparison.OrdinalIgnoreCase)).ToList())
-            {
-                currencyPriceRoot.Remove(key);
-            }
-
-            if (storeItems.Count == 0)
-            {
-                storeItems.Add(new CurrencyPrice(price, currency));
-                currencyPriceRoot.Add(storeAlias, storeItems);
-            }
-            else
-            {
-                var priceObject = storeItems.FirstOrDefault(x => x.Currency.Equals(currency, StringComparison.OrdinalIgnoreCase));
-                if (priceObject == null)
-                {
-                    storeItems.Add(new CurrencyPrice(price, currency));
-                }
-                else
-                {
-                    priceObject.Price = price;
-                }
-
-                currencyPriceRoot.Add(storeAlias, storeItems);
-            }
-
-            content.SetValue("price", JsonConvert.SerializeObject(currencyPriceRoot));
+            content.SetValue(propertyAlias, PriceHelper.SetPrice(fieldValue, price, currency, storeAlias));
             return;
         }
         catch
         {
-            currencyPriceRoot = new CurrencyPriceRoot();
         }
+
+        var currencyPriceRoot = new CurrencyPriceRoot();
 
         foreach (var store in API.Store.Instance.GetAllStores())
         {
@@ -279,7 +246,7 @@ public static class ImportContentExtensions
             currencyPriceRoot.Add(store.Alias, currencyPrices);
         }
 
-        content.SetValue("price", JsonConvert.SerializeObject(currencyPriceRoot));
+        content.SetValue(propertyAlias, JsonConvert.SerializeObject(currencyPriceRoot));
     }
 
     public static void SaveAndPublish(this IContentService contentService, IContent content, int userId = -1)

--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaFullIndexRebuildCoordinatorTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaFullIndexRebuildCoordinatorTests.cs
@@ -1,0 +1,102 @@
+using Ekom.Algolia.Indexing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaFullIndexRebuildCoordinatorTests
+{
+    [Fact]
+    public async Task TryStart_RejectsDuplicateRunUntilCurrentRunCompletes()
+    {
+        var productService = new BlockingProductIndexService();
+        var categoryService = new BlockingCategoryIndexService();
+        var contentService = new BlockingContentIndexService();
+        var coordinator = new AlgoliaFullIndexRebuildCoordinator(
+            productService,
+            categoryService,
+            contentService,
+            NullLogger<AlgoliaFullIndexRebuildCoordinator>.Instance);
+
+        Assert.True(coordinator.TryStart());
+        Assert.False(coordinator.TryStart());
+
+        productService.Complete();
+        categoryService.Complete();
+        contentService.Complete();
+
+        Assert.True(await WaitForStartAsync(coordinator));
+    }
+
+    [Fact]
+    public async Task TryStart_AllowsAnotherRunAfterCurrentRunFails()
+    {
+        var productService = new BlockingProductIndexService();
+        var categoryService = new BlockingCategoryIndexService();
+        var contentService = new BlockingContentIndexService();
+        var coordinator = new AlgoliaFullIndexRebuildCoordinator(
+            productService,
+            categoryService,
+            contentService,
+            NullLogger<AlgoliaFullIndexRebuildCoordinator>.Instance);
+
+        Assert.True(coordinator.TryStart());
+
+        productService.Fail();
+        categoryService.Complete();
+        contentService.Complete();
+
+        Assert.True(await WaitForStartAsync(coordinator));
+    }
+
+    private static async Task<bool> WaitForStartAsync(IAlgoliaFullIndexRebuildCoordinator coordinator)
+    {
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            if (coordinator.TryStart())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return false;
+    }
+
+    private sealed class BlockingProductIndexService : IAlgoliaProductIndexService
+    {
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task EnqueueProductAsync(string storeAlias, Guid productKey, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
+        public Task EnqueueProductsAsync(string storeAlias, IReadOnlyCollection<Guid> productKeys, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildAllAndWaitAsync(CancellationToken ct = default) => _completion.Task;
+        public void Complete() => _completion.TrySetResult();
+        public void Fail() => _completion.TrySetException(new InvalidOperationException());
+    }
+
+    private sealed class BlockingCategoryIndexService : IAlgoliaCategoryIndexService
+    {
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task EnqueueCategoryAsync(string storeAlias, Guid categoryKey, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
+        public Task EnqueueCategoriesAsync(string storeAlias, IReadOnlyCollection<Guid> categoryKeys, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildAllAndWaitAsync(CancellationToken ct = default) => _completion.Task;
+        public void Complete() => _completion.TrySetResult();
+    }
+
+    private sealed class BlockingContentIndexService : IAlgoliaContentIndexService
+    {
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task UpdateByIdsAsync(IReadOnlyCollection<int> nodeIds, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteByKeysAsync(IReadOnlyCollection<Guid> nodeKeys, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildAsync(string? indexName = null, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildAndWaitAsync(string? indexName = null, CancellationToken ct = default) => _completion.Task;
+        public void Complete() => _completion.TrySetResult();
+    }
+}

--- a/Ekom/Tests/Ekom.Tests/Tests/PriceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/PriceTests.cs
@@ -263,6 +263,20 @@ public class PriceTests
         Assert.Equal(0m, prices.Single(x => x.Currency.CurrencyValue == "en-US").OriginalValue);
     }
 
+    [Fact]
+    public void PriceHelper_SetPrice_ReturnsEkomPriceJson()
+    {
+        var serialized = PriceHelper.SetPrice(null, 99.95m, "is-IS", "store-a");
+        serialized = PriceHelper.SetPrice(serialized, 9.99m, "en-US", "store-a");
+
+        var prices = JsonConvert.DeserializeObject<CurrencyPriceRoot>(serialized);
+
+        Assert.NotNull(prices);
+        Assert.Single(prices);
+        Assert.Equal(99.95m, prices["store-a"].Single(x => x.Currency == "is-IS").Price);
+        Assert.Equal(9.99m, prices["store-a"].Single(x => x.Currency == "en-US").Price);
+    }
+
     [Theory]
     [InlineData(1538.42, 0.24, 4)]
     public void Isk_Diff_PerUnit_vs_PerTotal(decimal price, decimal vat, int qty)

--- a/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
+++ b/Plugins/Ekom.Algolia/AlgoliaServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ public static class AlgoliaServiceCollectionExtensions
         services.AddSingleton<IAlgoliaProductIndexQueue, AlgoliaProductIndexQueue>();
         services.AddSingleton<AlgoliaProductIndexExecutor>();
         services.AddSingleton<IAlgoliaProductIndexService, AlgoliaProductIndexService>();
+        services.AddSingleton<IAlgoliaFullIndexRebuildCoordinator, AlgoliaFullIndexRebuildCoordinator>();
         services.AddSingleton<AlgoliaProductIndexWorker>();
         services.AddHostedService(sp => sp.GetRequiredService<AlgoliaProductIndexWorker>());
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexJob.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexJob.cs
@@ -3,7 +3,8 @@ namespace Ekom.Algolia.Indexing;
 internal sealed record AlgoliaCategoryIndexJob(
     AlgoliaCategoryIndexJobType Type,
     string StoreAlias,
-    IReadOnlyCollection<Guid> CategoryKeys);
+    IReadOnlyCollection<Guid> CategoryKeys,
+    TaskCompletionSource? Completion = null);
 
 internal enum AlgoliaCategoryIndexJobType
 {

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexService.cs
@@ -9,6 +9,7 @@ public interface IAlgoliaCategoryIndexService
     Task EnqueueCategoriesAsync(string storeAlias, IReadOnlyCollection<Guid> categoryKeys, bool isPublished, CancellationToken ct = default);
     Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default);
     Task RebuildAllAsync(CancellationToken ct = default);
+    Task RebuildAllAndWaitAsync(CancellationToken ct = default);
 }
 
 internal sealed class AlgoliaCategoryIndexService : IAlgoliaCategoryIndexService
@@ -110,5 +111,30 @@ internal sealed class AlgoliaCategoryIndexService : IAlgoliaCategoryIndexService
         }
 
         return Task.CompletedTask;
+    }
+
+    public async Task RebuildAllAndWaitAsync(CancellationToken ct = default)
+    {
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Categories)
+            return;
+
+        var completions = new List<Task>();
+        foreach (var store in _options.Stores)
+        {
+            if (string.IsNullOrWhiteSpace(store.Alias))
+                continue;
+
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var job = new AlgoliaCategoryIndexJob(
+                AlgoliaCategoryIndexJobType.RebuildStore,
+                store.Alias,
+                Array.Empty<Guid>(),
+                completion);
+
+            await _queue.EnqueueAsync(job, ct).ConfigureAwait(false);
+            completions.Add(completion.Task);
+        }
+
+        await Task.WhenAll(completions).ConfigureAwait(false);
     }
 }

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexWorker.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexWorker.cs
@@ -54,12 +54,15 @@ internal sealed class AlgoliaCategoryIndexWorker : BackgroundService
                         try
                         {
                             await _executor.HandleAsync(chunk, stoppingToken).ConfigureAwait(false);
+                            CompleteJobs(chunk);
                         }
                         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                         {
+                            CompleteJobs(chunk, canceled: true);
                         }
                         catch (Exception ex)
                         {
+                            CompleteJobs(chunk, exception: ex);
                             _logger.LogError(ex, "Algolia Category Indexer failed processing chunk size {ChunkSize}", chunk.Length);
                         }
                         finally
@@ -89,5 +92,27 @@ internal sealed class AlgoliaCategoryIndexWorker : BackgroundService
             list.Add(job);
 
         return list;
+    }
+
+    private static void CompleteJobs(
+        IEnumerable<AlgoliaCategoryIndexJob> jobs,
+        Exception? exception = null,
+        bool canceled = false)
+    {
+        foreach (var job in jobs)
+        {
+            if (canceled)
+            {
+                job.Completion?.TrySetCanceled();
+            }
+            else if (exception is not null)
+            {
+                job.Completion?.TrySetException(exception);
+            }
+            else
+            {
+                job.Completion?.TrySetResult();
+            }
+        }
     }
 }

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexJob.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexJob.cs
@@ -4,7 +4,8 @@ internal sealed record AlgoliaContentIndexJob(
     AlgoliaContentIndexJobType Type,
     IReadOnlyCollection<int> NodeIds,
     IReadOnlyCollection<Guid> NodeKeys,
-    string? IndexName = null);
+    string? IndexName = null,
+    TaskCompletionSource? Completion = null);
 
 internal enum AlgoliaContentIndexJobType
 {

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexService.cs
@@ -5,6 +5,7 @@ public interface IAlgoliaContentIndexService
     Task UpdateByIdsAsync(IReadOnlyCollection<int> nodeIds, CancellationToken ct = default);
     Task DeleteByKeysAsync(IReadOnlyCollection<Guid> nodeKeys, CancellationToken ct = default);
     Task RebuildAsync(string? indexName = null, CancellationToken ct = default);
+    Task RebuildAndWaitAsync(string? indexName = null, CancellationToken ct = default);
 }
 
 internal sealed class AlgoliaContentIndexService : IAlgoliaContentIndexService
@@ -34,6 +35,14 @@ internal sealed class AlgoliaContentIndexService : IAlgoliaContentIndexService
 
     public Task RebuildAsync(string? indexName = null, CancellationToken ct = default)
         => EnqueueAsync(new AlgoliaContentIndexJob(AlgoliaContentIndexJobType.Rebuild, [], [], indexName), ct);
+
+    public async Task RebuildAndWaitAsync(string? indexName = null, CancellationToken ct = default)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await EnqueueAsync(new AlgoliaContentIndexJob(AlgoliaContentIndexJobType.Rebuild, [], [], indexName, completion), ct)
+            .ConfigureAwait(false);
+        await completion.Task.ConfigureAwait(false);
+    }
 
     private async Task EnqueueAsync(AlgoliaContentIndexJob job, CancellationToken ct)
     {

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexWorker.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaContentIndexWorker.cs
@@ -42,7 +42,23 @@ internal sealed class AlgoliaContentIndexWorker : BackgroundService
 
                 var drained = Drain(maxBatch * 10);
                 foreach (var chunk in drained.Chunk(maxBatch))
-                    await _executor.HandleAsync(chunk, stoppingToken).ConfigureAwait(false);
+                {
+                    try
+                    {
+                        await _executor.HandleAsync(chunk, stoppingToken).ConfigureAwait(false);
+                        CompleteJobs(chunk);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        CompleteJobs(chunk, canceled: true);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        CompleteJobs(chunk, exception: ex);
+                        throw;
+                    }
+                }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -65,5 +81,27 @@ internal sealed class AlgoliaContentIndexWorker : BackgroundService
             list.Add(job);
 
         return list;
+    }
+
+    private static void CompleteJobs(
+        IEnumerable<AlgoliaContentIndexJob> jobs,
+        Exception? exception = null,
+        bool canceled = false)
+    {
+        foreach (var job in jobs)
+        {
+            if (canceled)
+            {
+                job.Completion?.TrySetCanceled();
+            }
+            else if (exception is not null)
+            {
+                job.Completion?.TrySetException(exception);
+            }
+            else
+            {
+                job.Completion?.TrySetResult();
+            }
+        }
     }
 }

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaFullIndexRebuildCoordinator.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaFullIndexRebuildCoordinator.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ekom.Algolia.Indexing;
+
+public interface IAlgoliaFullIndexRebuildCoordinator
+{
+    bool TryStart();
+}
+
+public sealed class AlgoliaFullIndexRebuildCoordinator : IAlgoliaFullIndexRebuildCoordinator
+{
+    private readonly IAlgoliaProductIndexService _productIndexService;
+    private readonly IAlgoliaCategoryIndexService _categoryIndexService;
+    private readonly IAlgoliaContentIndexService _contentIndexService;
+    private readonly ILogger<AlgoliaFullIndexRebuildCoordinator> _logger;
+    private int _isRunning;
+
+    public AlgoliaFullIndexRebuildCoordinator(
+        IAlgoliaProductIndexService productIndexService,
+        IAlgoliaCategoryIndexService categoryIndexService,
+        IAlgoliaContentIndexService contentIndexService,
+        ILogger<AlgoliaFullIndexRebuildCoordinator> logger)
+    {
+        _productIndexService = productIndexService;
+        _categoryIndexService = categoryIndexService;
+        _contentIndexService = contentIndexService;
+        _logger = logger;
+    }
+
+    public bool TryStart()
+    {
+        if (Interlocked.CompareExchange(ref _isRunning, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        _ = Task.Run(RunAsync, CancellationToken.None);
+        return true;
+    }
+
+    private async Task RunAsync()
+    {
+        try
+        {
+            await Task.WhenAll(
+                _productIndexService.RebuildAllAndWaitAsync(),
+                _categoryIndexService.RebuildAllAndWaitAsync(),
+                _contentIndexService.RebuildAndWaitAsync()).ConfigureAwait(false);
+
+            _logger.LogInformation("Algolia manual full reindex completed.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Algolia manual full reindex failed.");
+        }
+        finally
+        {
+            Volatile.Write(ref _isRunning, 0);
+        }
+    }
+}

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexJob.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexJob.cs
@@ -3,7 +3,8 @@ namespace Ekom.Algolia.Indexing;
 internal sealed record AlgoliaProductIndexJob(
     AlgoliaProductIndexJobType Type,
     string StoreAlias,
-    IReadOnlyCollection<Guid> ProductKeys);
+    IReadOnlyCollection<Guid> ProductKeys,
+    TaskCompletionSource? Completion = null);
 
 internal enum AlgoliaProductIndexJobType
 {

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexService.cs
@@ -9,6 +9,7 @@ public interface IAlgoliaProductIndexService
     Task EnqueueProductsAsync(string storeAlias, IReadOnlyCollection<Guid> productKeys, bool isPublished, CancellationToken ct = default);
     Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default);
     Task RebuildAllAsync(CancellationToken ct = default);
+    Task RebuildAllAndWaitAsync(CancellationToken ct = default);
 }
 
 internal sealed class AlgoliaProductIndexService : IAlgoliaProductIndexService
@@ -152,5 +153,30 @@ internal sealed class AlgoliaProductIndexService : IAlgoliaProductIndexService
         }
 
         return Task.CompletedTask;
+    }
+
+    public async Task RebuildAllAndWaitAsync(CancellationToken ct = default)
+    {
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Products)
+            return;
+
+        var completions = new List<Task>();
+        foreach (var store in _options.Stores)
+        {
+            if (string.IsNullOrWhiteSpace(store.Alias))
+                continue;
+
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var job = new AlgoliaProductIndexJob(
+                AlgoliaProductIndexJobType.RebuildStore,
+                store.Alias,
+                Array.Empty<Guid>(),
+                completion);
+
+            await _queue.EnqueueAsync(job, ct).ConfigureAwait(false);
+            completions.Add(completion.Task);
+        }
+
+        await Task.WhenAll(completions).ConfigureAwait(false);
     }
 }

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexWorker.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexWorker.cs
@@ -65,12 +65,15 @@ internal sealed class AlgoliaProductIndexWorker : BackgroundService
                         try
                         {
                             await _executor.HandleAsync(chunk, stoppingToken).ConfigureAwait(false);
+                            CompleteJobs(chunk);
                         }
                         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                         {
+                            CompleteJobs(chunk, canceled: true);
                         }
                         catch (Exception ex)
                         {
+                            CompleteJobs(chunk, exception: ex);
                             _logger.LogError(ex, "Algolia Product Indexer failed processing chunk size {ChunkSize}", chunk.Length);
                         }
                         finally
@@ -104,5 +107,27 @@ internal sealed class AlgoliaProductIndexWorker : BackgroundService
         }
 
         return list;
+    }
+
+    private static void CompleteJobs(
+        IEnumerable<AlgoliaProductIndexJob> jobs,
+        Exception? exception = null,
+        bool canceled = false)
+    {
+        foreach (var job in jobs)
+        {
+            if (canceled)
+            {
+                job.Completion?.TrySetCanceled();
+            }
+            else if (exception is not null)
+            {
+                job.Completion?.TrySetException(exception);
+            }
+            else
+            {
+                job.Completion?.TrySetResult();
+            }
+        }
     }
 }

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -737,6 +737,8 @@ Rebuild all configured store indexes:
 POST /umbraco/backoffice/api/EkomAlgoliaBackoffice/RebuildIndexes
 ```
 
+Only one full rebuild can run per application instance. A concurrent full-rebuild request returns `409 Conflict` until the active product, category, and content rebuilds finish.
+
 Rebuild one store:
 
 ```http

--- a/Plugins/Ekom.Algolia/Umbraco/U10/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U10/AlgoliaBackofficeController.cs
@@ -7,30 +7,29 @@ namespace Ekom.Algolia.Controllers;
 
 public class EkomAlgoliaBackofficeController : UmbracoAuthorizedApiController
 {
+    private readonly IAlgoliaFullIndexRebuildCoordinator _fullIndexRebuildCoordinator;
     private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
     private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
-    private readonly IAlgoliaContentIndexService _algoliaContentIndexService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
+        IAlgoliaFullIndexRebuildCoordinator fullIndexRebuildCoordinator,
         IAlgoliaProductIndexService algoliaProductIndexService,
         IAlgoliaCategoryIndexService algoliaCategoryIndexService,
-        IAlgoliaContentIndexService algoliaContentIndexService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
+        _fullIndexRebuildCoordinator = fullIndexRebuildCoordinator;
         _algoliaProductIndexService = algoliaProductIndexService;
         _algoliaCategoryIndexService = algoliaCategoryIndexService;
-        _algoliaContentIndexService = algoliaContentIndexService;
         _logger = logger;
     }
 
     [HttpGet]
     [HttpPost]
-    public async Task<IActionResult> RebuildIndexesAsync(CancellationToken ct = default)
+    public IActionResult RebuildIndexesAsync()
     {
-        await _algoliaProductIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
-        await _algoliaCategoryIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
-        await _algoliaContentIndexService.RebuildAsync(ct: ct).ConfigureAwait(false);
+        if (!_fullIndexRebuildCoordinator.TryStart())
+            return Conflict(new { error = "An Algolia full reindex is already running." });
 
         _logger.LogInformation("Algolia manual reindex requested for all configured stores and content indexes.");
 

--- a/Plugins/Ekom.Algolia/Umbraco/U17/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U17/AlgoliaBackofficeController.cs
@@ -11,36 +11,35 @@ namespace Ekom.Algolia.Controllers;
 [Route("umbraco/backoffice/api/EkomAlgoliaBackoffice")]
 public class EkomAlgoliaBackofficeController : ControllerBase
 {
+    private readonly IAlgoliaFullIndexRebuildCoordinator _fullIndexRebuildCoordinator;
     private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
     private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
-    private readonly IAlgoliaContentIndexService _algoliaContentIndexService;
     private readonly ISecurityService _securityService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
+        IAlgoliaFullIndexRebuildCoordinator fullIndexRebuildCoordinator,
         IAlgoliaProductIndexService algoliaProductIndexService,
         IAlgoliaCategoryIndexService algoliaCategoryIndexService,
-        IAlgoliaContentIndexService algoliaContentIndexService,
         ISecurityService securityService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
+        _fullIndexRebuildCoordinator = fullIndexRebuildCoordinator;
         _algoliaProductIndexService = algoliaProductIndexService;
         _algoliaCategoryIndexService = algoliaCategoryIndexService;
-        _algoliaContentIndexService = algoliaContentIndexService;
         _securityService = securityService;
         _logger = logger;
     }
 
     [HttpGet("RebuildIndexes")]
     [HttpPost("RebuildIndexes")]
-    public async Task<IActionResult> RebuildIndexesAsync(CancellationToken ct = default)
+    public IActionResult RebuildIndexesAsync()
     {
         if (!_securityService.IsCurrentUserAdmin())
             return Forbid();
 
-        await _algoliaProductIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
-        await _algoliaCategoryIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
-        await _algoliaContentIndexService.RebuildAsync(ct: ct).ConfigureAwait(false);
+        if (!_fullIndexRebuildCoordinator.TryStart())
+            return Conflict(new { error = "An Algolia full reindex is already running." });
 
         _logger.LogInformation("Algolia manual reindex requested for all configured stores and content indexes.");
 

--- a/Plugins/Ekom.Algolia/Umbraco/U18/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U18/AlgoliaBackofficeController.cs
@@ -11,36 +11,35 @@ namespace Ekom.Algolia.Controllers;
 [Route("umbraco/backoffice/api/EkomAlgoliaBackoffice")]
 public class EkomAlgoliaBackofficeController : ControllerBase
 {
+    private readonly IAlgoliaFullIndexRebuildCoordinator _fullIndexRebuildCoordinator;
     private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
     private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
-    private readonly IAlgoliaContentIndexService _algoliaContentIndexService;
     private readonly ISecurityService _securityService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
+        IAlgoliaFullIndexRebuildCoordinator fullIndexRebuildCoordinator,
         IAlgoliaProductIndexService algoliaProductIndexService,
         IAlgoliaCategoryIndexService algoliaCategoryIndexService,
-        IAlgoliaContentIndexService algoliaContentIndexService,
         ISecurityService securityService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
+        _fullIndexRebuildCoordinator = fullIndexRebuildCoordinator;
         _algoliaProductIndexService = algoliaProductIndexService;
         _algoliaCategoryIndexService = algoliaCategoryIndexService;
-        _algoliaContentIndexService = algoliaContentIndexService;
         _securityService = securityService;
         _logger = logger;
     }
 
     [HttpGet("RebuildIndexes")]
     [HttpPost("RebuildIndexes")]
-    public async Task<IActionResult> RebuildIndexesAsync(CancellationToken ct = default)
+    public IActionResult RebuildIndexesAsync()
     {
         if (!_securityService.IsCurrentUserAdmin())
             return Forbid();
 
-        await _algoliaProductIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
-        await _algoliaCategoryIndexService.RebuildAllAsync(ct).ConfigureAwait(false);
-        await _algoliaContentIndexService.RebuildAsync(ct: ct).ConfigureAwait(false);
+        if (!_fullIndexRebuildCoordinator.TryStart())
+            return Conflict(new { error = "An Algolia full reindex is already running." });
 
         _logger.LogInformation("Algolia manual reindex requested for all configured stores and content indexes.");
 


### PR DESCRIPTION
## Summary
- prevent concurrent controller-triggered full Algolia rebuilds with a process-local coordinator
- return `409 Conflict` while a product, category, and content full rebuild is active
- track queued rebuild completion so the coordinator releases only after all rebuild work finishes or fails
- add `PriceHelper.SetPrice` for generating reusable Ekom.Price JSON values outside `IContent`
- update U10 and U17 `IContent.SetPrice` implementations to use the shared serializer

## Test Plan
- `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj" --no-restore`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~PriceTests|FullyQualifiedName~AlgoliaFullIndexRebuildCoordinatorTests" --no-restore`
