### PR TITLE
feat(algolia): suppress incremental indexing

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaIndexingScopeTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaIndexingScopeTests.cs
@@ -1,0 +1,62 @@
+using Ekom.Algolia.Indexing;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class AlgoliaIndexingScopeTests
+{
+    [Fact]
+    public void Suppress_SetsIsSuppressedUntilTheOutermostScopeIsDisposed()
+    {
+        Assert.False(AlgoliaIndexingScope.IsSuppressed);
+
+        using (AlgoliaIndexingScope.Suppress())
+        {
+            Assert.True(AlgoliaIndexingScope.IsSuppressed);
+
+            using (AlgoliaIndexingScope.Suppress())
+            {
+                Assert.True(AlgoliaIndexingScope.IsSuppressed);
+            }
+
+            Assert.True(AlgoliaIndexingScope.IsSuppressed);
+        }
+
+        Assert.False(AlgoliaIndexingScope.IsSuppressed);
+    }
+
+    [Fact]
+    public void Suppress_DisposeCanBeCalledMultipleTimes()
+    {
+        var scope = AlgoliaIndexingScope.Suppress();
+
+        scope.Dispose();
+        scope.Dispose();
+
+        Assert.False(AlgoliaIndexingScope.IsSuppressed);
+    }
+
+    [Fact]
+    public async Task Suppress_FlowsToTasksStartedWithinTheScope()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task task;
+        using (AlgoliaIndexingScope.Suppress())
+        {
+            task = Task.Run(async () =>
+            {
+                started.SetResult();
+                await release.Task;
+                Assert.True(AlgoliaIndexingScope.IsSuppressed);
+            });
+
+            await started.Task;
+        }
+
+        Assert.False(AlgoliaIndexingScope.IsSuppressed);
+        release.SetResult();
+        await task;
+    }
+}

--- a/Plugins/Ekom.Algolia/CHANGELOG.md
+++ b/Plugins/Ekom.Algolia/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **algolia:** add optional variant-level product indexing for SKU search.
 * **algolia:** optionally update indexed availability and stock after stock changes.
+* **algolia:** add scoped suppression for automatic incremental indexing during bulk changes.
 
 ### Bug Fixes
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaIndexingScope.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaIndexingScope.cs
@@ -1,0 +1,37 @@
+namespace Ekom.Algolia.Indexing;
+
+/// <summary>
+/// Suppresses automatic incremental Algolia indexing for the current asynchronous execution flow.
+/// </summary>
+public static class AlgoliaIndexingScope
+{
+    private static readonly AsyncLocal<int> Depth = new();
+
+    /// <summary>
+    /// Gets a value indicating whether automatic incremental Algolia indexing is suppressed.
+    /// </summary>
+    public static bool IsSuppressed => Depth.Value > 0;
+
+    /// <summary>
+    /// Suppresses automatic incremental Algolia indexing until the returned scope is disposed.
+    /// </summary>
+    public static IDisposable Suppress()
+    {
+        Depth.Value++;
+        return new Scope();
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            Depth.Value--;
+        }
+    }
+}

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -325,6 +325,19 @@ Filters apply to full rebuilds and incremental product indexing. When a filter e
 
 Product and category indexing is triggered from Umbraco content notifications for `ekmProduct` and `ekmCategory`.
 
+To avoid incremental indexing during a bulk import or a batch of direct `IContentService` changes, wrap the work in an `AlgoliaIndexingScope`. The scope suppresses notification-driven indexing and stock availability updates only for its current asynchronous execution flow. Dispose it before starting a full rebuild.
+
+```csharp
+using Ekom.Algolia.Indexing;
+
+using (AlgoliaIndexingScope.Suppress())
+{
+    importService.FullSync(data);
+}
+
+fullIndexRebuildCoordinator.TryStart();
+```
+
 Search requests use `SearchApiKey`. Indexing, settings updates, replicas, delete operations, and query suggestion provisioning use `AdminApiKey`.
 
 ```json

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaEkomEvents.cs
@@ -101,7 +101,7 @@ internal sealed class AlgoliaEkomEvents : IComponent
 
     private async Task OnStockChangedAsync(object sender, StockChangedEventArgs args, CancellationToken ct)
     {
-        if (!_options.Enabled || !_options.Indexing.Enabled)
+        if (AlgoliaIndexingScope.IsSuppressed || !_options.Enabled || !_options.Indexing.Enabled)
             return;
 
         using var scope = _scopeFactory.CreateScope();

--- a/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaUmbracoNotifications.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/Shared/AlgoliaUmbracoNotifications.cs
@@ -61,6 +61,9 @@ internal sealed class AlgoliaUmbracoNotifications :
 
     public async Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
     {
+        if (AlgoliaIndexingScope.IsSuppressed)
+            return;
+
         _logger.LogDebug("Algolia received ContentPublishedNotification with {Count} published entities.", notification.PublishedEntities.Count());
 
         foreach (var entity in notification.PublishedEntities)
@@ -69,6 +72,9 @@ internal sealed class AlgoliaUmbracoNotifications :
 
     public async Task HandleAsync(ContentUnpublishedNotification notification, CancellationToken cancellationToken)
     {
+        if (AlgoliaIndexingScope.IsSuppressed)
+            return;
+
         _logger.LogDebug("Algolia received ContentUnpublishedNotification with {Count} unpublished entities.", notification.UnpublishedEntities.Count());
 
         foreach (var entity in notification.UnpublishedEntities)
@@ -77,6 +83,9 @@ internal sealed class AlgoliaUmbracoNotifications :
 
     public async Task HandleAsync(ContentMovedToRecycleBinNotification notification, CancellationToken cancellationToken)
     {
+        if (AlgoliaIndexingScope.IsSuppressed)
+            return;
+
         _logger.LogDebug("Algolia received ContentMovedToRecycleBinNotification with {Count} entities.", notification.MoveInfoCollection.Count());
 
         foreach (var entity in notification.MoveInfoCollection.Select(x => x.Entity))
@@ -85,6 +94,9 @@ internal sealed class AlgoliaUmbracoNotifications :
 
     public async Task HandleAsync(ContentDeletedNotification notification, CancellationToken cancellationToken)
     {
+        if (AlgoliaIndexingScope.IsSuppressed)
+            return;
+
         _logger.LogDebug("Algolia received ContentDeletedNotification with {Count} deleted entities.", notification.DeletedEntities.Count());
 
         foreach (var entity in notification.DeletedEntities)


### PR DESCRIPTION
## Summary
- add a nested async-flow scope for suppressing automatic Algolia incremental indexing
- skip content notification indexing and stock availability updates while the scope is active
- document bulk-import usage and cover scope lifetime and task-flow behavior

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaIndexingScopeTests"`
- `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj"`
- `dotnet build "Plugins/Ekom.Algolia/U18/Ekom.Algolia.U18.csproj"`
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj"` *(4 existing unrelated test failures: DiscountCalculationTests, OrderInfoTests, ConfigurationTests, and PriceTests)*
