### PR TITLE
feat(warehouse): optimize stock cache and mutations

### DIFF
--- a/Ekom/CHANGELOG.md
+++ b/Ekom/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **discounts:** add native product and variant `ekmDiscountPrice` support using the Ekom Price datatype, competing with content and event-added discounts while preserving original prices.
+* **warehouse:** add cache-only balance reads, changed-only writes, explicit clearing, partial-success bulk updates, and SKU-level warehouse results.
 
 ## [0.2.269](https://github.com/Vettvangur/Ekom/compare/Ekom-v0.2.268...Ekom-v0.2.269) (2026-09-08)
 

--- a/Ekom/Ekom.Core/Ekom.AspNetCore/Registrations.cs
+++ b/Ekom/Ekom.Core/Ekom.AspNetCore/Registrations.cs
@@ -56,6 +56,7 @@ static class Registrations
         services.AddSingleton<IPerStoreCache<IShippingProvider>, ShippingProviderCache>();
         services.AddSingleton<IBaseCache<StockData>, StockCache>();
         services.AddSingleton<IPerStoreCache<StockData>, StockPerStoreCache>();
+        services.AddSingleton<WarehouseStockCache>();
 
         // The following database based caches are not strictly related to the preceding ones
         services.AddSingleton<ICouponCache, CouponCache>();
@@ -106,6 +107,7 @@ static class Registrations
         services.AddTransient<StockRepository>();
         services.AddTransient<DiscountStockRepository>();
         services.AddTransient<WarehouseStockRepository>();
+        services.AddTransient<IWarehouseStockRepository>(sp => sp.GetRequiredService<WarehouseStockRepository>());
 
         services.AddTransient<ManagerRepository>();
         services.AddTransient<OrderRepository>();
@@ -208,8 +210,9 @@ static class Registrations
         );
         services.AddTransient<Warehouse>(f =>
             new Warehouse(
-                f.GetRequiredService<WarehouseStockRepository>(),
-                f.GetRequiredService<IWarehouseDefinitionService>()
+                f.GetRequiredService<IWarehouseStockRepository>(),
+                f.GetRequiredService<IWarehouseDefinitionService>(),
+                f.GetRequiredService<WarehouseStockCache>()
             )
         );
         services.AddTransient<Ekom.API.Store>(f =>

--- a/Ekom/Ekom.Core/Ekom/API/Warehouse.cs
+++ b/Ekom/Ekom.Core/Ekom/API/Warehouse.cs
@@ -1,7 +1,9 @@
+using Ekom.Cache;
 using Ekom.Models;
 using Ekom.Repositories;
 using Ekom.Services;
 using Microsoft.Extensions.DependencyInjection;
+using System.Runtime.ExceptionServices;
 
 namespace Ekom.API;
 
@@ -15,15 +17,18 @@ public sealed class Warehouse
     /// </summary>
     public static Warehouse Instance => Configuration.Resolver.GetRequiredService<Warehouse>();
 
-    private readonly WarehouseStockRepository _warehouseStockRepository;
+    private readonly IWarehouseStockRepository _warehouseStockRepository;
     private readonly IWarehouseDefinitionService _warehouseDefinitionService;
+    private readonly WarehouseStockCache _warehouseStockCache;
 
     internal Warehouse(
-        WarehouseStockRepository warehouseStockRepository,
-        IWarehouseDefinitionService warehouseDefinitionService)
+        IWarehouseStockRepository warehouseStockRepository,
+        IWarehouseDefinitionService warehouseDefinitionService,
+        WarehouseStockCache warehouseStockCache)
     {
         _warehouseStockRepository = warehouseStockRepository;
         _warehouseDefinitionService = warehouseDefinitionService;
+        _warehouseStockCache = warehouseStockCache;
     }
 
     public Task<IReadOnlyList<WarehouseDefinition>> GetWarehousesAsync(string storeAlias, CancellationToken ct = default)
@@ -40,15 +45,17 @@ public sealed class Warehouse
         IEnumerable<string> skus,
         CancellationToken ct = default)
     {
+        await Task.CompletedTask.ConfigureAwait(false);
         string normalizedStoreAlias = NormalizeStoreAlias(storeAlias);
         ArgumentNullException.ThrowIfNull(skus);
+        ct.ThrowIfCancellationRequested();
+        _warehouseStockCache.EnsureReady();
 
-        string[] normalizedSkus = skus
+        HashSet<string> normalizedSkus = skus
             .Select(NormalizeSku)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+            .ToHashSet(StringComparer.Ordinal);
 
-        if (normalizedSkus.Length == 0)
+        if (normalizedSkus.Count == 0)
         {
             return Array.Empty<WarehouseStockBalance>();
         }
@@ -64,87 +71,110 @@ public sealed class Warehouse
             return Array.Empty<WarehouseStockBalance>();
         }
 
-        List<WarehouseStockData> stockData = await _warehouseStockRepository
-            .GetAsync(normalizedStoreAlias, normalizedSkus, ct)
-            .ConfigureAwait(false);
-
-        return stockData
+        IReadOnlyList<WarehouseStockBalance> balances = _warehouseStockCache
+            .Get(normalizedStoreAlias, normalizedSkus)
             .Where(stock => warehouseKeys.Contains(stock.WarehouseKey))
             .Select(Map)
             .ToList();
+
+        return balances;
     }
 
     /// <summary>
-    /// Gets a warehouse balance for a SKU.
+    /// Gets a warehouse balance for a SKU from the in-memory cache.
     /// </summary>
-    /// <param name="storeAlias">Store alias that owns the balance.</param>
-    /// <param name="warehouseKey">Warehouse identifier.</param>
-    /// <param name="sku">SKU to retrieve.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The balance when one exists; otherwise, <see langword="null"/>.</returns>
     public async Task<WarehouseStockBalance?> GetAsync(
         string storeAlias,
         Guid warehouseKey,
         string sku,
         CancellationToken ct = default)
     {
+        await Task.CompletedTask.ConfigureAwait(false);
         string normalizedStoreAlias = NormalizeStoreAlias(storeAlias);
         ValidateWarehouseKey(warehouseKey);
         EnsureWarehouseExists(normalizedStoreAlias, warehouseKey);
         string normalizedSku = NormalizeSku(sku);
+        ct.ThrowIfCancellationRequested();
 
-        WarehouseStockData? stockData = await _warehouseStockRepository
-            .GetAsync(normalizedStoreAlias, warehouseKey, normalizedSku, ct)
-            .ConfigureAwait(false);
-
+        WarehouseStockData? stockData = _warehouseStockCache.Get(normalizedStoreAlias, warehouseKey, normalizedSku);
         return stockData is null ? null : Map(stockData);
     }
 
     /// <summary>
-    /// Gets warehouse balances for SKUs.
+    /// Gets warehouse balances for SKUs from the in-memory cache.
     /// </summary>
-    /// <param name="storeAlias">Store alias that owns the balances.</param>
-    /// <param name="warehouseKey">Warehouse identifier.</param>
-    /// <param name="skus">SKUs to retrieve.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Balances for SKUs with persisted records.</returns>
     public async Task<IReadOnlyList<WarehouseStockBalance>> GetAsync(
         string storeAlias,
         Guid warehouseKey,
         IEnumerable<string> skus,
         CancellationToken ct = default)
     {
+        await Task.CompletedTask.ConfigureAwait(false);
         string normalizedStoreAlias = NormalizeStoreAlias(storeAlias);
         ValidateWarehouseKey(warehouseKey);
         EnsureWarehouseExists(normalizedStoreAlias, warehouseKey);
         ArgumentNullException.ThrowIfNull(skus);
+        ct.ThrowIfCancellationRequested();
+        _warehouseStockCache.EnsureReady();
 
-        string[] normalizedSkus = skus
+        HashSet<string> normalizedSkus = skus
             .Select(NormalizeSku)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+            .ToHashSet(StringComparer.Ordinal);
 
-        if (normalizedSkus.Length == 0)
+        if (normalizedSkus.Count == 0)
         {
             return Array.Empty<WarehouseStockBalance>();
         }
 
-        List<WarehouseStockData> stockData = await _warehouseStockRepository
-            .GetAsync(normalizedStoreAlias, warehouseKey, normalizedSkus, ct)
-            .ConfigureAwait(false);
+        IReadOnlyList<WarehouseStockBalance> balances = _warehouseStockCache
+            .Get(normalizedStoreAlias, normalizedSkus, warehouseKey)
+            .Select(Map)
+            .ToList();
 
-        return stockData.Select(Map).ToList();
+        return balances;
     }
 
     /// <summary>
-    /// Sets a warehouse balance for a SKU, creating it when it does not exist.
+    /// Gets visible warehouses combined with the cached balance for one SKU.
     /// </summary>
-    /// <param name="storeAlias">Store alias that owns the balance.</param>
-    /// <param name="warehouseKey">Warehouse identifier.</param>
-    /// <param name="sku">SKU to set.</param>
-    /// <param name="balance">Non-negative warehouse balance.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The set balance.</returns>
+    public async Task<IReadOnlyList<WarehouseStockLevel>> GetForSkuAsync(
+        string storeAlias,
+        string sku,
+        CancellationToken ct = default)
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        string normalizedStoreAlias = NormalizeStoreAlias(storeAlias);
+        string normalizedSku = NormalizeSku(sku);
+        ct.ThrowIfCancellationRequested();
+        _warehouseStockCache.EnsureReady();
+
+        IReadOnlyList<WarehouseStockLevel> levels = _warehouseDefinitionService
+            .GetPublishedWarehouses(normalizedStoreAlias)
+            .Where(warehouse => warehouse.Visible)
+            .OrderBy(warehouse => warehouse.SortOrder)
+            .Select(warehouse =>
+            {
+                WarehouseStockData? stock = _warehouseStockCache.Get(normalizedStoreAlias, warehouse.Key, normalizedSku);
+                return new WarehouseStockLevel
+                {
+                    StoreAlias = normalizedStoreAlias,
+                    WarehouseKey = warehouse.Key,
+                    Code = warehouse.Code,
+                    Name = warehouse.Name,
+                    SortOrder = warehouse.SortOrder,
+                    Sku = normalizedSku,
+                    Balance = stock?.Balance,
+                    UpdateDate = stock?.UpdateDate,
+                };
+            })
+            .ToList();
+
+        return levels;
+    }
+
+    /// <summary>
+    /// Sets a warehouse balance, skipping persistence when the value is unchanged.
+    /// </summary>
     public async Task<WarehouseStockBalance> SetAsync(
         string storeAlias,
         Guid warehouseKey,
@@ -152,71 +182,337 @@ public sealed class Warehouse
         decimal balance,
         CancellationToken ct = default)
     {
-        string normalizedStoreAlias = NormalizeStoreAlias(storeAlias);
-        ValidateWarehouseKey(warehouseKey);
-        EnsureWarehouseExists(normalizedStoreAlias, warehouseKey);
-        string normalizedSku = NormalizeSku(sku);
-        ValidateBalance(balance);
+        NormalizedMutation mutation = NormalizeMutation(new WarehouseStockMutationRequest
+        {
+            StoreAlias = storeAlias,
+            WarehouseKey = warehouseKey,
+            Sku = sku,
+            Operation = WarehouseStockMutationOperation.Set,
+            Balance = balance,
+        }, 0);
 
-        WarehouseStockData stockData = await _warehouseStockRepository
-            .SetAsync(normalizedStoreAlias, warehouseKey, normalizedSku, balance, ct)
-            .ConfigureAwait(false);
+        WarehouseStockBatchResult result = await ApplyNormalizedAsync([mutation], 1, null, ct).ConfigureAwait(false);
+        WarehouseStockMutationResult entry = result.Entries[0];
+        ThrowIfFailed(entry);
 
-        return Map(stockData);
+        return new WarehouseStockBalance
+        {
+            StoreAlias = entry.StoreAlias,
+            WarehouseKey = entry.WarehouseKey,
+            Sku = entry.Sku,
+            Balance = entry.Balance!.Value,
+            UpdateDate = entry.UpdateDate!.Value,
+        };
     }
 
     /// <summary>
-    /// Sets warehouse balances, creating records when they do not exist.
+    /// Sets warehouse balances for one warehouse.
     /// </summary>
-    /// <param name="storeAlias">Store alias that owns the balances.</param>
-    /// <param name="warehouseKey">Warehouse identifier.</param>
-    /// <param name="balances">SKU balances to set.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The set balances.</returns>
     public async Task<IReadOnlyList<WarehouseStockBalance>> SetAsync(
         string storeAlias,
         Guid warehouseKey,
         IEnumerable<WarehouseStockBalanceRequest> balances,
         CancellationToken ct = default)
     {
-        string normalizedStoreAlias = NormalizeStoreAlias(storeAlias);
-        ValidateWarehouseKey(warehouseKey);
-        EnsureWarehouseExists(normalizedStoreAlias, warehouseKey);
         ArgumentNullException.ThrowIfNull(balances);
-
-        var normalizedBalances = new List<WarehouseStockBalanceRequest>();
+        var mutations = new List<NormalizedMutation>();
         var skus = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (WarehouseStockBalanceRequest balance in balances)
         {
             ArgumentNullException.ThrowIfNull(balance);
+            NormalizedMutation mutation = NormalizeMutation(new WarehouseStockMutationRequest
+            {
+                StoreAlias = storeAlias,
+                WarehouseKey = warehouseKey,
+                Sku = balance.Sku,
+                Operation = WarehouseStockMutationOperation.Set,
+                Balance = balance.Balance,
+            }, mutations.Count);
 
-            string normalizedSku = NormalizeSku(balance.Sku);
-            ValidateBalance(balance.Balance);
-
-            if (!skus.Add(normalizedSku))
+            if (!skus.Add(mutation.Sku))
             {
                 throw new ArgumentException("Balances must not contain duplicate SKUs after normalization.", nameof(balances));
             }
 
-            normalizedBalances.Add(new WarehouseStockBalanceRequest
-            {
-                Sku = normalizedSku,
-                Balance = balance.Balance,
-            });
+            mutations.Add(mutation);
         }
 
-        var results = new List<WarehouseStockBalance>(normalizedBalances.Count);
-        foreach (WarehouseStockBalanceRequest balance in normalizedBalances)
+        var entries = new List<WarehouseStockMutationResult>(mutations.Count);
+        foreach (NormalizedMutation mutation in mutations)
         {
-            WarehouseStockData stockData = await _warehouseStockRepository
-                .SetAsync(normalizedStoreAlias, warehouseKey, balance.Sku, balance.Balance, ct)
+            WarehouseStockBatchResult result = await ApplyNormalizedAsync(
+                [mutation with { Index = 0 }],
+                1,
+                null,
+                ct).ConfigureAwait(false);
+            WarehouseStockMutationResult entry = result.Entries[0];
+            ThrowIfFailed(entry);
+            entries.Add(entry);
+        }
+
+        return entries.Select(entry => new WarehouseStockBalance
+        {
+            StoreAlias = entry.StoreAlias,
+            WarehouseKey = entry.WarehouseKey,
+            Sku = entry.Sku,
+            Balance = entry.Balance!.Value,
+            UpdateDate = entry.UpdateDate!.Value,
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Clears a persisted warehouse balance. An already-unset balance is unchanged.
+    /// </summary>
+    /// <returns><see langword="true"/> when a persisted record was removed.</returns>
+    public async Task<bool> ClearAsync(
+        string storeAlias,
+        Guid warehouseKey,
+        string sku,
+        CancellationToken ct = default)
+    {
+        NormalizedMutation mutation = NormalizeMutation(new WarehouseStockMutationRequest
+        {
+            StoreAlias = storeAlias,
+            WarehouseKey = warehouseKey,
+            Sku = sku,
+            Operation = WarehouseStockMutationOperation.Clear,
+        }, 0);
+
+        WarehouseStockBatchResult result = await ApplyNormalizedAsync([mutation], 1, null, ct).ConfigureAwait(false);
+        WarehouseStockMutationResult entry = result.Entries[0];
+        ThrowIfFailed(entry);
+        return entry.Status == WarehouseStockMutationStatus.Cleared;
+    }
+
+    /// <summary>
+    /// Applies warehouse mutations across stores, warehouses, and SKUs with per-entry failures.
+    /// </summary>
+    public async Task<WarehouseStockBatchResult> UpdateAsync(
+        IEnumerable<WarehouseStockMutationRequest> mutations,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(mutations);
+        List<WarehouseStockMutationRequest> requests = mutations.ToList();
+        var normalized = new List<NormalizedMutation>(requests.Count);
+        var initialResults = new WarehouseStockMutationResult?[requests.Count];
+        var identities = new HashSet<WarehouseStockIdentity>();
+
+        for (int index = 0; index < requests.Count; index++)
+        {
+            WarehouseStockMutationRequest? request = requests[index];
+            try
+            {
+                ArgumentNullException.ThrowIfNull(request);
+                NormalizedMutation mutation = NormalizeMutation(request, index);
+                var identity = new WarehouseStockIdentity(mutation.StoreAlias.ToUpperInvariant(), mutation.WarehouseKey, mutation.Sku);
+                if (!identities.Add(identity))
+                {
+                    throw new ArgumentException("The batch contains a duplicate warehouse stock identity after normalization.", nameof(mutations));
+                }
+
+                normalized.Add(mutation);
+            }
+            catch (ArgumentException ex)
+            {
+                initialResults[index] = Failure(index, request, ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                initialResults[index] = Failure(index, request, ex);
+            }
+        }
+
+        return await ApplyNormalizedAsync(normalized, requests.Count, initialResults, ct).ConfigureAwait(false);
+    }
+
+    private async Task<WarehouseStockBatchResult> ApplyNormalizedAsync(
+        IReadOnlyList<NormalizedMutation> mutations,
+        int resultCount,
+        WarehouseStockMutationResult?[]? initialResults,
+        CancellationToken ct)
+    {
+        var results = initialResults ?? new WarehouseStockMutationResult?[resultCount];
+        await _warehouseStockCache.MutationLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            _warehouseStockCache.EnsureReady();
+            var persistenceRequests = new List<WarehouseStockPersistenceRequest>();
+            Dictionary<int, NormalizedMutation> mutationsByIndex = mutations.ToDictionary(mutation => mutation.Index);
+
+            foreach (NormalizedMutation mutation in mutations)
+            {
+                WarehouseStockData? existing = _warehouseStockCache.Get(
+                    mutation.StoreAlias,
+                    mutation.WarehouseKey,
+                    mutation.Sku);
+
+                if (mutation.Operation == WarehouseStockMutationOperation.Set && existing?.Balance == mutation.Balance)
+                {
+                    results[mutation.Index] = Success(mutation, WarehouseStockMutationStatus.Unchanged, existing);
+                    continue;
+                }
+
+                if (mutation.Operation == WarehouseStockMutationOperation.Clear && existing == null)
+                {
+                    results[mutation.Index] = Success(mutation, WarehouseStockMutationStatus.Unchanged, null);
+                    continue;
+                }
+
+                persistenceRequests.Add(new WarehouseStockPersistenceRequest(
+                    mutation.Index,
+                    existing?.StoreAlias ?? mutation.StoreAlias.ToUpperInvariant(),
+                    mutation.WarehouseKey,
+                    existing?.Sku ?? mutation.Sku,
+                    mutation.Operation,
+                    mutation.Balance,
+                    existing));
+            }
+
+            if (persistenceRequests.Count == 0)
+            {
+                return CreateBatchResult(results);
+            }
+
+            WarehouseStockPersistenceBatchResult persistence = await _warehouseStockRepository
+                .ApplyAsync(persistenceRequests, ct)
                 .ConfigureAwait(false);
 
-            results.Add(Map(stockData));
+            foreach (WarehouseStockPersistenceResult persisted in persistence.Results)
+            {
+                NormalizedMutation mutation = mutationsByIndex[persisted.Request.Index];
+                if (persisted.Exception != null)
+                {
+                    results[mutation.Index] = Failure(mutation, persisted.Exception);
+                    continue;
+                }
+
+                if (mutation.Operation == WarehouseStockMutationOperation.Clear)
+                {
+                    _warehouseStockCache.Remove(mutation.StoreAlias, mutation.WarehouseKey, mutation.Sku);
+                    results[mutation.Index] = Success(mutation, WarehouseStockMutationStatus.Cleared, null);
+                    continue;
+                }
+
+                _warehouseStockCache.AddOrUpdate(persisted.Data!);
+                WarehouseStockMutationStatus status = persisted.Request.ExistingData == null
+                    ? WarehouseStockMutationStatus.Inserted
+                    : WarehouseStockMutationStatus.Updated;
+                results[mutation.Index] = Success(mutation, status, persisted.Data);
+            }
+
+            if (persistence.WasCanceled)
+            {
+                ct.ThrowIfCancellationRequested();
+                throw new OperationCanceledException(ct);
+            }
+        }
+        finally
+        {
+            _warehouseStockCache.MutationLock.Release();
         }
 
-        return results;
+        return CreateBatchResult(results);
+    }
+
+    private static WarehouseStockBatchResult CreateBatchResult(WarehouseStockMutationResult?[] results)
+    {
+        return new WarehouseStockBatchResult
+        {
+            Entries = results
+                .Select(result => result ?? throw new InvalidOperationException("Warehouse mutation did not produce a result."))
+                .ToList(),
+        };
+    }
+
+    private NormalizedMutation NormalizeMutation(WarehouseStockMutationRequest request, int index)
+    {
+        string storeAlias = NormalizeStoreAlias(request.StoreAlias);
+        ValidateWarehouseKey(request.WarehouseKey);
+        EnsureWarehouseExists(storeAlias, request.WarehouseKey);
+        string sku = NormalizeSku(request.Sku);
+
+        if (!Enum.IsDefined(request.Operation))
+        {
+            throw new ArgumentOutOfRangeException(nameof(request.Operation));
+        }
+
+        if (request.Operation == WarehouseStockMutationOperation.Set)
+        {
+            if (!request.Balance.HasValue)
+            {
+                throw new ArgumentException("A balance is required for a set operation.", nameof(request));
+            }
+
+            ValidateBalance(request.Balance.Value);
+        }
+
+        return new NormalizedMutation(index, storeAlias, request.WarehouseKey, sku, request.Operation, request.Balance);
+    }
+
+    private static WarehouseStockMutationResult Success(
+        NormalizedMutation mutation,
+        WarehouseStockMutationStatus status,
+        WarehouseStockData? data)
+    {
+        return new WarehouseStockMutationResult
+        {
+            Index = mutation.Index,
+            StoreAlias = mutation.StoreAlias,
+            WarehouseKey = mutation.WarehouseKey,
+            Sku = mutation.Sku,
+            Status = status,
+            Balance = data?.Balance,
+            UpdateDate = data?.UpdateDate,
+        };
+    }
+
+    private static WarehouseStockMutationResult Failure(NormalizedMutation mutation, Exception exception)
+    {
+        return new WarehouseStockMutationResult
+        {
+            Index = mutation.Index,
+            StoreAlias = mutation.StoreAlias,
+            WarehouseKey = mutation.WarehouseKey,
+            Sku = mutation.Sku,
+            Status = WarehouseStockMutationStatus.Failed,
+            Balance = mutation.Balance,
+            Error = exception.Message,
+            Exception = exception,
+        };
+    }
+
+    private static WarehouseStockMutationResult Failure(
+        int index,
+        WarehouseStockMutationRequest? request,
+        Exception exception)
+    {
+        return new WarehouseStockMutationResult
+        {
+            Index = index,
+            StoreAlias = request?.StoreAlias ?? string.Empty,
+            WarehouseKey = request?.WarehouseKey ?? Guid.Empty,
+            Sku = request?.Sku ?? string.Empty,
+            Status = WarehouseStockMutationStatus.Failed,
+            Balance = request?.Balance,
+            Error = exception.Message,
+            Exception = exception,
+        };
+    }
+
+    private static void ThrowIfFailed(WarehouseStockMutationResult result)
+    {
+        if (result.Status != WarehouseStockMutationStatus.Failed)
+        {
+            return;
+        }
+
+        if (result.Exception != null)
+        {
+            ExceptionDispatchInfo.Capture(result.Exception).Throw();
+        }
+
+        throw new InvalidOperationException(result.Error ?? "Warehouse stock update failed.");
     }
 
     private static string NormalizeStoreAlias(string storeAlias)
@@ -274,4 +570,14 @@ public sealed class Warehouse
             UpdateDate = stockData.UpdateDate,
         };
     }
+
+    private sealed record NormalizedMutation(
+        int Index,
+        string StoreAlias,
+        Guid WarehouseKey,
+        string Sku,
+        WarehouseStockMutationOperation Operation,
+        decimal? Balance);
+
+    private readonly record struct WarehouseStockIdentity(string StoreAlias, Guid WarehouseKey, string Sku);
 }

--- a/Ekom/Ekom.Core/Ekom/Cache/WarehouseStockCache.cs
+++ b/Ekom/Ekom.Core/Ekom/Cache/WarehouseStockCache.cs
@@ -1,0 +1,117 @@
+using Ekom.Models;
+using Ekom.Repositories;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Ekom.Cache;
+
+internal sealed class WarehouseStockCache
+{
+    private readonly IWarehouseStockRepository _repository;
+    private readonly ILogger<WarehouseStockCache> _logger;
+    private ConcurrentDictionary<WarehouseStockCacheKey, WarehouseStockData> _cache = new();
+    private bool _isReady;
+
+    public WarehouseStockCache(
+        IWarehouseStockRepository repository,
+        ILogger<WarehouseStockCache> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    internal SemaphoreSlim MutationLock { get; } = new(1, 1);
+
+    public void FillCache()
+    {
+        MutationLock.Wait();
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            _logger.LogInformation("Starting to fill warehouse stock cache...");
+
+            List<WarehouseStockData> stock = _repository.GetAllAsync().GetAwaiter().GetResult();
+            var nextCache = new ConcurrentDictionary<WarehouseStockCacheKey, WarehouseStockData>();
+            foreach (WarehouseStockData item in stock)
+            {
+                WarehouseStockCacheKey key = WarehouseStockCacheKey.Create(item.StoreAlias, item.WarehouseKey, item.Sku);
+                nextCache.AddOrUpdate(
+                    key,
+                    item,
+                    (_, current) => current.UpdateDate >= item.UpdateDate ? current : item);
+            }
+
+            if (nextCache.Count != stock.Count)
+            {
+                _logger.LogWarning(
+                    "Warehouse stock persistence contained {DuplicateCount} duplicate normalized identities; the newest balances were cached.",
+                    stock.Count - nextCache.Count);
+            }
+
+            Interlocked.Exchange(ref _cache, nextCache);
+            Volatile.Write(ref _isReady, true);
+
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Finished filling warehouse stock cache with {Count} items. Time it took to fill: {Elapsed}",
+                nextCache.Count,
+                stopwatch.Elapsed);
+        }
+        finally
+        {
+            MutationLock.Release();
+        }
+    }
+
+    internal WarehouseStockData? Get(string storeAlias, Guid warehouseKey, string sku)
+    {
+        EnsureReady();
+        _cache.TryGetValue(WarehouseStockCacheKey.Create(storeAlias, warehouseKey, sku), out WarehouseStockData? stock);
+        return stock;
+    }
+
+    internal IReadOnlyList<WarehouseStockData> Get(
+        string storeAlias,
+        IReadOnlySet<string> skus,
+        Guid? warehouseKey = null)
+    {
+        EnsureReady();
+        string normalizedStoreAlias = WarehouseStockCacheKey.Normalize(storeAlias);
+
+        return _cache
+            .Where(item => item.Key.StoreAlias == normalizedStoreAlias
+                && (!warehouseKey.HasValue || item.Key.WarehouseKey == warehouseKey.Value)
+                && skus.Contains(item.Key.Sku))
+            .Select(item => item.Value)
+            .ToList();
+    }
+
+    internal void AddOrUpdate(WarehouseStockData stock)
+    {
+        _cache[WarehouseStockCacheKey.Create(stock.StoreAlias, stock.WarehouseKey, stock.Sku)] = stock;
+    }
+
+    internal void Remove(string storeAlias, Guid warehouseKey, string sku)
+    {
+        _cache.TryRemove(WarehouseStockCacheKey.Create(storeAlias, warehouseKey, sku), out _);
+    }
+
+    internal void EnsureReady()
+    {
+        if (!Volatile.Read(ref _isReady))
+        {
+            throw new InvalidOperationException("Warehouse stock cache has not been initialized.");
+        }
+    }
+
+    private readonly record struct WarehouseStockCacheKey(string StoreAlias, Guid WarehouseKey, string Sku)
+    {
+        public static WarehouseStockCacheKey Create(string storeAlias, Guid warehouseKey, string sku)
+        {
+            return new WarehouseStockCacheKey(Normalize(storeAlias), warehouseKey, Normalize(sku));
+        }
+
+        public static string Normalize(string value) => value.Trim().ToUpperInvariant();
+    }
+}

--- a/Ekom/Ekom.Core/Ekom/Models/Import/ImportWarehouseStock.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/Import/ImportWarehouseStock.cs
@@ -7,5 +7,6 @@ public class ImportWarehouseStock
 {
     public required string StoreAlias { get; set; }
     public required Guid WarehouseKey { get; set; }
-    public required decimal Balance { get; set; }
+    public decimal Balance { get; set; }
+    public bool Clear { get; set; }
 }

--- a/Ekom/Ekom.Core/Ekom/Models/WarehouseStockBatchResult.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/WarehouseStockBatchResult.cs
@@ -1,0 +1,36 @@
+namespace Ekom.Models;
+
+/// <summary>
+/// The partial-success result of a warehouse stock batch.
+/// </summary>
+public sealed class WarehouseStockBatchResult
+{
+    public IReadOnlyList<WarehouseStockMutationResult> Entries { get; init; } = Array.Empty<WarehouseStockMutationResult>();
+    public int Inserted => Entries.Count(entry => entry.Status == WarehouseStockMutationStatus.Inserted);
+    public int Updated => Entries.Count(entry => entry.Status == WarehouseStockMutationStatus.Updated);
+    public int Cleared => Entries.Count(entry => entry.Status == WarehouseStockMutationStatus.Cleared);
+    public int Unchanged => Entries.Count(entry => entry.Status == WarehouseStockMutationStatus.Unchanged);
+    public int Failed => Entries.Count(entry => entry.Status == WarehouseStockMutationStatus.Failed);
+}
+
+public sealed class WarehouseStockMutationResult
+{
+    public int Index { get; init; }
+    public string StoreAlias { get; init; } = string.Empty;
+    public Guid WarehouseKey { get; init; }
+    public string Sku { get; init; } = string.Empty;
+    public WarehouseStockMutationStatus Status { get; init; }
+    public decimal? Balance { get; init; }
+    public DateTime? UpdateDate { get; init; }
+    public string? Error { get; init; }
+    internal Exception? Exception { get; init; }
+}
+
+public enum WarehouseStockMutationStatus
+{
+    Inserted,
+    Updated,
+    Cleared,
+    Unchanged,
+    Failed,
+}

--- a/Ekom/Ekom.Core/Ekom/Models/WarehouseStockEditorValue.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/WarehouseStockEditorValue.cs
@@ -14,4 +14,5 @@ public sealed class WarehouseStockEditorItem
     public string Name { get; init; } = string.Empty;
     public bool Visible { get; init; }
     public decimal? Balance { get; init; }
+    public bool IsDirty { get; init; }
 }

--- a/Ekom/Ekom.Core/Ekom/Models/WarehouseStockLevel.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/WarehouseStockLevel.cs
@@ -1,0 +1,16 @@
+namespace Ekom.Models;
+
+/// <summary>
+/// A visible warehouse definition combined with the balance for one SKU.
+/// </summary>
+public sealed class WarehouseStockLevel
+{
+    public string StoreAlias { get; init; } = string.Empty;
+    public Guid WarehouseKey { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public int SortOrder { get; init; }
+    public string Sku { get; init; } = string.Empty;
+    public decimal? Balance { get; init; }
+    public DateTime? UpdateDate { get; init; }
+}

--- a/Ekom/Ekom.Core/Ekom/Models/WarehouseStockMutationRequest.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/WarehouseStockMutationRequest.cs
@@ -1,0 +1,19 @@
+namespace Ekom.Models;
+
+/// <summary>
+/// A warehouse stock mutation that sets or clears one SKU balance.
+/// </summary>
+public sealed class WarehouseStockMutationRequest
+{
+    public string StoreAlias { get; init; } = string.Empty;
+    public Guid WarehouseKey { get; init; }
+    public string Sku { get; init; } = string.Empty;
+    public WarehouseStockMutationOperation Operation { get; init; }
+    public decimal? Balance { get; init; }
+}
+
+public enum WarehouseStockMutationOperation
+{
+    Set,
+    Clear,
+}

--- a/Ekom/Ekom.Core/Ekom/Repositories/IWarehouseStockRepository.cs
+++ b/Ekom/Ekom.Core/Ekom/Repositories/IWarehouseStockRepository.cs
@@ -1,0 +1,12 @@
+using Ekom.Models;
+
+namespace Ekom.Repositories;
+
+internal interface IWarehouseStockRepository
+{
+    Task<List<WarehouseStockData>> GetAllAsync(CancellationToken ct = default);
+
+    Task<WarehouseStockPersistenceBatchResult> ApplyAsync(
+        IReadOnlyList<WarehouseStockPersistenceRequest> requests,
+        CancellationToken ct = default);
+}

--- a/Ekom/Ekom.Core/Ekom/Repositories/WarehouseStockRepository.cs
+++ b/Ekom/Ekom.Core/Ekom/Repositories/WarehouseStockRepository.cs
@@ -1,10 +1,11 @@
 using Ekom.Models;
 using Ekom.Services;
 using LinqToDB;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Ekom.Repositories;
 
-internal sealed class WarehouseStockRepository
+internal sealed class WarehouseStockRepository : IWarehouseStockRepository
 {
     private readonly DatabaseFactory _databaseFactory;
 
@@ -13,88 +14,102 @@ internal sealed class WarehouseStockRepository
         _databaseFactory = databaseFactory;
     }
 
-    public async Task<WarehouseStockData?> GetAsync(
-        string storeAlias,
-        Guid warehouseKey,
-        string sku,
-        CancellationToken ct = default)
+    public async Task<List<WarehouseStockData>> GetAllAsync(CancellationToken ct = default)
     {
         await using DbContext db = _databaseFactory.GetDatabase();
-
-        return await db.WarehouseStockData
-            .FirstOrDefaultAsync(
-                x => x.StoreAlias == storeAlias
-                    && x.WarehouseKey == warehouseKey
-                    && x.Sku == sku,
-                ct)
-            .ConfigureAwait(false);
+        return await db.WarehouseStockData.ToListAsync(ct).ConfigureAwait(false);
     }
 
-    public async Task<List<WarehouseStockData>> GetAsync(
-        string storeAlias,
-        IReadOnlyCollection<string> skus,
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Each database mutation must report its own failure and allow later entries to continue.")]
+    public async Task<WarehouseStockPersistenceBatchResult> ApplyAsync(
+        IReadOnlyList<WarehouseStockPersistenceRequest> requests,
         CancellationToken ct = default)
     {
         await using DbContext db = _databaseFactory.GetDatabase();
+        var results = new List<WarehouseStockPersistenceResult>(requests.Count);
 
-        return await db.WarehouseStockData
-            .Where(x => x.StoreAlias == storeAlias && skus.Contains(x.Sku))
-            .ToListAsync(ct)
-            .ConfigureAwait(false);
-    }
-
-    public async Task<List<WarehouseStockData>> GetAsync(
-        string storeAlias,
-        Guid warehouseKey,
-        IReadOnlyCollection<string> skus,
-        CancellationToken ct = default)
-    {
-        await using DbContext db = _databaseFactory.GetDatabase();
-
-        return await db.WarehouseStockData
-            .Where(x => x.StoreAlias == storeAlias
-                && x.WarehouseKey == warehouseKey
-                && skus.Contains(x.Sku))
-            .ToListAsync(ct)
-            .ConfigureAwait(false);
-    }
-
-    public async Task<WarehouseStockData> SetAsync(
-        string storeAlias,
-        Guid warehouseKey,
-        string sku,
-        decimal balance,
-        CancellationToken ct = default)
-    {
-        DateTime now = DateTime.UtcNow;
-        await using DbContext db = _databaseFactory.GetDatabase();
-
-        await db.WarehouseStockData.InsertOrUpdateAsync(
-                () => new WarehouseStockData
-                {
-                    StoreAlias = storeAlias,
-                    WarehouseKey = warehouseKey,
-                    Sku = sku,
-                    Balance = balance,
-                    CreateDate = now,
-                    UpdateDate = now,
-                },
-                _ => new WarehouseStockData
-                {
-                    Balance = balance,
-                    UpdateDate = now,
-                },
-                token: ct)
-            .ConfigureAwait(false);
-
-        return new WarehouseStockData
+        foreach (WarehouseStockPersistenceRequest request in requests)
         {
-            StoreAlias = storeAlias,
-            WarehouseKey = warehouseKey,
-            Sku = sku,
-            Balance = balance,
-            CreateDate = now,
-            UpdateDate = now,
-        };
+            try
+            {
+                if (request.Operation == WarehouseStockMutationOperation.Clear)
+                {
+                    string normalizedStoreAlias = request.StoreAlias.Trim().ToUpperInvariant();
+                    string normalizedSku = request.Sku.Trim().ToUpperInvariant();
+                    await db.WarehouseStockData
+                        .Where(item => item.WarehouseKey == request.WarehouseKey
+                            && item.StoreAlias.ToUpper() == normalizedStoreAlias
+                            && item.Sku.ToUpper() == normalizedSku)
+                        .DeleteAsync(ct)
+                        .ConfigureAwait(false);
+                    results.Add(new WarehouseStockPersistenceResult(request, null, null));
+                    continue;
+                }
+
+                DateTime now = DateTime.UtcNow;
+                decimal balance = request.Balance.GetValueOrDefault();
+                await db.WarehouseStockData.InsertOrUpdateAsync(
+                        () => new WarehouseStockData
+                        {
+                            StoreAlias = request.StoreAlias,
+                            WarehouseKey = request.WarehouseKey,
+                            Sku = request.Sku,
+                            Balance = balance,
+                            CreateDate = now,
+                            UpdateDate = now,
+                        },
+                        _ => new WarehouseStockData
+                        {
+                            Balance = balance,
+                            UpdateDate = now,
+                        },
+                        token: ct)
+                    .ConfigureAwait(false);
+
+                results.Add(new WarehouseStockPersistenceResult(
+                    request,
+                    new WarehouseStockData
+                    {
+                        StoreAlias = request.StoreAlias,
+                        WarehouseKey = request.WarehouseKey,
+                        Sku = request.Sku,
+                        Balance = balance,
+                        CreateDate = request.ExistingData?.CreateDate ?? now,
+                        UpdateDate = now,
+                    },
+                    null));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return new WarehouseStockPersistenceBatchResult(results, true);
+            }
+            catch (Exception ex)
+            {
+                results.Add(new WarehouseStockPersistenceResult(request, null, ex));
+            }
+        }
+
+        return new WarehouseStockPersistenceBatchResult(results, false);
     }
 }
+
+internal sealed record WarehouseStockPersistenceRequest(
+    int Index,
+    string StoreAlias,
+    Guid WarehouseKey,
+    string Sku,
+    WarehouseStockMutationOperation Operation,
+    decimal? Balance,
+    WarehouseStockData? ExistingData);
+
+internal sealed record WarehouseStockPersistenceResult(
+    WarehouseStockPersistenceRequest Request,
+    WarehouseStockData? Data,
+    Exception? Exception);
+
+internal sealed record WarehouseStockPersistenceBatchResult(
+    IReadOnlyList<WarehouseStockPersistenceResult> Results,
+    bool WasCanceled);

--- a/Ekom/Ekom.Umbraco/Ekom.U10/EkomCacheInitializer.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/EkomCacheInitializer.cs
@@ -47,6 +47,7 @@ internal sealed class EkomCacheInitializer
                     : _factory.GetService<IBaseCache<StockData>>() as ICache;
 
                 stockCache?.FillCache();
+                _factory.GetRequiredService<WarehouseStockCache>().FillCache();
                 _factory.GetService<ICouponCache>()?.FillCache();
             }
             catch (Exception ex)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializer.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/EkomCacheInitializer.cs
@@ -77,6 +77,7 @@ internal sealed class EkomCacheInitializer
 
                 stockCache?.FillCache();
 
+                _factory.GetRequiredService<WarehouseStockCache>().FillCache();
                 _factory.GetService<ICouponCache>()?.FillCache();
             }
             catch (Exception ex)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/Services/ImportService.cs
@@ -1306,18 +1306,26 @@ public class ImportService : IImportService
             return;
         }
 
-        foreach (var warehouseStockByWarehouse in warehouseStock.GroupBy(stock => new { stock.StoreAlias, stock.WarehouseKey }))
+        WarehouseStockBatchResult result = _warehouse.UpdateAsync(warehouseStock
+                .Select(stock => new WarehouseStockMutationRequest
+                {
+                    StoreAlias = stock.StoreAlias,
+                    WarehouseKey = stock.WarehouseKey,
+                    Sku = sku,
+                    Operation = stock.Clear
+                        ? WarehouseStockMutationOperation.Clear
+                        : WarehouseStockMutationOperation.Set,
+                    Balance = stock.Clear ? null : stock.Balance,
+                }))
+            .GetAwaiter()
+            .GetResult();
+
+        if (result.Failed > 0)
         {
-            _warehouse.SetAsync(
-                    warehouseStockByWarehouse.Key.StoreAlias,
-                    warehouseStockByWarehouse.Key.WarehouseKey,
-                    warehouseStockByWarehouse.Select(stock => new WarehouseStockBalanceRequest
-                    {
-                        Sku = sku,
-                        Balance = stock.Balance,
-                    }))
-                .GetAwaiter()
-                .GetResult();
+            string errors = string.Join("; ", result.Entries
+                .Where(entry => entry.Status == WarehouseStockMutationStatus.Failed)
+                .Select(entry => $"{entry.StoreAlias}/{entry.WarehouseKey}/{entry.Sku}: {entry.Error}"));
+            throw new InvalidOperationException($"One or more warehouse stock imports failed: {errors}");
         }
     }
 

--- a/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/UmbracoEventListeners.cs
@@ -8,6 +8,7 @@ using Ekom.Utilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
@@ -374,16 +375,71 @@ internal sealed class UmbracoEventListeners :
                 return;
             }
 
-            foreach (WarehouseStockEditorItem item in (value.Items ?? Array.Empty<WarehouseStockEditorItem>())
-                .Where(item => item?.Balance.HasValue == true))
+            IReadOnlyList<WarehouseStockEditorItem> items = (value.Items ?? Array.Empty<WarehouseStockEditorItem>())
+                .OfType<WarehouseStockEditorItem>()
+                .ToList();
+            List<WarehouseStockEditorItem> dirtyItems = items
+                .Where(item => item?.IsDirty == true)
+                .ToList();
+
+            if (dirtyItems.Count == 0)
             {
-                await Warehouse.Instance.SetAsync(
-                    item.StoreAlias,
-                    item.WarehouseKey,
-                    sku,
-                    item.Balance!.Value,
-                    cancellationToken).ConfigureAwait(false);
+                return;
             }
+
+            WarehouseStockBatchResult result = await Warehouse.Instance.UpdateAsync(
+                dirtyItems.Select(item => new WarehouseStockMutationRequest
+                {
+                    StoreAlias = item.StoreAlias,
+                    WarehouseKey = item.WarehouseKey,
+                    Sku = sku,
+                    Operation = item.Balance.HasValue
+                        ? WarehouseStockMutationOperation.Set
+                        : WarehouseStockMutationOperation.Clear,
+                    Balance = item.Balance,
+                }),
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (WarehouseStockMutationResult failure in result.Entries
+                .Where(entry => entry.Status == WarehouseStockMutationStatus.Failed))
+            {
+                _logger.LogWarning(
+                    "Could not update warehouse stock on node {NodeId} for store {StoreAlias}, warehouse {WarehouseKey}, SKU {Sku}: {Error}",
+                    content.Id,
+                    failure.StoreAlias,
+                    failure.WarehouseKey,
+                    failure.Sku,
+                    failure.Error);
+            }
+
+            int mutationIndex = 0;
+            IReadOnlyList<WarehouseStockEditorItem> cleanItems = items.Select(item =>
+            {
+                bool isDirty = item.IsDirty
+                    && result.Entries[mutationIndex++].Status == WarehouseStockMutationStatus.Failed;
+
+                return new WarehouseStockEditorItem
+                {
+                    StoreAlias = item.StoreAlias,
+                    WarehouseKey = item.WarehouseKey,
+                    Code = item.Code,
+                    Name = item.Name,
+                    Visible = item.Visible,
+                    Balance = item.Balance,
+                    IsDirty = isDirty,
+                };
+            }).ToList();
+
+            content.SetValue("warehouseStock", JsonConvert.SerializeObject(
+                new WarehouseStockEditorValue
+                {
+                    Sku = value.Sku,
+                    Items = cleanItems,
+                },
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                }));
         }
         catch (JsonException ex)
         {

--- a/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/warehouse-stock-editor.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/App_Plugins/Ekom/dist/warehouse-stock-editor.element.js
@@ -1,17 +1,17 @@
 var l = Object.defineProperty;
-var h = (u, i, e) => i in u ? l(u, i, { enumerable: !0, configurable: !0, writable: !0, value: e }) : u[i] = e;
-var n = (u, i, e) => h(u, typeof i != "symbol" ? i + "" : i, e);
+var h = (d, n, e) => n in d ? l(d, n, { enumerable: !0, configurable: !0, writable: !0, value: e }) : d[n] = e;
+var u = (d, n, e) => h(d, typeof n != "symbol" ? n + "" : n, e);
 import { UmbChangeEvent as p } from "@umbraco-cms/backoffice/event";
-class f extends HTMLElement {
+class m extends HTMLElement {
   constructor() {
     super(...arguments);
-    n(this, "manifest");
-    n(this, "name");
-    n(this, "dataSourceAlias");
-    n(this, "config");
-    n(this, "editor");
-    n(this, "status");
-    n(this, "warehouseStock", { sku: "", items: [] });
+    u(this, "manifest");
+    u(this, "name");
+    u(this, "dataSourceAlias");
+    u(this, "config");
+    u(this, "editor");
+    u(this, "status");
+    u(this, "warehouseStock", { sku: "", items: [] });
   }
   get value() {
     return this.warehouseStock;
@@ -36,10 +36,11 @@ class f extends HTMLElement {
     }
     this.setStatus("Loading warehouse stock...");
     try {
-      this.warehouseStock = await this.fetchJson(`/ekom/backoffice/WarehouseStock/${e}`), this.renderStock(), this.warehouseStock.sku.length === 0 ? this.setStatus("Save a SKU before editing warehouse stock.") : this.warehouseStock.items.length === 0 ? this.setStatus("No warehouses are configured for this product or variant.") : this.setStatus("");
+      const t = await this.fetchJson(`/ekom/backoffice/WarehouseStock/${e}`);
+      this.warehouseStock = this.mergePendingChanges(t, this.warehouseStock), this.renderStock(), this.warehouseStock.sku.length === 0 ? this.setStatus("Save a SKU before editing warehouse stock.") : this.warehouseStock.items.length === 0 ? this.setStatus("No warehouses are configured for this product or variant.") : this.setStatus("");
     } catch (t) {
-      const s = t instanceof Error ? t.message : "Could not load warehouse stock.";
-      this.setStatus(s, !0);
+      const r = t instanceof Error ? t.message : "Could not load warehouse stock.";
+      this.setStatus(r, !0);
     }
   }
   renderShell() {
@@ -70,19 +71,19 @@ class f extends HTMLElement {
   renderStock() {
     if (this.editor == null)
       return;
-    const e = document.createDocumentFragment(), t = [...new Set(this.warehouseStock.items.map((s) => s.storeAlias))];
-    for (const s of t) {
-      const a = document.createElement("fieldset"), r = document.createElement("legend");
-      r.textContent = s;
+    const e = document.createDocumentFragment(), t = [...new Set(this.warehouseStock.items.map((r) => r.storeAlias))];
+    for (const r of t) {
+      const a = document.createElement("fieldset"), s = document.createElement("legend");
+      s.textContent = r;
       const o = document.createElement("div");
       o.className = "header";
-      for (const d of ["Code", "Warehouse", "Balance"]) {
+      for (const i of ["Code", "Warehouse", "Balance"]) {
         const c = document.createElement("div");
-        c.textContent = d, o.append(c);
+        c.textContent = i, o.append(c);
       }
-      a.append(r, o);
-      for (const d of this.warehouseStock.items.filter((c) => c.storeAlias === s))
-        a.append(this.createRow(d));
+      a.append(s, o);
+      for (const i of this.warehouseStock.items.filter((c) => c.storeAlias === r))
+        a.append(this.createRow(i));
       e.append(a);
     }
     this.editor.replaceChildren(e), this.syncDisabledState();
@@ -90,36 +91,58 @@ class f extends HTMLElement {
   createRow(e) {
     const t = document.createElement("div");
     t.className = "row";
-    const s = document.createElement("div");
-    s.textContent = e.code;
+    const r = document.createElement("div");
+    r.textContent = e.code;
     const a = document.createElement("div");
     if (a.textContent = e.name, !e.visible) {
       const o = document.createElement("span");
       o.className = "hidden", o.textContent = " (Hidden)", a.append(o);
     }
-    const r = document.createElement("input");
-    return r.type = "number", r.min = "0", r.step = "any", r.placeholder = "Not set", r.dataset.store = e.storeAlias, r.dataset.warehouse = e.warehouseKey, r.value = e.balance == null ? "" : String(e.balance), r.addEventListener("input", () => this.setBalance(e.storeAlias, e.warehouseKey, r.value)), t.append(s, a, r), t;
+    const s = document.createElement("input");
+    return s.type = "number", s.min = "0", s.step = "any", s.placeholder = "Not set", s.dataset.store = e.storeAlias, s.dataset.warehouse = e.warehouseKey, s.value = e.balance == null ? "" : String(e.balance), s.addEventListener("input", () => this.setBalance(e.storeAlias, e.warehouseKey, s)), t.append(r, a, s), t;
   }
-  setBalance(e, t, s) {
-    const a = s === "" ? null : Number(s), r = a == null || Number.isFinite(a) && a >= 0 ? a : null;
+  setBalance(e, t, r) {
+    const a = r.value, s = a === "" ? null : Number(a);
+    if (s != null && (!Number.isFinite(s) || s < 0)) {
+      r.setCustomValidity("Balance must be a non-negative number.");
+      return;
+    }
+    r.setCustomValidity("");
+    const o = s;
     this.warehouseStock = {
       ...this.warehouseStock,
-      items: this.warehouseStock.items.map((o) => o.storeAlias === e && o.warehouseKey === t ? { ...o, balance: r } : o)
+      items: this.warehouseStock.items.map((i) => i.storeAlias === e && i.warehouseKey === t ? { ...i, balance: o, isDirty: !0 } : i)
     }, this.dispatchEvent(new p());
   }
   normalizeValue(e) {
     const t = typeof e == "string" ? this.tryParseJson(e) : e;
     if (t == null || typeof t != "object" || Array.isArray(t))
       return { sku: "", items: [] };
-    const s = t;
+    const r = t;
     return {
-      sku: typeof s.sku == "string" ? s.sku : "",
-      items: Array.isArray(s.items) ? s.items : []
+      sku: typeof r.sku == "string" ? r.sku : "",
+      items: Array.isArray(r.items) ? r.items.filter((a) => a != null && typeof a == "object").map((a) => ({ ...a, isDirty: a.isDirty === !0 })) : []
     };
+  }
+  mergePendingChanges(e, t) {
+    const r = t.items.filter((s) => s.isDirty), a = new Set(e.items.map((s) => this.getIdentity(s)));
+    return {
+      ...e,
+      items: [
+        ...e.items.map((s) => {
+          const o = r.find((i) => this.getIdentity(i) === this.getIdentity(s));
+          return o == null ? { ...s, isDirty: !1 } : { ...s, balance: o.balance, isDirty: !0 };
+        }),
+        ...r.filter((s) => !a.has(this.getIdentity(s)))
+      ]
+    };
+  }
+  getIdentity(e) {
+    return `${e.storeAlias.trim().toUpperCase()}|${e.warehouseKey.toUpperCase()}`;
   }
   syncInputs() {
     for (const e of this.querySelectorAll("input[data-warehouse]")) {
-      const t = this.warehouseStock.items.find((s) => s.storeAlias === e.dataset.store && s.warehouseKey === e.dataset.warehouse);
+      const t = this.warehouseStock.items.find((r) => r.storeAlias === e.dataset.store && r.warehouseKey === e.dataset.warehouse);
       e.value = (t == null ? void 0 : t.balance) == null ? "" : String(t.balance);
     }
   }
@@ -150,8 +173,8 @@ class f extends HTMLElement {
     return await t.json();
   }
 }
-customElements.define("ekom-warehouse-stock-editor", f);
+customElements.define("ekom-warehouse-stock-editor", m);
 export {
-  f as EkomWarehouseStockEditorElement,
-  f as default
+  m as EkomWarehouseStockEditorElement,
+  m as default
 };

--- a/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/warehouse-stock-editor.element.ts
+++ b/Ekom/Ekom.Web/Ekom.Web.U17/Client/src/property-editors/warehouse-stock-editor.element.ts
@@ -17,6 +17,7 @@ type WarehouseStockItem = {
   name: string;
   visible: boolean;
   balance: number | null;
+  isDirty: boolean;
 };
 
 export class EkomWarehouseStockEditorElement extends HTMLElement implements UmbPropertyEditorUiElement {
@@ -62,7 +63,8 @@ export class EkomWarehouseStockEditorElement extends HTMLElement implements UmbP
     this.setStatus('Loading warehouse stock...');
 
     try {
-      this.warehouseStock = await this.fetchJson<WarehouseStockValue>(`/ekom/backoffice/WarehouseStock/${contentKey}`);
+      const loadedStock = await this.fetchJson<WarehouseStockValue>(`/ekom/backoffice/WarehouseStock/${contentKey}`);
+      this.warehouseStock = this.mergePendingChanges(loadedStock, this.warehouseStock);
       this.renderStock();
 
       if (this.warehouseStock.sku.length === 0) {
@@ -164,20 +166,27 @@ export class EkomWarehouseStockEditorElement extends HTMLElement implements UmbP
     input.dataset.store = item.storeAlias;
     input.dataset.warehouse = item.warehouseKey;
     input.value = item.balance == null ? '' : String(item.balance);
-    input.addEventListener('input', () => this.setBalance(item.storeAlias, item.warehouseKey, input.value));
+    input.addEventListener('input', () => this.setBalance(item.storeAlias, item.warehouseKey, input));
 
     row.append(code, name, input);
     return row;
   }
 
-  private setBalance(storeAlias: string, warehouseKey: string, rawValue: string): void {
+  private setBalance(storeAlias: string, warehouseKey: string, input: HTMLInputElement): void {
+    const rawValue = input.value;
     const parsed = rawValue === '' ? null : Number(rawValue);
-    const balance = parsed == null || (Number.isFinite(parsed) && parsed >= 0) ? parsed : null;
+    if (parsed != null && (!Number.isFinite(parsed) || parsed < 0)) {
+      input.setCustomValidity('Balance must be a non-negative number.');
+      return;
+    }
+
+    input.setCustomValidity('');
+    const balance = parsed;
 
     this.warehouseStock = {
       ...this.warehouseStock,
       items: this.warehouseStock.items.map(item => item.storeAlias === storeAlias && item.warehouseKey === warehouseKey
-        ? { ...item, balance }
+        ? { ...item, balance, isDirty: true }
         : item),
     };
     this.dispatchEvent(new UmbChangeEvent());
@@ -192,8 +201,34 @@ export class EkomWarehouseStockEditorElement extends HTMLElement implements UmbP
     const stock = parsed as Partial<WarehouseStockValue>;
     return {
       sku: typeof stock.sku === 'string' ? stock.sku : '',
-      items: Array.isArray(stock.items) ? stock.items : [],
+      items: Array.isArray(stock.items)
+        ? stock.items
+          .filter(item => item != null && typeof item === 'object')
+          .map(item => ({ ...item, isDirty: item.isDirty === true }))
+        : [],
     };
+  }
+
+  private mergePendingChanges(loaded: WarehouseStockValue, current: WarehouseStockValue): WarehouseStockValue {
+    const pending = current.items.filter(item => item.isDirty);
+    const loadedIdentities = new Set(loaded.items.map(item => this.getIdentity(item)));
+
+    return {
+      ...loaded,
+      items: [
+        ...loaded.items.map(item => {
+          const pendingItem = pending.find(candidate => this.getIdentity(candidate) === this.getIdentity(item));
+          return pendingItem == null
+            ? { ...item, isDirty: false }
+            : { ...item, balance: pendingItem.balance, isDirty: true };
+        }),
+        ...pending.filter(item => !loadedIdentities.has(this.getIdentity(item))),
+      ],
+    };
+  }
+
+  private getIdentity(item: WarehouseStockItem): string {
+    return `${item.storeAlias.trim().toUpperCase()}|${item.warehouseKey.toUpperCase()}`;
   }
 
   private syncInputs(): void {

--- a/Ekom/Ekom.Web/Ekom.Web.U18/App_Plugins/Ekom/dist/warehouse-stock-editor.element.js
+++ b/Ekom/Ekom.Web/Ekom.Web.U18/App_Plugins/Ekom/dist/warehouse-stock-editor.element.js
@@ -1,17 +1,17 @@
 var l = Object.defineProperty;
-var h = (u, i, e) => i in u ? l(u, i, { enumerable: !0, configurable: !0, writable: !0, value: e }) : u[i] = e;
-var n = (u, i, e) => h(u, typeof i != "symbol" ? i + "" : i, e);
+var h = (d, n, e) => n in d ? l(d, n, { enumerable: !0, configurable: !0, writable: !0, value: e }) : d[n] = e;
+var u = (d, n, e) => h(d, typeof n != "symbol" ? n + "" : n, e);
 import { UmbChangeEvent as p } from "@umbraco-cms/backoffice/event";
-class f extends HTMLElement {
+class m extends HTMLElement {
   constructor() {
     super(...arguments);
-    n(this, "manifest");
-    n(this, "name");
-    n(this, "dataSourceAlias");
-    n(this, "config");
-    n(this, "editor");
-    n(this, "status");
-    n(this, "warehouseStock", { sku: "", items: [] });
+    u(this, "manifest");
+    u(this, "name");
+    u(this, "dataSourceAlias");
+    u(this, "config");
+    u(this, "editor");
+    u(this, "status");
+    u(this, "warehouseStock", { sku: "", items: [] });
   }
   get value() {
     return this.warehouseStock;
@@ -36,10 +36,11 @@ class f extends HTMLElement {
     }
     this.setStatus("Loading warehouse stock...");
     try {
-      this.warehouseStock = await this.fetchJson(`/ekom/backoffice/WarehouseStock/${e}`), this.renderStock(), this.warehouseStock.sku.length === 0 ? this.setStatus("Save a SKU before editing warehouse stock.") : this.warehouseStock.items.length === 0 ? this.setStatus("No warehouses are configured for this product or variant.") : this.setStatus("");
+      const t = await this.fetchJson(`/ekom/backoffice/WarehouseStock/${e}`);
+      this.warehouseStock = this.mergePendingChanges(t, this.warehouseStock), this.renderStock(), this.warehouseStock.sku.length === 0 ? this.setStatus("Save a SKU before editing warehouse stock.") : this.warehouseStock.items.length === 0 ? this.setStatus("No warehouses are configured for this product or variant.") : this.setStatus("");
     } catch (t) {
-      const s = t instanceof Error ? t.message : "Could not load warehouse stock.";
-      this.setStatus(s, !0);
+      const r = t instanceof Error ? t.message : "Could not load warehouse stock.";
+      this.setStatus(r, !0);
     }
   }
   renderShell() {
@@ -70,19 +71,19 @@ class f extends HTMLElement {
   renderStock() {
     if (this.editor == null)
       return;
-    const e = document.createDocumentFragment(), t = [...new Set(this.warehouseStock.items.map((s) => s.storeAlias))];
-    for (const s of t) {
-      const a = document.createElement("fieldset"), r = document.createElement("legend");
-      r.textContent = s;
+    const e = document.createDocumentFragment(), t = [...new Set(this.warehouseStock.items.map((r) => r.storeAlias))];
+    for (const r of t) {
+      const a = document.createElement("fieldset"), s = document.createElement("legend");
+      s.textContent = r;
       const o = document.createElement("div");
       o.className = "header";
-      for (const d of ["Code", "Warehouse", "Balance"]) {
+      for (const i of ["Code", "Warehouse", "Balance"]) {
         const c = document.createElement("div");
-        c.textContent = d, o.append(c);
+        c.textContent = i, o.append(c);
       }
-      a.append(r, o);
-      for (const d of this.warehouseStock.items.filter((c) => c.storeAlias === s))
-        a.append(this.createRow(d));
+      a.append(s, o);
+      for (const i of this.warehouseStock.items.filter((c) => c.storeAlias === r))
+        a.append(this.createRow(i));
       e.append(a);
     }
     this.editor.replaceChildren(e), this.syncDisabledState();
@@ -90,36 +91,58 @@ class f extends HTMLElement {
   createRow(e) {
     const t = document.createElement("div");
     t.className = "row";
-    const s = document.createElement("div");
-    s.textContent = e.code;
+    const r = document.createElement("div");
+    r.textContent = e.code;
     const a = document.createElement("div");
     if (a.textContent = e.name, !e.visible) {
       const o = document.createElement("span");
       o.className = "hidden", o.textContent = " (Hidden)", a.append(o);
     }
-    const r = document.createElement("input");
-    return r.type = "number", r.min = "0", r.step = "any", r.placeholder = "Not set", r.dataset.store = e.storeAlias, r.dataset.warehouse = e.warehouseKey, r.value = e.balance == null ? "" : String(e.balance), r.addEventListener("input", () => this.setBalance(e.storeAlias, e.warehouseKey, r.value)), t.append(s, a, r), t;
+    const s = document.createElement("input");
+    return s.type = "number", s.min = "0", s.step = "any", s.placeholder = "Not set", s.dataset.store = e.storeAlias, s.dataset.warehouse = e.warehouseKey, s.value = e.balance == null ? "" : String(e.balance), s.addEventListener("input", () => this.setBalance(e.storeAlias, e.warehouseKey, s)), t.append(r, a, s), t;
   }
-  setBalance(e, t, s) {
-    const a = s === "" ? null : Number(s), r = a == null || Number.isFinite(a) && a >= 0 ? a : null;
+  setBalance(e, t, r) {
+    const a = r.value, s = a === "" ? null : Number(a);
+    if (s != null && (!Number.isFinite(s) || s < 0)) {
+      r.setCustomValidity("Balance must be a non-negative number.");
+      return;
+    }
+    r.setCustomValidity("");
+    const o = s;
     this.warehouseStock = {
       ...this.warehouseStock,
-      items: this.warehouseStock.items.map((o) => o.storeAlias === e && o.warehouseKey === t ? { ...o, balance: r } : o)
+      items: this.warehouseStock.items.map((i) => i.storeAlias === e && i.warehouseKey === t ? { ...i, balance: o, isDirty: !0 } : i)
     }, this.dispatchEvent(new p());
   }
   normalizeValue(e) {
     const t = typeof e == "string" ? this.tryParseJson(e) : e;
     if (t == null || typeof t != "object" || Array.isArray(t))
       return { sku: "", items: [] };
-    const s = t;
+    const r = t;
     return {
-      sku: typeof s.sku == "string" ? s.sku : "",
-      items: Array.isArray(s.items) ? s.items : []
+      sku: typeof r.sku == "string" ? r.sku : "",
+      items: Array.isArray(r.items) ? r.items.filter((a) => a != null && typeof a == "object").map((a) => ({ ...a, isDirty: a.isDirty === !0 })) : []
     };
+  }
+  mergePendingChanges(e, t) {
+    const r = t.items.filter((s) => s.isDirty), a = new Set(e.items.map((s) => this.getIdentity(s)));
+    return {
+      ...e,
+      items: [
+        ...e.items.map((s) => {
+          const o = r.find((i) => this.getIdentity(i) === this.getIdentity(s));
+          return o == null ? { ...s, isDirty: !1 } : { ...s, balance: o.balance, isDirty: !0 };
+        }),
+        ...r.filter((s) => !a.has(this.getIdentity(s)))
+      ]
+    };
+  }
+  getIdentity(e) {
+    return `${e.storeAlias.trim().toUpperCase()}|${e.warehouseKey.toUpperCase()}`;
   }
   syncInputs() {
     for (const e of this.querySelectorAll("input[data-warehouse]")) {
-      const t = this.warehouseStock.items.find((s) => s.storeAlias === e.dataset.store && s.warehouseKey === e.dataset.warehouse);
+      const t = this.warehouseStock.items.find((r) => r.storeAlias === e.dataset.store && r.warehouseKey === e.dataset.warehouse);
       e.value = (t == null ? void 0 : t.balance) == null ? "" : String(t.balance);
     }
   }
@@ -150,8 +173,8 @@ class f extends HTMLElement {
     return await t.json();
   }
 }
-customElements.define("ekom-warehouse-stock-editor", f);
+customElements.define("ekom-warehouse-stock-editor", m);
 export {
-  f as EkomWarehouseStockEditorElement,
-  f as default
+  m as EkomWarehouseStockEditorElement,
+  m as default
 };

--- a/Ekom/Tests/Ekom.Tests/Tests/WarehouseStockEditorValueTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/WarehouseStockEditorValueTests.cs
@@ -19,7 +19,8 @@ public class WarehouseStockEditorValueTests
                   "code": "MAIN",
                   "name": "Main warehouse",
                   "visible": true,
-                  "balance": 0
+                  "balance": 0,
+                  "isDirty": true
                 },
                 {
                   "storeAlias": "default",
@@ -38,6 +39,8 @@ public class WarehouseStockEditorValueTests
         Assert.NotNull(value);
         Assert.Equal("ABC-123", value.Sku);
         Assert.Equal(0m, value.Items[0].Balance);
+        Assert.True(value.Items[0].IsDirty);
         Assert.Null(value.Items[1].Balance);
+        Assert.False(value.Items[1].IsDirty);
     }
 }

--- a/Ekom/Tests/Ekom.Tests/Tests/WarehouseStockTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/WarehouseStockTests.cs
@@ -1,0 +1,406 @@
+using Ekom.Cache;
+using Ekom.Models;
+using Ekom.Repositories;
+using Ekom.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using WarehouseApi = Ekom.API.Warehouse;
+
+namespace Ekom.Tests.Tests;
+
+public class WarehouseStockTests
+{
+    private const string DefaultStore = "default";
+    private static readonly Guid MainWarehouse = Guid.Parse("d8cf6892-f075-430b-b94b-f43f5828bbca");
+    private static readonly Guid SecondaryWarehouse = Guid.Parse("1365c4a6-8dca-4369-969b-2d4dff62a901");
+
+    [Fact]
+    public async Task GetAsync_BeforeInitialCacheFill_ThrowsCacheUnavailable()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        WarehouseApi warehouse = CreateWarehouse(repository, out _);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            warehouse.GetAsync(DefaultStore, MainWarehouse, "sku-1"));
+
+        Assert.Contains("has not been initialized", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, repository.GetAllCallCount);
+    }
+
+    [Fact]
+    public async Task Reads_AfterCacheFill_DoNotReloadRepository()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        repository.Data.Add(CreateData(DefaultStore, MainWarehouse, "SKU-1", 4m));
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        WarehouseStockBalance? single = await warehouse.GetAsync(DefaultStore, MainWarehouse, "sku-1");
+        IReadOnlyList<WarehouseStockBalance> warehouseBalances = await warehouse.GetAsync(
+            DefaultStore,
+            MainWarehouse,
+            ["sku-1"]);
+        IReadOnlyList<WarehouseStockBalance> storeBalances = await warehouse.GetAsync(DefaultStore, ["sku-1"]);
+        IReadOnlyList<WarehouseStockLevel> levels = await warehouse.GetForSkuAsync(DefaultStore, "sku-1");
+
+        Assert.Equal(4m, single?.Balance);
+        Assert.Single(warehouseBalances);
+        Assert.Single(storeBalances);
+        Assert.Equal(4m, levels.Single(level => level.WarehouseKey == MainWarehouse).Balance);
+        Assert.Equal(1, repository.GetAllCallCount);
+    }
+
+    [Fact]
+    public async Task SetAndClear_PreserveUnsetZeroAndUnchangedUpdateDate()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        bool clearedUnset = await warehouse.ClearAsync(DefaultStore, MainWarehouse, "sku-1");
+        WarehouseStockBalance inserted = await warehouse.SetAsync(DefaultStore, MainWarehouse, "sku-1", 0m);
+        WarehouseStockBalance unchanged = await warehouse.SetAsync(DefaultStore, MainWarehouse, "sku-1", 0m);
+        bool clearedZero = await warehouse.ClearAsync(DefaultStore, MainWarehouse, "sku-1");
+        WarehouseStockBalance? afterClear = await warehouse.GetAsync(DefaultStore, MainWarehouse, "sku-1");
+
+        Assert.False(clearedUnset);
+        Assert.Equal(0m, inserted.Balance);
+        Assert.Equal(inserted.UpdateDate, unchanged.UpdateDate);
+        Assert.True(clearedZero);
+        Assert.Null(afterClear);
+        Assert.Equal(2, repository.ApplyCallCount);
+        Assert.Empty(repository.Data);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReportsValidationAndPersistenceFailuresPerEntry()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        repository.FailingSkus.Add("FAIL");
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        WarehouseStockBatchResult result = await warehouse.UpdateAsync([
+            new WarehouseStockMutationRequest
+            {
+                StoreAlias = DefaultStore,
+                WarehouseKey = MainWarehouse,
+                Sku = "first",
+                Balance = 1m,
+            },
+            new WarehouseStockMutationRequest
+            {
+                StoreAlias = DefaultStore,
+                WarehouseKey = Guid.NewGuid(),
+                Sku = "invalid-warehouse",
+                Balance = 2m,
+            },
+            new WarehouseStockMutationRequest
+            {
+                StoreAlias = DefaultStore,
+                WarehouseKey = MainWarehouse,
+                Sku = "fail",
+                Balance = 3m,
+            },
+            new WarehouseStockMutationRequest
+            {
+                StoreAlias = "second",
+                WarehouseKey = SecondaryWarehouse,
+                Sku = "last",
+                Balance = 4m,
+            },
+        ]);
+
+        Assert.Equal(2, result.Inserted);
+        Assert.Equal(2, result.Failed);
+        Assert.Equal(WarehouseStockMutationStatus.Inserted, result.Entries[0].Status);
+        Assert.Equal(WarehouseStockMutationStatus.Failed, result.Entries[1].Status);
+        Assert.Equal(WarehouseStockMutationStatus.Failed, result.Entries[2].Status);
+        Assert.Equal(WarehouseStockMutationStatus.Inserted, result.Entries[3].Status);
+        Assert.Equal(1, repository.ApplyCallCount);
+        Assert.Equal(2, repository.Data.Count);
+    }
+
+    [Fact]
+    public async Task ExistingSetBatch_RemainsFailFast()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        repository.FailingSkus.Add("FAIL");
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => warehouse.SetAsync(
+            DefaultStore,
+            MainWarehouse,
+            [
+                new WarehouseStockBalanceRequest { Sku = "fail", Balance = 1m },
+                new WarehouseStockBalanceRequest { Sku = "not-written", Balance = 2m },
+            ]));
+
+        Assert.Equal(1, repository.ApplyCallCount);
+        Assert.Empty(repository.Data);
+    }
+
+    [Fact]
+    public async Task SetAsync_NormalizesStoreAliasIdentityForNewRecords()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        await warehouse.SetAsync("default", MainWarehouse, "sku-1", 1m);
+        await warehouse.SetAsync("DEFAULT", MainWarehouse, "SKU-1", 2m);
+
+        WarehouseStockData data = Assert.Single(repository.Data);
+        Assert.Equal("DEFAULT", data.StoreAlias);
+        Assert.Equal("SKU-1", data.Sku);
+        Assert.Equal(2m, data.Balance);
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesCaseVariantDuplicateRows()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        WarehouseStockData older = CreateData("default", MainWarehouse, "sku-1", 1m);
+        WarehouseStockData newer = CreateData("DEFAULT", MainWarehouse, "SKU-1", 2m);
+        newer.UpdateDate = older.UpdateDate.AddMinutes(1);
+        repository.Data.Add(older);
+        repository.Data.Add(newer);
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        bool cleared = await warehouse.ClearAsync(DefaultStore, MainWarehouse, "sku-1");
+        cache.FillCache();
+        WarehouseStockBalance? balance = await warehouse.GetAsync(DefaultStore, MainWarehouse, "sku-1");
+
+        Assert.True(cleared);
+        Assert.Empty(repository.Data);
+        Assert.Null(balance);
+    }
+
+    [Fact]
+    public async Task GetForSkuAsync_ReturnsVisibleDefinitionsWithNullableCachedBalances()
+    {
+        var definitions = new[]
+        {
+            new WarehouseDefinition
+            {
+                Key = SecondaryWarehouse,
+                Code = "SECONDARY",
+                Name = "Secondary",
+                SortOrder = 20,
+                Visible = true,
+            },
+            new WarehouseDefinition
+            {
+                Key = MainWarehouse,
+                Code = "MAIN",
+                Name = "Main",
+                SortOrder = 10,
+                Visible = true,
+            },
+            new WarehouseDefinition
+            {
+                Key = Guid.NewGuid(),
+                Code = "HIDDEN",
+                Name = "Hidden",
+                SortOrder = 5,
+                Visible = false,
+            },
+        };
+        var repository = new FakeWarehouseStockRepository();
+        repository.Data.Add(CreateData(DefaultStore, MainWarehouse, "SKU-1", 8m));
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache, definitions);
+        cache.FillCache();
+
+        IReadOnlyList<WarehouseStockLevel> levels = await warehouse.GetForSkuAsync(DefaultStore, "sku-1");
+
+        Assert.Equal(2, levels.Count);
+        Assert.Equal(MainWarehouse, levels[0].WarehouseKey);
+        Assert.Equal(8m, levels[0].Balance);
+        Assert.NotNull(levels[0].UpdateDate);
+        Assert.Equal(SecondaryWarehouse, levels[1].WarehouseKey);
+        Assert.Null(levels[1].Balance);
+        Assert.Null(levels[1].UpdateDate);
+    }
+
+    [Fact]
+    public async Task FailedRefresh_RetainsPreviousSnapshot()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        repository.Data.Add(CreateData(DefaultStore, MainWarehouse, "SKU-1", 5m));
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+        repository.GetAllOverride = () => throw new InvalidOperationException("Refresh failed.");
+
+        Assert.Throws<InvalidOperationException>(() => cache.FillCache());
+        WarehouseStockBalance? balance = await warehouse.GetAsync(DefaultStore, MainWarehouse, "sku-1");
+
+        Assert.Equal(5m, balance?.Balance);
+    }
+
+    [Fact]
+    public async Task RefreshAndWrite_AreCoordinatedWithoutLosingNewerWrite()
+    {
+        var repository = new FakeWarehouseStockRepository();
+        repository.Data.Add(CreateData(DefaultStore, MainWarehouse, "SKU-1", 1m));
+        WarehouseApi warehouse = CreateWarehouse(repository, out WarehouseStockCache cache);
+        cache.FillCache();
+
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        repository.GetAllOverride = async () =>
+        {
+            refreshStarted.SetResult();
+            await releaseRefresh.Task.ConfigureAwait(false);
+            return repository.Snapshot();
+        };
+
+        Task refresh = Task.Run(cache.FillCache);
+        await refreshStarted.Task;
+        Task<WarehouseStockBalance> write = warehouse.SetAsync(DefaultStore, MainWarehouse, "sku-1", 2m);
+        Assert.False(write.IsCompleted);
+
+        releaseRefresh.SetResult();
+        await Task.WhenAll(refresh, write);
+        WarehouseStockBalance? balance = await warehouse.GetAsync(DefaultStore, MainWarehouse, "sku-1");
+
+        Assert.Equal(2m, balance?.Balance);
+    }
+
+    private static WarehouseApi CreateWarehouse(
+        FakeWarehouseStockRepository repository,
+        out WarehouseStockCache cache,
+        IReadOnlyList<WarehouseDefinition>? definitions = null)
+    {
+        definitions ??=
+        [
+            new WarehouseDefinition
+            {
+                Key = MainWarehouse,
+                Code = "MAIN",
+                Name = "Main",
+                SortOrder = 10,
+                Visible = true,
+            },
+            new WarehouseDefinition
+            {
+                Key = SecondaryWarehouse,
+                Code = "SECONDARY",
+                Name = "Secondary",
+                SortOrder = 20,
+                Visible = true,
+            },
+        ];
+
+        var definitionService = new Mock<IWarehouseDefinitionService>();
+        definitionService
+            .Setup(service => service.GetPublishedWarehouses(It.IsAny<string>()))
+            .Returns(definitions);
+
+        cache = new WarehouseStockCache(repository, NullLogger<WarehouseStockCache>.Instance);
+        return new WarehouseApi(repository, definitionService.Object, cache);
+    }
+
+    private static WarehouseStockData CreateData(string storeAlias, Guid warehouseKey, string sku, decimal balance)
+    {
+        DateTime now = DateTime.UtcNow;
+        return new WarehouseStockData
+        {
+            StoreAlias = storeAlias,
+            WarehouseKey = warehouseKey,
+            Sku = sku,
+            Balance = balance,
+            CreateDate = now,
+            UpdateDate = now,
+        };
+    }
+
+    private sealed class FakeWarehouseStockRepository : IWarehouseStockRepository
+    {
+        private readonly object _lock = new();
+
+        public List<WarehouseStockData> Data { get; } = [];
+        public HashSet<string> FailingSkus { get; } = new(StringComparer.Ordinal);
+        public Func<Task<List<WarehouseStockData>>>? GetAllOverride { get; set; }
+        public int GetAllCallCount { get; private set; }
+        public int ApplyCallCount { get; private set; }
+
+        public Task<List<WarehouseStockData>> GetAllAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            GetAllCallCount++;
+            return GetAllOverride?.Invoke() ?? Task.FromResult(Snapshot());
+        }
+
+        public Task<WarehouseStockPersistenceBatchResult> ApplyAsync(
+            IReadOnlyList<WarehouseStockPersistenceRequest> requests,
+            CancellationToken ct = default)
+        {
+            ApplyCallCount++;
+            var results = new List<WarehouseStockPersistenceResult>(requests.Count);
+
+            lock (_lock)
+            {
+                foreach (WarehouseStockPersistenceRequest request in requests)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    if (FailingSkus.Contains(request.Sku))
+                    {
+                        results.Add(new WarehouseStockPersistenceResult(
+                            request,
+                            null,
+                            new InvalidOperationException("Simulated persistence failure.")));
+                        continue;
+                    }
+
+                    Data.RemoveAll(item => IsMatch(item, request));
+                    if (request.Operation == WarehouseStockMutationOperation.Clear)
+                    {
+                        results.Add(new WarehouseStockPersistenceResult(request, null, null));
+                        continue;
+                    }
+
+                    DateTime now = DateTime.UtcNow;
+                    var data = new WarehouseStockData
+                    {
+                        StoreAlias = request.StoreAlias,
+                        WarehouseKey = request.WarehouseKey,
+                        Sku = request.Sku,
+                        Balance = request.Balance.GetValueOrDefault(),
+                        CreateDate = request.ExistingData?.CreateDate ?? now,
+                        UpdateDate = now,
+                    };
+                    Data.Add(data);
+                    results.Add(new WarehouseStockPersistenceResult(request, data, null));
+                }
+            }
+
+            return Task.FromResult(new WarehouseStockPersistenceBatchResult(results, false));
+        }
+
+        public List<WarehouseStockData> Snapshot()
+        {
+            lock (_lock)
+            {
+                return Data.Select(item => new WarehouseStockData
+                {
+                    StoreAlias = item.StoreAlias,
+                    WarehouseKey = item.WarehouseKey,
+                    Sku = item.Sku,
+                    Balance = item.Balance,
+                    CreateDate = item.CreateDate,
+                    UpdateDate = item.UpdateDate,
+                }).ToList();
+            }
+        }
+
+        private static bool IsMatch(WarehouseStockData item, WarehouseStockPersistenceRequest request)
+        {
+            return string.Equals(item.StoreAlias, request.StoreAlias, StringComparison.OrdinalIgnoreCase)
+                && item.WarehouseKey == request.WarehouseKey
+                && string.Equals(item.Sku, request.Sku, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All Ekom settings live under the `Ekom` section in `appsettings.json`.
 
 ### Warehouse stock
 
-Warehouse stock is display-only inventory for U17 and U18. It does not change sellable stock, availability, reservations, or checkout deductions. Define warehouses on each published `ekmStore` node using the **Ekom Warehouse Editor** datatype. Visibility controls storefront display only; hidden warehouses can still receive balance updates. Warehouse balances are scoped by store alias, warehouse key, and a trimmed, case-insensitive SKU.
+Warehouse stock is display-only inventory for U17 and U18. It does not change sellable stock, availability, reservations, or checkout deductions. Define warehouses on each published `ekmStore` node using the **Ekom Warehouse Editor** datatype. Visibility controls storefront display only; hidden warehouses can still receive balance updates. Warehouse balances are scoped by store alias, warehouse key, and a trimmed, case-insensitive SKU. All storefront reads use an in-memory snapshot loaded during Ekom cache initialization and manual cache refreshes.
 
 Products and individual variants expose **Warehouse Stock** directly below **Stock Buffer**. These balances are persisted when the document is saved, using the same content-saving event flow as ordinary stock. Save a SKU before editing warehouse balances.
 
@@ -159,6 +159,7 @@ Use `Ekom.API.Warehouse` for storefront and integration access:
 ```csharp
 var warehouses = await Warehouse.Instance.GetWarehousesAsync("Store", ct);
 var balances = await Warehouse.Instance.GetAsync("Store", ["SKU-1", "SKU-2"], ct);
+var levels = await Warehouse.Instance.GetForSkuAsync("Store", "SKU-1", ct);
 
 await Warehouse.Instance.SetAsync(
     storeAlias: "Store",
@@ -166,9 +167,30 @@ await Warehouse.Instance.SetAsync(
     sku: "SKU-1",
     balance: 8m,
     ct: ct);
+
+await Warehouse.Instance.ClearAsync("Store", warehouseKey, "SKU-1", ct);
+
+var result = await Warehouse.Instance.UpdateAsync([
+    new WarehouseStockMutationRequest
+    {
+        StoreAlias = "Store",
+        WarehouseKey = warehouseKey,
+        Sku = "SKU-1",
+        Balance = 12m,
+    },
+    new WarehouseStockMutationRequest
+    {
+        StoreAlias = "Store",
+        WarehouseKey = secondaryWarehouseKey,
+        Sku = "SKU-1",
+        Operation = WarehouseStockMutationOperation.Clear,
+    },
+], ct);
 ```
 
-Warehouse balances can also be imported through `ImportProduct.WarehouseStock` and `ImportVariant.WarehouseStock`. Imported entries overwrite supplied balances; omitted entries are unchanged. Changing a SKU does not move balances to the new SKU.
+Sets whose balance is already cached are not written again and preserve their `UpdateDate`. Batch updates return inserted, updated, cleared, unchanged, and failed entries; validation and persistence failures are isolated per entry.
+
+Warehouse balances can also be imported through `ImportProduct.WarehouseStock` and `ImportVariant.WarehouseStock`. Set `Balance` to update an entry or `Clear` to `true` to remove it. Omitted entries are unchanged. Changing a SKU does not move balances to the new SKU.
 
 ### Catalog search overrides
 


### PR DESCRIPTION
## Summary
- add an atomic warehouse stock cache with coordinated refresh and write locking
- make warehouse reads cache-only and support explicit clear, changed-only updates, and per-entry batch results
- batch repository persistence and clean up duplicate normalized warehouse/SKU identities
- wire cache initialization and mutation handling into Umbraco, imports, and the warehouse stock editor
- add regression coverage, documentation, changelog notes, and regenerated U17/U18 editor assets

## Test Plan
- focused warehouse regression tests: 11 passed
- U17 and U18 .NET builds: passed with 0 errors
- U17 and U18 client `npm run typecheck`: passed
- U17 and U18 client `npm run build`: passed
- `git diff --check`: passed

## Notes
- deployment is single-instance; cross-instance cache synchronization is out of scope
- the full test suite still reports five pre-existing shared-configuration/price failures when run together; the affected test classes pass independently
