### PR TITLE
fix(discounts): handle missing ordered constraints

### DIFF
--- a/Ekom/CHANGELOG.md
+++ b/Ekom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+* **discounts:** treat missing constraints on legacy and custom discounts as unrestricted when creating ordered discounts.
+
 ### Features
 
 * **discounts:** add native product and variant `ekmDiscountPrice` support using the Ekom Price datatype, competing with content and event-added discounts while preserving original prices.

--- a/Ekom/Ekom.Core/Ekom/Models/OrderedObjects/OrderedDiscount.cs
+++ b/Ekom/Ekom.Core/Ekom/Models/OrderedObjects/OrderedDiscount.cs
@@ -19,7 +19,7 @@ public class OrderedDiscount : IComparable<IDiscount>, IDiscount
         DiscountType type,
         List<string> discountItems,
         List<string> excludeDiscountItems,
-        Constraints constraints,
+        Constraints? constraints,
         bool hasMasterStock,
         bool globalDiscount)
     {
@@ -30,7 +30,7 @@ public class OrderedDiscount : IComparable<IDiscount>, IDiscount
         Amount = amount;
         Title = title;
         Type = type;
-        Constraints = constraints;
+        Constraints = constraints ?? new Constraints();
         HasMasterStock = hasMasterStock;
         GlobalDiscount = globalDiscount;
     }
@@ -48,7 +48,9 @@ public class OrderedDiscount : IComparable<IDiscount>, IDiscount
         ExcludeDiscountItems = discount.ExcludeDiscountItems;
         Amount = discount.Amount;
         Type = discount.Type;
-        Constraints = new Constraints(discount.Constraints);
+        Constraints = discount.Constraints is { } constraints
+            ? new Constraints(constraints)
+            : new Constraints();
         HasMasterStock = discount.HasMasterStock;
         GlobalDiscount = discount.GlobalDiscount;
     }

--- a/Ekom/Tests/Ekom.Tests/Tests/DiscountCalculationTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/DiscountCalculationTests.cs
@@ -65,6 +65,31 @@ public class DiscountCalculationTests
     }
 
     [Fact]
+    public void OrderedDiscount_LegacyNullConstraintsAreNormalizedAsUnrestricted()
+    {
+        var legacyDiscount = new OrderedDiscount(
+            Guid.NewGuid(),
+            "Legacy discount",
+            false,
+            10m,
+            DiscountType.Fixed,
+            [],
+            [],
+            null,
+            false,
+            false);
+
+        var result = new OrderedDiscount(legacyDiscount);
+
+        Assert.Empty(legacyDiscount.Constraints.StartRanges);
+        Assert.Empty(legacyDiscount.Constraints.EndRanges);
+        Assert.Empty(legacyDiscount.Constraints.CountriesInZone);
+        Assert.Empty(result.Constraints.StartRanges);
+        Assert.Empty(result.Constraints.EndRanges);
+        Assert.Empty(result.Constraints.CountriesInZone);
+    }
+
+    [Fact]
     public void SelectDiscount_UsesMonetaryValueForMixedDiscountTypes()
     {
         using var configurationScope = new ConfigurationScope();

--- a/Ekom/Tests/Ekom.Tests/Tests/NativeDiscountPriceTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/NativeDiscountPriceTests.cs
@@ -163,7 +163,7 @@ public class NativeDiscountPriceTests
         customer.SetupGet(x => x.Key).Returns(Guid.NewGuid());
         customer.SetupGet(x => x.Type).Returns(customerType);
         customer.SetupGet(x => x.Amount).Returns(customerAmount);
-        customer.SetupGet(x => x.Constraints).Returns(new Constraints());
+        customer.SetupGet(x => x.Constraints).Returns((IConstraints)null!);
         int calls = 0;
         Guid nativeKey = Guid.Empty;
         fixture.Events.AfterApplicableDiscountsAsync += (_, args) =>


### PR DESCRIPTION
## Summary
- normalize null discount constraints to empty, unrestricted constraints when deserializing or cloning `OrderedDiscount`
- preserve compatibility with legacy orders and custom/event-provided discounts that use null constraints to mean unrestricted
- add regression coverage for legacy ordered discounts and event-added product discounts
- document the fix in the changelog

## Test Plan
- focused discount tests: 45 passed
- U10 build: passed with 0 errors
- `ConfigurationTests` independently: 1 passed
- `PriceTests` independently: 288 passed
- `git diff --check`: passed

## Notes
- the complete test run reported 489 passed and 4 existing shared-state failures in `ConfigurationTests` and `PriceTests`; both affected test classes pass independently
