### PR TITLE
feat(discounts): add native product discount prices

### DIFF
--- a/Ekom/CHANGELOG.md
+++ b/Ekom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **discounts:** add native product and variant `ekmDiscountPrice` support using the Ekom Price datatype, competing with content and event-added discounts while preserving original prices.
+
 ## [0.2.266](https://github.com/Vettvangur/Ekom/compare/Ekom-v0.2.265...Ekom-v0.2.266) (2026-09-07)
 
 

--- a/Ekom/Ekom.Core/Ekom/Models/Behaviors/Constraints.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Behaviors/Constraints.cs
@@ -142,6 +142,13 @@ public class Constraints : IConstraints
     /// <summary>
     /// ctor
     /// </summary>
+    internal Constraints()
+    {
+        _manualStartRanges = [];
+        _manualEndRanges = [];
+        CountriesInZone = Array.Empty<string>();
+    }
+
     public Constraints(INodeEntity node)
     {
         _node = node;

--- a/Ekom/Ekom.Core/Ekom/Models/OrderedObjects/OrderedProduct.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderedObjects/OrderedProduct.cs
@@ -1,10 +1,8 @@
 using Ekom.API;
 using Ekom.Services;
 using Ekom.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.Xml.Serialization;
 
 namespace Ekom.Models;
@@ -274,15 +272,7 @@ public class OrderedProduct
             Prices = product.Prices.ToList();
         }
 
-        IDiscount? productDiscount = Configuration.Resolver.GetService<ProductDiscountService>()?
-            .GetProductDiscount(
-                product.Path,
-                product.Store.Alias,
-                Price.Value.ToString(CultureInfo.InvariantCulture),
-                product.Categories.Select(x => x.Id.ToString()).ToArray()
-            );
-
-        ProductDiscount = productDiscount != null ? new OrderedDiscount(productDiscount) : null;
+        ProductDiscount = Price?.Discount is { } discount ? new OrderedDiscount(discount) : null;
 
         if (variant != null)
         {

--- a/Ekom/Ekom.Core/Ekom/Models/Product.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Product.cs
@@ -28,21 +28,34 @@ public class Product : PerStoreNodeEntity, IProduct
     private readonly ConcurrentDictionary<string, Lazy<object>> _cache = new();
 
     public virtual IDiscount? ProductDiscount(string? price = null)
+        => ProductDiscount(price, CookieHelper.GetCurrencyCookieValue(Store.Currencies, Store.Alias) ?? Store.Currency);
+
+    public virtual IDiscount? ProductDiscount(string? price, CurrencyModel currency)
     {
-        price = string.IsNullOrEmpty(price) ? OriginalPrice.OriginalValue.ToString() : price;
+        price = string.IsNullOrEmpty(price)
+            ? (NativeDiscountPrice.Read(_priceValue, Store.Alias, currency.CurrencyValue,
+                (Store.Currencies.FirstOrDefault() ?? Store.Currency).CurrencyValue) ?? 0).ToString(CultureInfo.InvariantCulture)
+            : price;
 
         return Configuration.Resolver.GetService<ProductDiscountService>()?
             .GetProductDiscount(
                 Path,
                 Store.Alias,
                 price,
-                categories.Select(x => x.Id.ToString()).ToArray()
+                categories.Select(x => x.Id.ToString()).ToArray(),
+                NativeDiscountPrice.Read(this, Store, currency)
             );
     }
 
     public virtual async Task<IDiscount?> ProductDiscountAsync(string? price = null, CancellationToken ct = default)
+        => await ProductDiscountAsync(price, ct, CookieHelper.GetCurrencyCookieValue(Store.Currencies, Store.Alias) ?? Store.Currency).ConfigureAwait(false);
+
+    public virtual async Task<IDiscount?> ProductDiscountAsync(string? price, CancellationToken ct, CurrencyModel currency)
     {
-        price = string.IsNullOrEmpty(price) ? OriginalPrice.OriginalValue.ToString() : price;
+        price = string.IsNullOrEmpty(price)
+            ? (NativeDiscountPrice.Read(_priceValue, Store.Alias, currency.CurrencyValue,
+                (Store.Currencies.FirstOrDefault() ?? Store.Currency).CurrencyValue) ?? 0).ToString(CultureInfo.InvariantCulture)
+            : price;
 
         var discountService = Configuration.Resolver.GetService<ProductDiscountService>();
         if (discountService == null)
@@ -53,7 +66,8 @@ public class Product : PerStoreNodeEntity, IProduct
             Store.Alias,
             price,
             categories.Select(x => x.Id.ToString()).ToArray(),
-            ct: ct
+            ct: ct,
+            discountPrice: NativeDiscountPrice.Read(this, Store, currency)
         ).ConfigureAwait(false);
     }
 
@@ -367,7 +381,8 @@ public class Product : PerStoreNodeEntity, IProduct
             string globalGen = PriceCache.GlobalGeneration;
             string productGen = PriceCache.GetItemGeneration(productKey, Store.Alias);
 
-            var key = $"prices:g={globalGen}:p={productGen}:store={Store.Alias}:prod={productKey}:cats={string.Join('|', categories)}:hash={CacheHelpers.Sha256(_priceValue)}";
+            var sale = NativeDiscountPrice.Raw(this);
+            var key = $"prices:g={globalGen}:p={productGen}:store={Store.Alias}:currency={storeCurrency.CurrencyValue}:prod={productKey}:cats={string.Join('|', categories)}:hash={CacheHelpers.Sha256(_priceValue)}:sale={CacheHelpers.Sha256(sale)}";
 
             return CacheHelpers.GetOrCreateSingleFlight(
                 key,
@@ -379,7 +394,8 @@ public class Product : PerStoreNodeEntity, IProduct
                     storeCurrency,
                     Store.Alias,
                     Path,
-                    categories),
+                    categories,
+                    sale),
                 TimeSpan.FromHours(48)
             );
         }
@@ -403,7 +419,8 @@ public class Product : PerStoreNodeEntity, IProduct
             Store.Currency,
             Store.Alias,
             Path,
-            categories
+            categories,
+            NativeDiscountPrice.Raw(this)
         );
     }
 

--- a/Ekom/Ekom.Core/Ekom/Models/Variant.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Variant.cs
@@ -153,29 +153,48 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     /// Gets the productDiscount for the specific Variant
     /// </summary>
     public IProductDiscount? ProductDiscount(string price)
+        => ProductDiscount(price, CookieHelper.GetCurrencyCookieValue(Store.Currencies, Store.Alias) ?? Store.Currency);
+
+    public IProductDiscount? ProductDiscount(string price, CurrencyModel currency)
     {
+        var product = Product;
+        var source = GetDiscountSource(currency, product);
         return Configuration.Resolver.GetService<ProductDiscountService>()?
             .GetProductDiscount(
-                Path,
+                source.Path,
                 Store.Alias,
                 price,
-                Product?.Categories.Select(x => x.Id.ToString()).ToArray()
+                product?.Categories.Select(x => x.Id.ToString()).ToArray(),
+                NativeDiscountPrice.Read(source, Store, currency)
             );
     }
 
     public virtual async Task<IProductDiscount?> ProductDiscountAsync(string price, CancellationToken ct = default)
+        => await ProductDiscountAsync(price, ct, CookieHelper.GetCurrencyCookieValue(Store.Currencies, Store.Alias) ?? Store.Currency).ConfigureAwait(false);
+
+    public virtual async Task<IProductDiscount?> ProductDiscountAsync(string price, CancellationToken ct, CurrencyModel currency)
     {
         var discountService = Configuration.Resolver.GetService<ProductDiscountService>();
         if (discountService == null)
             return null;
 
+        var product = Product;
+        var source = GetDiscountSource(currency, product);
         return await discountService.GetProductDiscountAsync(
-            Path,
+            source.Path,
             Store.Alias,
             price,
-            Product?.Categories.Select(x => x.Id.ToString()).ToArray(),
-            ct: ct
+            product?.Categories.Select(x => x.Id.ToString()).ToArray(),
+            ct: ct,
+            discountPrice: NativeDiscountPrice.Read(source, Store, currency)
         ).ConfigureAwait(false);
+    }
+
+    private INodeEntity GetDiscountSource(CurrencyModel currency, IProduct? product)
+    {
+        var ownPrice = NativeDiscountPrice.Read(_priceValue, Store.Alias, currency.CurrencyValue,
+            (Store.Currencies.FirstOrDefault() ?? Store.Currency).CurrencyValue);
+        return (ownPrice == null || ownPrice == 0) && product != null ? product : this;
     }
 
     /// <summary>
@@ -208,7 +227,8 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
     {
         get
         {
-            string[] categories = Product?.Categories.Select(x => x.Id.ToString()).ToArray()
+            var product = Product;
+            string[] categories = product?.Categories.Select(x => x.Id.ToString()).ToArray()
                                     ?? Array.Empty<string>();
 
             string itemKey = Path;
@@ -216,8 +236,13 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
             string globalGen = PriceCache.GlobalGeneration;
             string productGen = PriceCache.GetItemGeneration(itemKey, Store.Alias);
 
+            var sale = NativeDiscountPrice.Raw(this);
+            var parentGen = product == null ? string.Empty : PriceCache.GetItemGeneration(product.Path, Store.Alias);
+            var parentPrice = product?.Properties.GetPropertyValue("price", Store.Alias) ?? string.Empty;
+            var parentSale = NativeDiscountPrice.Raw(product);
+
             string cacheKey =
-                $"prices:g={globalGen}:p={productGen}:store={Store.Alias}:prod={itemKey}:cats={string.Join('|', categories)}:hash={CacheHelpers.Sha256(_priceValue)}";
+                $"prices:g={globalGen}:p={productGen}:store={Store.Alias}:currency={Store.Currency.CurrencyValue}:prod={itemKey}:cats={string.Join('|', categories)}:hash={CacheHelpers.Sha256(_priceValue)}:sale={CacheHelpers.Sha256(sale)}:parent={parentGen}:parentPrice={CacheHelpers.Sha256(parentPrice)}:parentSale={CacheHelpers.Sha256(parentSale)}";
 
             return CacheHelpers.GetOrCreateSingleFlight(
                 cacheKey,
@@ -232,26 +257,26 @@ public class Variant : PerStoreNodeEntity, IVariant, IPerStoreNodeEntity
                         Store.Currency,
                         Store.Alias,
                         Path,
-                        categories
+                        categories,
+                        sale
                     );
 
-                    // --- Repair any zero-priced entries using Product.Prices ---
-                    if (Product != null)
+                    // Missing and zero base prices inherit the parent's price and selected discount together.
+                    if (product != null)
                     {
-                        var fallbackPrices = Product.BuildPricesFromRaw(categories);
+                        var fallbackPrices = product.BuildPricesFromRaw(categories);
 
-                        foreach (IPrice? p in prices.Where(x => x.OriginalValue == 0).ToList())
+                        foreach (var fallback in fallbackPrices)
                         {
-                            var replacement = fallbackPrices
-                                .FirstOrDefault(x => x.Currency.CurrencyValue == p.Currency.CurrencyValue);
-
-                            if (replacement != null)
+                            int index = prices.FindIndex(x => string.Equals(
+                                x.Currency.CurrencyValue, fallback.Currency.CurrencyValue, StringComparison.OrdinalIgnoreCase));
+                            if (index < 0)
                             {
-                                int index = prices.IndexOf(p);
-                                if (index >= 0)
-                                {
-                                    prices[index] = replacement;
-                                }
+                                prices.Add(fallback);
+                            }
+                            else if (prices[index].OriginalValue == 0)
+                            {
+                                prices[index] = fallback;
                             }
                         }
                     }

--- a/Ekom/Ekom.Core/Ekom/Services/ProductDiscountService.cs
+++ b/Ekom/Ekom.Core/Ekom/Services/ProductDiscountService.cs
@@ -18,33 +18,38 @@ class ProductDiscountService
         string path,
         string? storeAlias,
         string inputPrice,
-        string[]? categories = null)
+        string[]? categories = null,
+        decimal? discountPrice = null)
         => GetProductDiscountCoreAsync(
             path,
             storeAlias,
             inputPrice,
             categories,
-            CancellationToken.None).GetAwaiter().GetResult();
+            CancellationToken.None,
+            discountPrice).GetAwaiter().GetResult();
 
     public virtual Task<IProductDiscount?> GetProductDiscountAsync(
         string path,
         string? storeAlias,
         string inputPrice,
         string[]? categories = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        decimal? discountPrice = null)
         => GetProductDiscountCoreAsync(
             path,
             storeAlias,
             inputPrice,
             categories,
-            ct);
+            ct,
+            discountPrice);
 
     private async Task<IProductDiscount?> GetProductDiscountCoreAsync(
         string path,
         string? storeAlias,
         string inputPrice,
         string[]? categories = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        decimal? discountPrice = null)
     {
         ct.ThrowIfCancellationRequested();
 
@@ -125,6 +130,11 @@ class ProductDiscountService
                 applicableDiscounts.Add(kvp.Value);
         }
 
+        if (discountPrice is > 0 && discountPrice.Value < price)
+        {
+            applicableDiscounts.Add(new NativePriceDiscount(price - discountPrice.Value));
+        }
+
         var applicableArgs = new DiscountEvents.ProductDiscountApplicableEventArgs(
             path,
             storeAlias,
@@ -141,6 +151,23 @@ class ProductDiscountService
             return null;
 
         return SelectBestDiscount(applicableArgs.ApplicableDiscounts, price);
+    }
+
+    private sealed class NativePriceDiscount : OrderedDiscount, IProductDiscount
+    {
+        // Reserved feature identity, independent of price, currency, or request context.
+        internal NativePriceDiscount(decimal saving)
+            : base(new Guid("7dd69e20-92a4-4aab-8c81-f66f935d679c"), "Sale price", false,
+                saving, DiscountType.Fixed, [], [],
+                new Constraints(), false, false)
+        {
+        }
+
+        public decimal StartOfRange => 0;
+        public decimal EndOfRange => 0;
+        public bool Disabled => false;
+
+        int IComparable<IDiscount>.CompareTo(IDiscount? other) => other == null ? 1 : base.CompareTo(other);
     }
 
     internal static IProductDiscount? SelectBestDiscount(

--- a/Ekom/Ekom.Core/Ekom/Utilities/NativeDiscountPrice.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/NativeDiscountPrice.cs
@@ -1,0 +1,84 @@
+using Ekom.Models;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Ekom.Utilities;
+
+internal static class NativeDiscountPrice
+{
+    internal static string Raw(INodeEntity? node)
+        => node?.Properties.TryGetValue("ekmDiscountPrice", out var value) == true ? value : string.Empty;
+
+    internal static decimal? Read(INodeEntity node, IStore store, CurrencyModel currency)
+        => Read(Raw(node), store.Alias, currency.CurrencyValue,
+            (store.Currencies.FirstOrDefault() ?? store.Currency).CurrencyValue);
+
+    // Scalars belong to the default currency. Currency arrays never fall back to their first entry.
+    internal static decimal? Read(string? raw, string? storeAlias, string currency, string defaultCurrency)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var text = raw.Trim();
+        if (text[0] != '[' && text[0] != '{' && text[0] != '"')
+        {
+            return string.Equals(currency, defaultCurrency, StringComparison.OrdinalIgnoreCase) &&
+                decimal.TryParse(text.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out var scalar)
+                ? scalar : null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            var value = doc.RootElement;
+            if (value.ValueKind == JsonValueKind.Object)
+            {
+                if (TryProperty(value, "values", out var values)) value = values;
+                if (!TryProperty(value, storeAlias, out var storeValue)) return null;
+                value = storeValue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in value.EnumerateArray())
+                {
+                    if (TryProperty(item, "Currency", out var code) &&
+                        code.ValueKind == JsonValueKind.String &&
+                        string.Equals(code.GetString(), currency, StringComparison.OrdinalIgnoreCase) &&
+                        TryProperty(item, "Price", out var amount))
+                    {
+                        return amount.ValueKind is JsonValueKind.String or JsonValueKind.Number &&
+                            decimal.TryParse(amount.ToString().Replace(',', '.'), NumberStyles.Any,
+                                CultureInfo.InvariantCulture, out var price)
+                            ? price : null;
+                    }
+                }
+                return null;
+            }
+
+            return value.ValueKind is JsonValueKind.String or JsonValueKind.Number
+                ? Read(value.ToString(), storeAlias, currency, defaultCurrency)
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryProperty(JsonElement element, string? name, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+        value = default;
+        return false;
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Utilities/PriceBuilder.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/PriceBuilder.cs
@@ -16,6 +16,19 @@ public static class PriceBuilder
         string? storeAlias,
         string? path,
         string[]? categories)
+        => BuildPricesSync(priceJson, storeCurrencies, vat, vatIncludedInPrice,
+            fallbackCurrency, storeAlias, path, categories, null);
+
+    public static List<IPrice> BuildPricesSync(
+        string priceJson,
+        List<CurrencyModel> storeCurrencies,
+        decimal vat,
+        bool vatIncludedInPrice,
+        CurrencyModel fallbackCurrency,
+        string? storeAlias,
+        string? path,
+        string[]? categories,
+        string? discountPriceJson)
     {
 
         var prices = new List<IPrice>();
@@ -39,7 +52,9 @@ public static class PriceBuilder
         if (!isArray)
         {
             IDiscount? disc = (!string.IsNullOrEmpty(path) && discountSvc != null)
-                ? discountSvc.GetProductDiscount(path!, storeAlias, priceJson, categories)
+                ? discountSvc.GetProductDiscount(path!, storeAlias, priceJson, categories,
+                    NativeDiscountPrice.Read(discountPriceJson, storeAlias, fallbackCurrency.CurrencyValue,
+                        (storeCurrencies.FirstOrDefault() ?? fallbackCurrency).CurrencyValue))
                 : null;
 
             prices.Add(new Price(
@@ -77,14 +92,18 @@ public static class PriceBuilder
             string? currStr = GetStringValue(currencyElement);
 
             var currency = (!string.IsNullOrEmpty(currStr)
-                    ? storeCurrencies.FirstOrDefault(x => x.CurrencyValue == currStr)
+                    ? storeCurrencies.FirstOrDefault(x => string.Equals(x.CurrencyValue, currStr, StringComparison.OrdinalIgnoreCase))
                     : null)
                 ?? storeCurrencies.FirstOrDefault()
                 ?? fallbackCurrency;
 
             // ---- DISCOUNT ----
             IDiscount? disc = (!string.IsNullOrEmpty(path) && discountSvc != null)
-                ? discountSvc.GetProductDiscount(path!, storeAlias, priceStr, categories)
+                ? discountSvc.GetProductDiscount(path!, storeAlias, priceStr, categories,
+                    string.Equals(currStr, currency.CurrencyValue, StringComparison.OrdinalIgnoreCase)
+                        ? NativeDiscountPrice.Read(discountPriceJson, storeAlias, currency.CurrencyValue,
+                            (storeCurrencies.FirstOrDefault() ?? fallbackCurrency).CurrencyValue)
+                        : null)
                 : null;
 
             prices.Add(new Price(

--- a/Ekom/Ekom.Core/Ekom/Utilities/StringExtensions.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/StringExtensions.cs
@@ -256,7 +256,20 @@ public static class StringExtension
         CurrencyModel? fallbackCurrency = null,
         string? storeAlias = null,
         string? path = null,
-        string[]? categories = null
+        string[]? categories = null)
+        => GetPriceValues(priceJson, storeCurrencies, vat, vatIncludedInPrice,
+            fallbackCurrency, storeAlias, path, categories, null);
+
+    public static List<IPrice> GetPriceValues(
+        this string priceJson,
+        List<CurrencyModel> storeCurrencies,
+        decimal vat,
+        bool vatIncludedInPrice,
+        CurrencyModel? fallbackCurrency,
+        string? storeAlias,
+        string? path,
+        string[]? categories,
+        string? discountPriceJson
         )
     {
         var discountService = Configuration.Resolver.GetService<ProductDiscountService>();
@@ -269,7 +282,8 @@ public static class StringExtension
             foreach (JToken price in _prices)
             {
                 string? currencyValue = GetPropertyIgnoreCase(price, "Currency")?.Value<string>();
-                CurrencyModel? currency = storeCurrencies.FirstOrDefault(x => x.CurrencyValue == currencyValue) ?? storeCurrencies.FirstOrDefault();
+                CurrencyModel? currency = storeCurrencies.FirstOrDefault(x => string.Equals(
+                    x.CurrencyValue, currencyValue, StringComparison.OrdinalIgnoreCase)) ?? storeCurrencies.FirstOrDefault();
                 string? priceValue = GetPropertyIgnoreCase(price, "Price")?.Value<string>();
 
                 IDiscount? productDiscount = !string.IsNullOrEmpty(path) && discountService != null
@@ -278,7 +292,11 @@ public static class StringExtension
                             path,
                             storeAlias,
                             priceValue,
-                            categories
+                            categories,
+                            string.Equals(currencyValue, currency?.CurrencyValue, StringComparison.OrdinalIgnoreCase)
+                                ? NativeDiscountPrice.Read(discountPriceJson, storeAlias, currencyValue ?? string.Empty,
+                                    (storeCurrencies.FirstOrDefault() ?? fallbackCurrency)?.CurrencyValue ?? string.Empty)
+                                : null
                         )
                     : null;
 
@@ -309,7 +327,9 @@ public static class StringExtension
                     path,
                     storeAlias,
                     priceJson,
-                    categories
+                    categories,
+                    NativeDiscountPrice.Read(discountPriceJson, storeAlias, fallbackCurrency.CurrencyValue,
+                        (storeCurrencies.FirstOrDefault() ?? fallbackCurrency).CurrencyValue)
                 )
             : null;
 

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EnsureNodesExist.cs
@@ -611,28 +611,34 @@ class EnsureNodesExist : IComponent
                                         Name = "Price",
                                         SortOrder = 4
                                     },
+                                    new PropertyType(_shortStringHelper, priceDt, "ekmDiscountPrice")
+                                    {
+                                        Name = "Discount Price",
+                                        Mandatory = false,
+                                        SortOrder = 5
+                                    },
                                     new PropertyType(_shortStringHelper, stockDt, "stock")
                                     {
                                         Name = "Stock",
-                                        SortOrder = 5
+                                        SortOrder = 6
                                     },
                                     new PropertyType(_shortStringHelper, propertyNumericDt, "ekmStockBuffer")
                                     {
                                         Name = "Stock Buffer",
                                         Description = "Reduces the available stock by this amount",
-                                        SortOrder = 6
+                                        SortOrder = 7
                                     },
                                     new PropertyType(_shortStringHelper, booleanDt, "enableBackorder")
                                     {
                                         Name = "Enable Backorder",
                                         Description = "If set then the variant can be sold indefinitely",
-                                        SortOrder = 7
+                                        SortOrder = 8
                                     },
                                     new PropertyType(_shortStringHelper, decimalDt, "vat")
                                     {
                                         Name = "VAT",
                                         Description = "%, override store VAT.",
-                                        SortOrder = 8
+                                        SortOrder = 9
                                     },
                                 }))
                             {
@@ -733,6 +739,11 @@ class EnsureNodesExist : IComponent
                                     new PropertyType(_shortStringHelper, priceDt, "price")
                                     {
                                         Name = "Price",
+                                    },
+                                    new PropertyType(_shortStringHelper, priceDt, "ekmDiscountPrice")
+                                    {
+                                        Name = "Discount Price",
+                                        Mandatory = false,
                                     },
                                     new PropertyType(_shortStringHelper, stockDt, "stock")
                                     {
@@ -1458,6 +1469,7 @@ class EnsureNodesExist : IComponent
                 #endregion
             }
 
+            EnsureDiscountPriceProperties();
             EnsureDiscountAndProviderFolderContentTypes();
 
             _logger.LogDebug("Done");
@@ -1506,6 +1518,49 @@ class EnsureNodesExist : IComponent
         }
 
         return textDt;
+    }
+
+    private void EnsureDiscountPriceProperties()
+    {
+        foreach (var alias in new[] { "ekmProduct", "ekmProductVariant" })
+        {
+            var contentType = _contentTypeService.Get(alias);
+            if (contentType == null || contentType.CompositionPropertyTypes.Any(x =>
+                x.Alias.Equals("ekmDiscountPrice", StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            var group = contentType.PropertyGroups.FirstOrDefault(x =>
+                x.PropertyTypes.Any(p => p.Alias == "price"));
+            var price = group?.PropertyTypes.FirstOrDefault(x => x.Alias == "price");
+            if (group == null || price == null || price.PropertyEditorAlias != "Ekom.Price")
+            {
+                _logger.LogWarning("Cannot add Discount Price to {Alias} because a direct Ekom Price property group is missing.", alias);
+                continue;
+            }
+
+            var discountPrice = new PropertyType(_shortStringHelper, price.PropertyEditorAlias, price.ValueStorageType, "ekmDiscountPrice")
+            {
+                Name = "Discount Price",
+                DataTypeId = price.DataTypeId,
+                Variations = price.Variations,
+                Mandatory = false,
+                SortOrder = price.SortOrder + 1,
+            };
+
+            // Make room after Price without changing other groups or their relative ordering.
+            var sortOrder = discountPrice.SortOrder;
+            foreach (var property in group.PropertyTypes.OrderBy(x => x.SortOrder).SkipWhile(x => x != price).Skip(1))
+            {
+                property.SortOrder = Math.Max(property.SortOrder, ++sortOrder);
+                sortOrder = property.SortOrder;
+            }
+
+            group.PropertyTypes.Add(discountPrice);
+            _contentTypeService.Save(contentType);
+            _logger.LogInformation("Added Discount Price to content type {Alias}", alias);
+        }
     }
 
     private void EnsureDiscountAndProviderFolderContentTypes()
@@ -1620,6 +1675,16 @@ class EnsureNodesExist : IComponent
 
         if (ekmContentType == null)
         {
+            if (contentType.Alias == "ekmProduct")
+            {
+                // Product properties otherwise share the default sort order.
+                var sortOrder = 0;
+                foreach (var property in contentType.PropertyGroups.Single(x => x.Alias == "product").PropertyTypes)
+                {
+                    property.SortOrder = sortOrder++;
+                }
+            }
+
             ekmContentType = contentType;
             _contentTypeService.Save(ekmContentType);
             _logger.LogInformation(

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
@@ -657,22 +657,28 @@ class EnsureNodesExist : IAsyncComponent
                                         Name = "Price",
                                         SortOrder = 4
                                     },
+                                    new PropertyType(_shortStringHelper, priceDt, "ekmDiscountPrice")
+                                    {
+                                        Name = "Discount Price",
+                                        Mandatory = false,
+                                        SortOrder = 5
+                                    },
                                     new PropertyType(_shortStringHelper, stockDt, "stock")
                                     {
                                         Name = "Stock",
-                                        SortOrder = 5
+                                        SortOrder = 6
                                     },
                                     new PropertyType(_shortStringHelper, booleanDt, "enableBackorder")
                                     {
                                         Name = "Enable Backorder",
                                         Description = "If set then the variant can be sold indefinitely",
-                                        SortOrder = 6
+                                        SortOrder = 7
                                     },
                                     new PropertyType(_shortStringHelper, numericDt, "vat")
                                     {
                                         Name = "VAT",
                                         Description = "%, override store VAT.",
-                                        SortOrder = 7
+                                        SortOrder = 8
                                     },
                                 }))
                             {
@@ -774,6 +780,11 @@ class EnsureNodesExist : IAsyncComponent
                                     new PropertyType(_shortStringHelper, priceDt, "price")
                                     {
                                         Name = "Price",
+                                    },
+                                    new PropertyType(_shortStringHelper, priceDt, "ekmDiscountPrice")
+                                    {
+                                        Name = "Discount Price",
+                                        Mandatory = false,
                                     },
                                     new PropertyType(_shortStringHelper, stockDt, "stock")
                                     {
@@ -1509,6 +1520,7 @@ class EnsureNodesExist : IAsyncComponent
                 #endregion
             }
 
+            EnsureDiscountPriceProperties();
             EnsureDiscountAndProviderFolderContentTypes();
             EnsureSkuProductPickerDataType();
 
@@ -1601,6 +1613,49 @@ class EnsureNodesExist : IAsyncComponent
         });
 
         SaveDataType(dataType);
+    }
+
+    private void EnsureDiscountPriceProperties()
+    {
+        foreach (var alias in new[] { "ekmProduct", "ekmProductVariant" })
+        {
+            var contentType = _contentTypeService.Get(alias);
+            if (contentType == null || contentType.CompositionPropertyTypes.Any(x =>
+                x.Alias.Equals("ekmDiscountPrice", StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            var group = contentType.PropertyGroups.FirstOrDefault(x =>
+                x.PropertyTypes.Any(p => p.Alias == "price"));
+            var price = group?.PropertyTypes.FirstOrDefault(x => x.Alias == "price");
+            if (group == null || price == null || price.PropertyEditorAlias != "Ekom.Price")
+            {
+                _logger.LogWarning("Cannot add Discount Price to {Alias} because a direct Ekom Price property group is missing.", alias);
+                continue;
+            }
+
+            var discountPrice = new PropertyType(_shortStringHelper, price.PropertyEditorAlias, price.ValueStorageType, "ekmDiscountPrice")
+            {
+                Name = "Discount Price",
+                DataTypeId = price.DataTypeId,
+                Variations = price.Variations,
+                Mandatory = false,
+                SortOrder = price.SortOrder + 1,
+            };
+
+            // Make room after Price without changing other groups or their relative ordering.
+            var sortOrder = discountPrice.SortOrder;
+            foreach (var property in group.PropertyTypes.OrderBy(x => x.SortOrder).SkipWhile(x => x != price).Skip(1))
+            {
+                property.SortOrder = Math.Max(property.SortOrder, ++sortOrder);
+                sortOrder = property.SortOrder;
+            }
+
+            group.PropertyTypes.Add(discountPrice);
+            SaveContentType(contentType);
+            _logger.LogInformation("Added Discount Price to content type {Alias}", alias);
+        }
     }
 
     private void EnsureDiscountAndProviderFolderContentTypes()
@@ -1949,6 +2004,16 @@ class EnsureNodesExist : IAsyncComponent
 
         if (ekmContentType == null)
         {
+            if (contentType.Alias == "ekmProduct")
+            {
+                // Product properties otherwise share the default sort order.
+                var sortOrder = 0;
+                foreach (var property in contentType.PropertyGroups.Single(x => x.Alias == "product").PropertyTypes)
+                {
+                    property.SortOrder = sortOrder++;
+                }
+            }
+
             ekmContentType = contentType;
             SaveContentType(ekmContentType);
             _logger.LogInformation(

--- a/Ekom/Tests/Ekom.Tests/Tests/NativeDiscountPriceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/NativeDiscountPriceTests.cs
@@ -1,0 +1,360 @@
+using Ekom.API;
+using Ekom.Cache;
+using Ekom.Events;
+using Ekom.Models;
+using Ekom.Models.Umbraco;
+using Ekom.Services;
+using Ekom.Tests.Objects;
+using Ekom.Utilities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Concurrent;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class NativeDiscountPriceCollection
+{
+    public const string Name = "Native discount price";
+}
+
+[Collection(NativeDiscountPriceCollection.Name)]
+public class NativeDiscountPriceTests
+{
+    [Fact]
+    public void GetPriceValues_LegacyShortAndPartialCallsRemainSupported()
+    {
+        using var fixture = new Fixture();
+        const string raw = "[{\"Currency\":\"en-US\",\"Price\":100}]";
+        var currencies = fixture.Store.Currencies;
+        var currency = fixture.Store.Currency;
+
+        List<IPrice>[] results =
+        [
+            StringExtension.GetPriceValues(raw, currencies, 0, true),
+            raw.GetPriceValues(currencies, 0, true, currency),
+            raw.GetPriceValues(currencies, 0, true, currency, "Web"),
+            raw.GetPriceValues(currencies, 0, true, currency, "Web", "-1,100,200"),
+            raw.GetPriceValues(currencies, 0, true, currency, "Web", "-1,100,200", []),
+            raw.GetPriceValues(currencies, 0, true, storeAlias: "Web", path: "-1,100,200"),
+        ];
+
+        foreach (var prices in results)
+        {
+            var price = Assert.Single(prices);
+            Assert.Same(currency, price.Currency);
+            Assert.Equal(100m, price.AfterDiscount.Value);
+            Assert.False(price.HasDiscount);
+        }
+    }
+
+    [Theory]
+    [InlineData("80")]
+    [InlineData("[{\"Currency\":\"en-US\",\"Price\":80},{\"Currency\":\"en-GB\",\"Price\":70}]")]
+    public async Task ProductDiscount_ExplicitCurrencyUsesConfiguredDefaultForScalarBase(string target)
+    {
+        using var fixture = new Fixture(useSecondCurrency: true);
+        var product = fixture.Product("100", target);
+        var usd = fixture.Store.Currencies[0];
+        var gbp = fixture.Store.Currency;
+
+        var sync = product.ProductDiscount(null, usd);
+        var asyncDiscount = await product.ProductDiscountAsync(null, CancellationToken.None, usd);
+
+        Assert.NotNull(sync);
+        Assert.Equal(20m, sync.Amount);
+        Assert.Equal(sync.Amount, asyncDiscount?.Amount);
+        Assert.Null(product.ProductDiscount(null, gbp));
+        Assert.Null(await product.ProductDiscountAsync(null, CancellationToken.None, gbp));
+    }
+
+    [Fact]
+    public async Task Variant_ExplicitCurrencyUsesConfiguredDefaultForScalarBaseAndParentFallback()
+    {
+        using var fixture = new Fixture(useSecondCurrency: true);
+        var product = fixture.Product("[{\"Currency\":\"en-US\",\"Price\":100},{\"Currency\":\"en-GB\",\"Price\":200}]",
+            "[{\"Currency\":\"en-US\",\"Price\":80},{\"Currency\":\"en-GB\",\"Price\":150}]");
+        var variant = new TestVariant(Content("120",
+            "[{\"Currency\":\"en-US\",\"Price\":90},{\"Currency\":\"en-GB\",\"Price\":50}]",
+            "-1,100,200,300,400"), fixture.Store, product);
+        var usd = fixture.Store.Currencies[0];
+        var gbp = fixture.Store.Currency;
+
+        Assert.Equal(30m, variant.ProductDiscount("120", usd)?.Amount);
+        Assert.Equal(30m, (await variant.ProductDiscountAsync("120", CancellationToken.None, usd))?.Amount);
+        Assert.Equal(50m, variant.ProductDiscount("200", gbp)?.Amount);
+        Assert.Equal(50m, (await variant.ProductDiscountAsync("200", CancellationToken.None, gbp))?.Amount);
+    }
+
+    [Fact]
+    public void ScalarBuilders_PreserveExplicitFallbackCurrency()
+    {
+        using var fixture = new Fixture(useSecondCurrency: true);
+        var currency = fixture.Store.Currency;
+        var built = PriceBuilder.BuildPricesSync("100", fixture.Store.Currencies, 0, true,
+            currency, "Web", "-1,100,200", []);
+        var extended = "100".GetPriceValues(fixture.Store.Currencies, 0, true, currency);
+
+        foreach (var prices in new[] { built, extended })
+        {
+            var price = Assert.Single(prices);
+            Assert.Same(currency, price.Currency);
+            Assert.Equal(100m, price.AfterDiscount.Value);
+        }
+    }
+
+    [Theory]
+    [InlineData("80", "Web", "en-US", 80)]
+    [InlineData("80,5", "Web", "en-US", 80.5)]
+    [InlineData("80", "Web", "en-GB", 100)]
+    [InlineData("[{\"Currency\":\"en-GB\",\"Price\":70},{\"currency\":\"EN-us\",\"price\":\"80\"}]", "Web", "en-US", 80)]
+    [InlineData("[{\"Currency\":\"en-GB\",\"Price\":70}]", "Web", "en-US", 100)]
+    [InlineData("{\"values\":{\"web\":[{\"Currency\":\"en-US\",\"Price\":80}],\"Other\":[{\"Currency\":\"en-US\",\"Price\":60}]}}", "Web", "en-US", 80)]
+    [InlineData("{\"Web\":80,\"Other\":60}", "Other", "en-US", 60)]
+    [InlineData("{\"Other\":60}", "Web", "en-US", 100)]
+    [InlineData("", "Web", "en-US", 100)]
+    [InlineData("not a price", "Web", "en-US", 100)]
+    [InlineData("[{", "Web", "en-US", 100)]
+    [InlineData("[{\"Currency\":\"en-US\",\"Price\":{}}]", "Web", "en-US", 100)]
+    [InlineData("0", "Web", "en-US", 100)]
+    [InlineData("-10", "Web", "en-US", 100)]
+    [InlineData("100", "Web", "en-US", 100)]
+    [InlineData("120", "Web", "en-US", 100)]
+    public void BuildPrices_AppliesOnlyValidTargetForMatchingStoreAndCurrency(
+        string target, string storeAlias, string currency, decimal expected)
+    {
+        using var fixture = new Fixture();
+        string raw = $"[{{\"Currency\":\"{currency}\",\"Price\":100}}]";
+
+        var prices = PriceBuilder.BuildPricesSync(raw, fixture.Store.Currencies, 0, true,
+            fixture.Store.Currency, storeAlias, "-1,100,200", [], target);
+        var price = Assert.Single(prices, x => x.Currency.CurrencyValue == currency);
+
+        Assert.Equal(100m, price.OriginalValue);
+        Assert.Equal(expected, price.AfterDiscount.Value);
+        Assert.Equal(expected < 100, price.HasDiscount);
+        if (expected < 100)
+        {
+            Assert.Equal(DiscountType.Fixed, price.Discount.Type);
+            Assert.Equal(100 - expected, price.Discount.Amount);
+        }
+        else
+        {
+            Assert.Null(price.Discount);
+        }
+    }
+
+    [Theory]
+    [InlineData(DiscountType.Fixed, 10, false, 80)]
+    [InlineData(DiscountType.Fixed, 30, false, 70)]
+    [InlineData(DiscountType.Percentage, 0.1, false, 80)]
+    [InlineData(DiscountType.Percentage, 0.3, false, 70)]
+    [InlineData(DiscountType.Percentage, 0.1, true, 90)]
+    public async Task ProductDiscount_EventSeesAndCanRemoveNativeCandidateBeforeBestSelection(
+        DiscountType customerType, decimal customerAmount, bool removeNative, decimal expected)
+    {
+        using var fixture = new Fixture();
+        var product = fixture.Product("100", "80");
+        var customer = new Mock<IProductDiscount>();
+        customer.SetupGet(x => x.Key).Returns(Guid.NewGuid());
+        customer.SetupGet(x => x.Type).Returns(customerType);
+        customer.SetupGet(x => x.Amount).Returns(customerAmount);
+        customer.SetupGet(x => x.Constraints).Returns(new Constraints());
+        int calls = 0;
+        Guid nativeKey = Guid.Empty;
+        fixture.Events.AfterApplicableDiscountsAsync += (_, args) =>
+        {
+            calls++;
+            Assert.Equal(product.Path, args.Path);
+            Assert.Equal("Web", args.StoreAlias);
+            Assert.Equal(100m, args.Price);
+            var native = Assert.Single(args.ApplicableDiscounts);
+            Assert.Equal(DiscountType.Fixed, native.Type);
+            Assert.Equal(20m, native.Amount);
+            nativeKey = native.Key;
+            if (removeNative) args.ApplicableDiscounts.Remove(native);
+            args.ApplicableDiscounts.Add(customer.Object);
+            return Task.CompletedTask;
+        };
+
+        var price = Assert.Single(product.Prices);
+        var asyncDiscount = await product.ProductDiscountAsync(null, CancellationToken.None, fixture.Store.Currency);
+
+        Assert.Equal(2, calls);
+        Assert.Equal(expected, price.AfterDiscount.Value);
+        Assert.NotNull(asyncDiscount);
+        var expectedKey = expected == 80 ? nativeKey : customer.Object.Key;
+        Assert.Equal(expectedKey, price.Discount.Key);
+        Assert.Equal(expectedKey, asyncDiscount.Key);
+    }
+
+    [Theory]
+    [InlineData(true, 120, 96, 80, 16, 96)]
+    [InlineData(false, 100, 80, 80, 16, 96)]
+    public void Product_PreservesOriginalPriceAndAppliesTargetInStoreVatBasis(
+        bool vatIncluded, decimal original, decimal target, decimal net, decimal vat, decimal gross)
+    {
+        using var fixture = new Fixture(vatIncluded, 0.2m);
+        var product = fixture.Product(original.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            target.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        var price = Assert.Single(product.Prices);
+
+        Assert.Equal(original, product.OriginalPrice.OriginalValue);
+        Assert.False(product.OriginalPrice.HasDiscount);
+        Assert.Equal(original, price.OriginalValue);
+        Assert.Equal(original, price.BeforeDiscount.Value);
+        Assert.Equal(target, price.AfterDiscount.Value);
+        Assert.Equal(net, price.WithoutVat.Value);
+        Assert.Equal(vat, price.Vat.Value);
+        Assert.Equal(gross, price.WithVat.Value);
+    }
+
+    [Theory]
+    [InlineData("", "50", 100, 80)]
+    [InlineData("0", "50", 100, 80)]
+    [InlineData("120", "90", 120, 90)]
+    [InlineData("120", "", 120, 120)]
+    public async Task Variant_InheritsParentTargetOnlyWhenBasePriceIsInherited(
+        string ownPrice, string ownTarget, decimal original, decimal expected)
+    {
+        using var fixture = new Fixture();
+        var product = fixture.Product("100", "80");
+        var variant = new TestVariant(Content(ownPrice, ownTarget, "-1,100,200,300,400"), fixture.Store, product);
+
+        var price = Assert.Single(variant.Prices);
+        var discount = await variant.ProductDiscountAsync(original.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            CancellationToken.None, fixture.Store.Currency);
+
+        Assert.Equal(original, price.OriginalValue);
+        Assert.Equal(expected, price.AfterDiscount.Value);
+        Assert.Equal(expected < original, price.HasDiscount);
+        Assert.Equal(price.Discount?.Amount, discount?.Amount);
+    }
+
+    [Fact]
+    public void Variant_InheritsMissingCurrencyWithoutOverwritingOwnCurrencyTarget()
+    {
+        using var fixture = new Fixture();
+        var product = fixture.Product("[{\"Currency\":\"en-US\",\"Price\":100},{\"Currency\":\"en-GB\",\"Price\":200}]",
+            "[{\"Currency\":\"en-US\",\"Price\":80},{\"Currency\":\"en-GB\",\"Price\":150}]");
+        var variant = new TestVariant(Content("[{\"Currency\":\"en-US\",\"Price\":120}]",
+            "[{\"Currency\":\"en-US\",\"Price\":90},{\"Currency\":\"en-GB\",\"Price\":50}]",
+            "-1,100,200,300,400"), fixture.Store, product);
+
+        var prices = variant.Prices;
+
+        Assert.Equal(90m, Assert.Single(prices, x => x.Currency.CurrencyValue == "en-US").AfterDiscount.Value);
+        var inherited = Assert.Single(prices, x => x.Currency.CurrencyValue == "en-GB");
+        Assert.Equal(200m, inherited.OriginalValue);
+        Assert.Equal(150m, inherited.AfterDiscount.Value);
+    }
+
+    [Fact]
+    public void Prices_CacheTracksOwnAndInheritedTargetChanges()
+    {
+        using var fixture = new Fixture();
+        var product = fixture.Product("100", "80");
+        var inherited = new TestVariant(Content("0", "50", "-1,100,200,300,400"), fixture.Store, product);
+        var owned = new TestVariant(Content("120", "90", "-1,100,200,300,401"), fixture.Store, product);
+        var productPrices = product.Prices;
+        var inheritedPrices = inherited.Prices;
+        var ownedPrices = owned.Prices;
+        Assert.Same(productPrices, product.Prices);
+        Assert.Same(inheritedPrices, inherited.Prices);
+        Assert.Same(ownedPrices, owned.Prices);
+        Assert.Equal(80m, Assert.Single(inheritedPrices).AfterDiscount.Value);
+
+        product.SetTarget("70");
+        owned.SetTarget("85");
+
+        Assert.NotSame(productPrices, product.Prices);
+        Assert.NotSame(inheritedPrices, inherited.Prices);
+        Assert.NotSame(ownedPrices, owned.Prices);
+        Assert.Equal(70m, Assert.Single(product.Prices).AfterDiscount.Value);
+        Assert.Equal(70m, Assert.Single(inherited.Prices).AfterDiscount.Value);
+        Assert.Equal(85m, Assert.Single(owned.Prices).AfterDiscount.Value);
+        Assert.Equal(80m, Assert.Single(productPrices).AfterDiscount.Value);
+    }
+
+    private static UmbracoContent Content(string price, string target, string path = "-1,100,200")
+        => new(new Dictionary<string, string>(), new Dictionary<string, string>
+        {
+            ["id"] = path.Split(',')[^1],
+            ["__Key"] = Guid.NewGuid().ToString(),
+            ["parentID"] = "100",
+            ["parentKey"] = Guid.NewGuid().ToString(),
+            ["level"] = "3",
+            ["nodeName"] = "Regression product",
+            ["__Path"] = path,
+            ["__NodeTypeAlias"] = "ekmProduct",
+            ["sortOrder"] = "0",
+            ["createDate"] = "2024-01-01T00:00:00Z",
+            ["updateDate"] = "2024-01-01T00:00:00Z",
+            ["sku"] = "native-price-test",
+            ["price"] = price,
+            ["ekmDiscountPrice"] = target,
+        });
+
+    private sealed class TestVariant(UmbracoContent content, IStore store, IProduct product) : Variant(content, store)
+    {
+        public override IProduct? Product => product;
+        public void SetTarget(string target) => _properties["ekmDiscountPrice"] = target;
+    }
+
+    private sealed class TestProduct(UmbracoContent content, IStore store) : Product(content, store)
+    {
+        public void SetTarget(string target) => _properties["ekmDiscountPrice"] = target;
+    }
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly ConfigurationScope _configuration;
+        private readonly MemoryCache _memory = new(new MemoryCacheOptions());
+        public DiscountEvents Events { get; } = new();
+        public IStore Store { get; }
+
+        public Fixture(bool vatIncluded = true, decimal vat = 0, bool useSecondCurrency = false)
+        {
+            var usd = new CurrencyModel { CurrencyValue = "en-US", CurrencyFormat = "C" };
+            var gbp = new CurrencyModel { CurrencyValue = "en-GB", CurrencyFormat = "C" };
+            var store = new Mock<IStore>();
+            store.SetupGet(x => x.Alias).Returns("Web");
+            store.SetupGet(x => x.Currency).Returns(useSecondCurrency ? gbp : usd);
+            store.SetupGet(x => x.Currencies).Returns([usd, gbp]);
+            store.SetupGet(x => x.Vat).Returns(vat);
+            store.SetupGet(x => x.VatIncludedInPrice).Returns(vatIncluded);
+            Store = store.Object;
+            var discounts = new Mock<IPerStoreCache<IProductDiscount>>();
+            discounts.SetupGet(x => x.Cache).Returns(new ConcurrentDictionary<string, ConcurrentDictionary<Guid, IProductDiscount>>());
+            var stores = new Mock<IStoreService>();
+            stores.Setup(x => x.GetStoreByAlias("Web")).Returns(Store);
+            stores.Setup(x => x.GetStoreFromCache()).Returns(Store);
+            _configuration = new ConfigurationScope(addServices: services =>
+            {
+                services.AddSingleton<IMemoryCache>(_memory);
+                services.AddSingleton(new ProductDiscountService(discounts.Object, Events));
+                services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+                services.AddSingleton<IStoreService>(stores.Object);
+                services.AddTransient(sp => new Catalog(Mock.Of<ILogger<Catalog>>(),
+                    sp.GetRequiredService<Configuration>(), sp.GetRequiredService<IServiceScopeFactory>(),
+                    Mock.Of<IPerStoreIndexedCache<IProduct>>(), Mock.Of<IPerStoreIndexedCache<ICategory>>(),
+                    discounts.Object, Mock.Of<IPerStoreIndexedCache<IVariant>>(),
+                    Mock.Of<IPerStoreIndexedCache<IVariantGroup>>(), stores.Object,
+                    sp.GetRequiredService<IHttpContextAccessor>(), Mock.Of<IProductFilterService>()));
+            });
+        }
+
+        public TestProduct Product(string price, string target) => new(Content(price, target), Store);
+
+        public void Dispose()
+        {
+            _configuration.Dispose();
+            _memory.Dispose();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -263,6 +263,29 @@ Keys are matched case-insensitively and `PricingContext` is never null (empty wh
 
 `StoreAlias` is supplied when product or variant pricing has a store context; it is null for legacy or cross-store cache operations.
 
+### Product discount prices
+
+Products and variants support an optional **Discount Price** property (`ekmDiscountPrice`), placed below Price and using the same **Ekom Price** datatype. It is a target selling price, not an amount off, and uses the same VAT basis as the normal price.
+
+Ekom converts a valid positive target below the normal price into a fixed-saving product discount. It competes with applicable `ekmProductDiscount` discounts and discounts added by `AfterApplicableDiscountsAsync`; product discounts do not stack. For example, a normal price of 100 and discount price of 85 loses to a 20% product discount, resulting in 80. Original prices and existing order/coupon stacking rules are preserved.
+
+- Missing, empty, zero, negative, invalid, or non-reducing values do not create a discount.
+- The native candidate is present before `AfterApplicableDiscountsAsync`, so existing customer-discount handlers need no changes and may filter it like other candidates.
+- Independently priced variants use their own discount price. A variant inheriting the parent price for a currency also inherits the parent's selected discount.
+- Existing installations receive the missing property during schema initialization. Existing property definitions are preserved; content is not populated or republished.
+
+ERP integrations can sync the property using the normal store/currency price format:
+
+```json
+{
+  "myStore": [
+    { "Currency": "en-US", "Price": 85 }
+  ]
+}
+```
+
+Use the store's configured currency identifiers. Targets in currency arrays require a matching currency; scalar targets apply only to the first configured store currency. Use the structured format for multicurrency integrations. Customer-specific event discounts still require appropriate price-cache partitioning, as described above.
+
 ### Tracking and consent
 
 Ekom tracking supports order-level `Consent` and `Tracking` data for automatic GA4 and Meta purchase dispatch.


### PR DESCRIPTION
## Summary
- Add optional ekmDiscountPrice on products and variants below Price using the same Ekom Price datatype, including an idempotent existing-install ensure step.
- Convert target selling prices into fixed-saving candidates before AfterApplicableDiscountsAsync so content discounts and customer-discount handlers compete through existing best-discount selection.
- Preserve original prices, support store/currency matching and variant inheritance, update cache inputs and selected order discount metadata.
- Document ERP usage and add 34 regression cases.

## Test plan
- [x] Native discount, discount-event and price-cache tests: 45/45 passed.
- [x] Existing price tests separately: 254/254 passed.
- [x] Existing discount calculation tests separately: 10/10 passed.
- [x] Core and Umbraco U10/U17/U18 builds succeeded.
- [x] git diff --check passed.
- [ ] Verify field placement and repeat-startup behavior in a live Umbraco installation.
- [ ] Verify persisted order round trips in the host application.

## Verification notes
Two tests failed in a broader combined run but passed in separate processes, suggesting shared-configuration interference; a clean full-suite result is not established. Builds report dependency/analyzer warnings. Verification above preceded rebasing onto latest Ekom; the only rebase conflict was the changelog, resolved by preserving both entries.

This branch contains only the native discount-price feature; the previously inherited Algolia commit was excluded when rebasing onto Ekom.