### PR TITLE
fix(release): restore U17 and U18 package publishing

### DIFF
--- a/.github/workflows/publish-ekom.yml
+++ b/.github/workflows/publish-ekom.yml
@@ -38,36 +38,48 @@ jobs:
       - name: Restore U10 packages
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           dotnet restore "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
           dotnet restore "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
 
       - name: Build U10 packages (Release)
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           dotnet build "Ekom/Ekom.Umbraco/Ekom.U10/Ekom.U10.csproj" -c Release --no-restore -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
           dotnet build "Ekom/Ekom.Web/Ekom.Web/Ekom.Web.csproj" -c Release --no-restore -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0
 
       - name: Restore U17 packages
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           dotnet restore "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
           dotnet restore "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
 
       - name: Build U17 packages (Release)
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           dotnet build "Ekom/Ekom.Umbraco/Ekom.U17/Ekom.U17.csproj" -c Release --no-restore -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
           dotnet build "Ekom/Ekom.Web/Ekom.Web.U17/Ekom.Web.U17.csproj" -c Release --no-restore -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
 
       - name: Restore U18 packages
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           dotnet restore "Ekom/Ekom.Umbraco/Ekom.U18/Ekom.U18.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
           dotnet restore "Ekom/Ekom.Web/Ekom.Web.U18/Ekom.Web.U18.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
 
       - name: Build U18 packages (Release)
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           dotnet build "Ekom/Ekom.Umbraco/Ekom.U18/Ekom.U18.csproj" -c Release --no-restore -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
           dotnet build "Ekom/Ekom.Web/Ekom.Web.U18/Ekom.Web.U18.csproj" -c Release --no-restore -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
 
@@ -75,6 +87,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
 
           function Get-SemVerFromTag([string] $tag) {
             if ($tag -match 'v(?<ver>\d+\.\d+\.\d+(?:-[0-9A-Za-z\.-]+)?)$') { return $Matches['ver'] }
@@ -108,6 +121,24 @@ jobs:
           dotnet restore "Ekom/Ekom.Web/Ekom.Web.U18/Ekom.Web.U18.csproj" -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
           dotnet pack "Ekom/Ekom.Umbraco/Ekom.U18/Ekom.U18.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
           dotnet pack "Ekom/Ekom.Web/Ekom.Web.U18/Ekom.Web.U18.csproj" -c Release --no-build -o artifacts -p:PackageVersion=$version -p:TargetFramework=net10.0 -p:TargetFrameworks=net10.0
+
+          $expectedPackages = @(
+            "Ekom.Common.$version.nupkg"
+            "Ekom.Core.$version.nupkg"
+            "Ekom.AspNetCore.$version.nupkg"
+            "Ekom.U10.$version.nupkg"
+            "Ekom.Web.$version.nupkg"
+            "Ekom.U17.$version.nupkg"
+            "Ekom.Web.U17.$version.nupkg"
+            "Ekom.U18.$version.nupkg"
+            "Ekom.Web.U18.$version.nupkg"
+          )
+          $missingPackages = $expectedPackages | Where-Object {
+            -not (Test-Path (Join-Path "artifacts" $_) -PathType Leaf)
+          }
+          if ($missingPackages) {
+            throw "Missing expected packages: $($missingPackages -join ', ')"
+          }
 
           Get-ChildItem -Path artifacts -Filter *.nupkg -File | Format-Table Name,Length
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EnsureNodesExist.cs
@@ -1729,6 +1729,8 @@ class EnsureNodesExist : IAsyncComponent
         }
 
         SaveContentType(contentType);
+    }
+
     private void EnsureDiscountPriceProperties()
     {
         foreach (var alias in new[] { "ekmProduct", "ekmProductVariant" })


### PR DESCRIPTION
## Summary
- restore the missing method-closing brace that prevented the shared U17 source from compiling for U17 and U18
- make multi-command PowerShell restore, build, and pack steps stop on native command failures
- require all nine expected Ekom packages to exist before authenticating and pushing to NuGet

This addresses the partial `Ekom-v0.2.268` publication reported by run https://github.com/Vettvangur/Ekom/actions/runs/34256414652, where failed U17/U18 builds were masked and their packages were omitted.

## Test Plan
- parsed `.github/workflows/publish-ekom.yml` as YAML
- built `Ekom.U17`, `Ekom.Web.U17`, `Ekom.U18`, and `Ekom.Web.U18` in Release for `net10.0`
- packed all four U17/U18 packages with `--no-build` and confirmed their `.nupkg` outputs
- ran `git diff --check`
