### PR TITLE
fix(algolia): coordinate store rebuilds

### DIFF
--- a/Ekom/Tests/Ekom.Tests/Tests/AlgoliaFullIndexRebuildCoordinatorTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/AlgoliaFullIndexRebuildCoordinatorTests.cs
@@ -49,11 +49,110 @@ public class AlgoliaFullIndexRebuildCoordinatorTests
         Assert.True(await WaitForStartAsync(coordinator));
     }
 
+    [Fact]
+    public async Task TryStartStore_RejectsDuplicateStoreUntilCurrentRunCompletes()
+    {
+        var productService = new BlockingProductIndexService();
+        var categoryService = new BlockingCategoryIndexService();
+        var coordinator = CreateCoordinator(productService, categoryService);
+
+        Assert.True(coordinator.TryStartStore("Store"));
+        Assert.False(coordinator.TryStartStore("store"));
+
+        productService.CompleteStore("Store");
+        categoryService.CompleteStore("Store");
+
+        Assert.True(await WaitForStartStoreAsync(coordinator, "Store"));
+        productService.CompleteStore("Store");
+        categoryService.CompleteStore("Store");
+    }
+
+    [Fact]
+    public async Task TryStartStore_AllowsDifferentStoresToRunConcurrently()
+    {
+        var productService = new BlockingProductIndexService();
+        var categoryService = new BlockingCategoryIndexService();
+        var coordinator = CreateCoordinator(productService, categoryService);
+
+        Assert.True(coordinator.TryStartStore("StoreA"));
+        Assert.True(coordinator.TryStartStore("StoreB"));
+
+        productService.CompleteStore("StoreA");
+        categoryService.CompleteStore("StoreA");
+        productService.CompleteStore("StoreB");
+        categoryService.CompleteStore("StoreB");
+
+        Assert.True(await WaitForStartStoreAsync(coordinator, "StoreA"));
+        productService.CompleteStore("StoreA");
+        categoryService.CompleteStore("StoreA");
+    }
+
+    [Fact]
+    public async Task TryStart_RejectsFullRebuildWhileStoreRebuildIsActive()
+    {
+        var productService = new BlockingProductIndexService();
+        var categoryService = new BlockingCategoryIndexService();
+        var contentService = new BlockingContentIndexService();
+        var coordinator = CreateCoordinator(productService, categoryService, contentService);
+
+        Assert.True(coordinator.TryStartStore("Store"));
+        Assert.False(coordinator.TryStart());
+
+        productService.CompleteStore("Store");
+        categoryService.CompleteStore("Store");
+
+        Assert.True(await WaitForStartAsync(coordinator));
+        productService.Complete();
+        categoryService.Complete();
+        contentService.Complete();
+    }
+
+    [Fact]
+    public void TryStartStore_RejectsStoreRebuildWhileFullRebuildIsActive()
+    {
+        var productService = new BlockingProductIndexService();
+        var categoryService = new BlockingCategoryIndexService();
+        var contentService = new BlockingContentIndexService();
+        var coordinator = CreateCoordinator(productService, categoryService, contentService);
+
+        Assert.True(coordinator.TryStart());
+        Assert.False(coordinator.TryStartStore("Store"));
+
+        productService.Complete();
+        categoryService.Complete();
+        contentService.Complete();
+    }
+
+    private static AlgoliaFullIndexRebuildCoordinator CreateCoordinator(
+        IAlgoliaProductIndexService productService,
+        IAlgoliaCategoryIndexService categoryService,
+        IAlgoliaContentIndexService? contentService = null)
+        => new(
+            productService,
+            categoryService,
+            contentService ?? new BlockingContentIndexService(),
+            NullLogger<AlgoliaFullIndexRebuildCoordinator>.Instance);
+
     private static async Task<bool> WaitForStartAsync(IAlgoliaFullIndexRebuildCoordinator coordinator)
     {
         for (var attempt = 0; attempt < 50; attempt++)
         {
             if (coordinator.TryStart())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> WaitForStartStoreAsync(IAlgoliaFullIndexRebuildCoordinator coordinator, string storeAlias)
+    {
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            if (coordinator.TryStartStore(storeAlias))
             {
                 return true;
             }
@@ -71,10 +170,28 @@ public class AlgoliaFullIndexRebuildCoordinatorTests
         public Task EnqueueProductAsync(string storeAlias, Guid productKey, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
         public Task EnqueueProductsAsync(string storeAlias, IReadOnlyCollection<Guid> productKeys, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
         public Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildStoreAndWaitAsync(string storeAlias, CancellationToken ct = default) => GetStoreCompletion(storeAlias).Task;
         public Task RebuildAllAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task RebuildAllAndWaitAsync(CancellationToken ct = default) => _completion.Task;
         public void Complete() => _completion.TrySetResult();
+        public void CompleteStore(string storeAlias) => GetStoreCompletion(storeAlias).TrySetResult();
         public void Fail() => _completion.TrySetException(new InvalidOperationException());
+
+        private readonly Dictionary<string, TaskCompletionSource> _storeCompletions = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _storeCompletionsLock = new();
+
+        private TaskCompletionSource GetStoreCompletion(string storeAlias)
+        {
+            lock (_storeCompletionsLock)
+            {
+                if (_storeCompletions.TryGetValue(storeAlias, out var completion))
+                    return completion;
+
+                completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _storeCompletions[storeAlias] = completion;
+                return completion;
+            }
+        }
     }
 
     private sealed class BlockingCategoryIndexService : IAlgoliaCategoryIndexService
@@ -84,9 +201,27 @@ public class AlgoliaFullIndexRebuildCoordinatorTests
         public Task EnqueueCategoryAsync(string storeAlias, Guid categoryKey, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
         public Task EnqueueCategoriesAsync(string storeAlias, IReadOnlyCollection<Guid> categoryKeys, bool isPublished, CancellationToken ct = default) => Task.CompletedTask;
         public Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RebuildStoreAndWaitAsync(string storeAlias, CancellationToken ct = default) => GetStoreCompletion(storeAlias).Task;
         public Task RebuildAllAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task RebuildAllAndWaitAsync(CancellationToken ct = default) => _completion.Task;
         public void Complete() => _completion.TrySetResult();
+        public void CompleteStore(string storeAlias) => GetStoreCompletion(storeAlias).TrySetResult();
+
+        private readonly Dictionary<string, TaskCompletionSource> _storeCompletions = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _storeCompletionsLock = new();
+
+        private TaskCompletionSource GetStoreCompletion(string storeAlias)
+        {
+            lock (_storeCompletionsLock)
+            {
+                if (_storeCompletions.TryGetValue(storeAlias, out var completion))
+                    return completion;
+
+                completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _storeCompletions[storeAlias] = completion;
+                return completion;
+            }
+        }
     }
 
     private sealed class BlockingContentIndexService : IAlgoliaContentIndexService

--- a/Plugins/Ekom.Algolia/CHANGELOG.md
+++ b/Plugins/Ekom.Algolia/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **algolia:** add optional variant-level product indexing for SKU search.
 * **algolia:** optionally update indexed availability and stock after stock changes.
+* **algolia:** prevent concurrent rebuilds for the same store.
 
 ### Bug Fixes
 

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaCategoryIndexService.cs
@@ -8,6 +8,7 @@ public interface IAlgoliaCategoryIndexService
     Task EnqueueCategoryAsync(string storeAlias, Guid categoryKey, bool isPublished, CancellationToken ct = default);
     Task EnqueueCategoriesAsync(string storeAlias, IReadOnlyCollection<Guid> categoryKeys, bool isPublished, CancellationToken ct = default);
     Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default);
+    Task RebuildStoreAndWaitAsync(string storeAlias, CancellationToken ct = default);
     Task RebuildAllAsync(CancellationToken ct = default);
     Task RebuildAllAndWaitAsync(CancellationToken ct = default);
 }
@@ -91,6 +92,25 @@ internal sealed class AlgoliaCategoryIndexService : IAlgoliaCategoryIndexService
         }, CancellationToken.None);
 
         return Task.CompletedTask;
+    }
+
+    public async Task RebuildStoreAndWaitAsync(string storeAlias, CancellationToken ct = default)
+    {
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Categories)
+            return;
+
+        if (string.IsNullOrWhiteSpace(storeAlias))
+            return;
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var job = new AlgoliaCategoryIndexJob(
+            AlgoliaCategoryIndexJobType.RebuildStore,
+            storeAlias,
+            Array.Empty<Guid>(),
+            completion);
+
+        await _queue.EnqueueAsync(job, ct).ConfigureAwait(false);
+        await completion.Task.ConfigureAwait(false);
     }
 
     public Task RebuildAllAsync(CancellationToken ct = default)

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaFullIndexRebuildCoordinator.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaFullIndexRebuildCoordinator.cs
@@ -5,6 +5,7 @@ namespace Ekom.Algolia.Indexing;
 public interface IAlgoliaFullIndexRebuildCoordinator
 {
     bool TryStart();
+    bool TryStartStore(string storeAlias);
 }
 
 public sealed class AlgoliaFullIndexRebuildCoordinator : IAlgoliaFullIndexRebuildCoordinator
@@ -13,7 +14,9 @@ public sealed class AlgoliaFullIndexRebuildCoordinator : IAlgoliaFullIndexRebuil
     private readonly IAlgoliaCategoryIndexService _categoryIndexService;
     private readonly IAlgoliaContentIndexService _contentIndexService;
     private readonly ILogger<AlgoliaFullIndexRebuildCoordinator> _logger;
-    private int _isRunning;
+    private readonly HashSet<string> _activeStoreRebuilds = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _sync = new();
+    private bool _isFullRebuildRunning;
 
     public AlgoliaFullIndexRebuildCoordinator(
         IAlgoliaProductIndexService productIndexService,
@@ -29,16 +32,36 @@ public sealed class AlgoliaFullIndexRebuildCoordinator : IAlgoliaFullIndexRebuil
 
     public bool TryStart()
     {
-        if (Interlocked.CompareExchange(ref _isRunning, 1, 0) != 0)
+        lock (_sync)
         {
-            return false;
+            if (_isFullRebuildRunning || _activeStoreRebuilds.Count > 0)
+                return false;
+
+            _isFullRebuildRunning = true;
         }
 
-        _ = Task.Run(RunAsync, CancellationToken.None);
+        _ = Task.Run(RunFullAsync, CancellationToken.None);
         return true;
     }
 
-    private async Task RunAsync()
+    public bool TryStartStore(string storeAlias)
+    {
+        if (string.IsNullOrWhiteSpace(storeAlias))
+            return false;
+
+        storeAlias = storeAlias.Trim();
+
+        lock (_sync)
+        {
+            if (_isFullRebuildRunning || !_activeStoreRebuilds.Add(storeAlias))
+                return false;
+        }
+
+        _ = Task.Run(() => RunStoreAsync(storeAlias), CancellationToken.None);
+        return true;
+    }
+
+    private async Task RunFullAsync()
     {
         try
         {
@@ -55,7 +78,29 @@ public sealed class AlgoliaFullIndexRebuildCoordinator : IAlgoliaFullIndexRebuil
         }
         finally
         {
-            Volatile.Write(ref _isRunning, 0);
+            lock (_sync)
+                _isFullRebuildRunning = false;
+        }
+    }
+
+    private async Task RunStoreAsync(string storeAlias)
+    {
+        try
+        {
+            await Task.WhenAll(
+                _productIndexService.RebuildStoreAndWaitAsync(storeAlias),
+                _categoryIndexService.RebuildStoreAndWaitAsync(storeAlias)).ConfigureAwait(false);
+
+            _logger.LogInformation("Algolia manual store reindex completed for store {Store}.", storeAlias);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Algolia manual store reindex failed for store {Store}.", storeAlias);
+        }
+        finally
+        {
+            lock (_sync)
+                _activeStoreRebuilds.Remove(storeAlias);
         }
     }
 }

--- a/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexService.cs
+++ b/Plugins/Ekom.Algolia/Indexing/AlgoliaProductIndexService.cs
@@ -8,6 +8,7 @@ public interface IAlgoliaProductIndexService
     Task EnqueueProductAsync(string storeAlias, Guid productKey, bool isPublished, CancellationToken ct = default);
     Task EnqueueProductsAsync(string storeAlias, IReadOnlyCollection<Guid> productKeys, bool isPublished, CancellationToken ct = default);
     Task RebuildStoreAsync(string storeAlias, CancellationToken ct = default);
+    Task RebuildStoreAndWaitAsync(string storeAlias, CancellationToken ct = default);
     Task RebuildAllAsync(CancellationToken ct = default);
     Task RebuildAllAndWaitAsync(CancellationToken ct = default);
 }
@@ -133,6 +134,25 @@ internal sealed class AlgoliaProductIndexService : IAlgoliaProductIndexService
         }, CancellationToken.None);
 
         return Task.CompletedTask;
+    }
+
+    public async Task RebuildStoreAndWaitAsync(string storeAlias, CancellationToken ct = default)
+    {
+        if (!_options.Enabled || !_options.Indexing.Enabled || !_options.Indexing.Products)
+            return;
+
+        if (string.IsNullOrWhiteSpace(storeAlias))
+            return;
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var job = new AlgoliaProductIndexJob(
+            AlgoliaProductIndexJobType.RebuildStore,
+            storeAlias,
+            Array.Empty<Guid>(),
+            completion);
+
+        await _queue.EnqueueAsync(job, ct).ConfigureAwait(false);
+        await completion.Task.ConfigureAwait(false);
     }
 
     public Task RebuildAllAsync(CancellationToken ct = default)

--- a/Plugins/Ekom.Algolia/README.md
+++ b/Plugins/Ekom.Algolia/README.md
@@ -758,7 +758,7 @@ Rebuild all configured store indexes:
 POST /umbraco/backoffice/api/EkomAlgoliaBackoffice/RebuildIndexes
 ```
 
-Only one full rebuild can run per application instance. A concurrent full-rebuild request returns `409 Conflict` until the active product, category, and content rebuilds finish.
+Only one full rebuild can run per application instance. A concurrent full-rebuild request returns `409 Conflict` until the active product, category, and content rebuilds finish. A store rebuild is also rejected with `409 Conflict` while a full rebuild or another rebuild for that store is active. Rebuilds for different stores can run concurrently.
 
 Rebuild one store:
 

--- a/Plugins/Ekom.Algolia/Umbraco/U10/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U10/AlgoliaBackofficeController.cs
@@ -8,19 +8,13 @@ namespace Ekom.Algolia.Controllers;
 public class EkomAlgoliaBackofficeController : UmbracoAuthorizedApiController
 {
     private readonly IAlgoliaFullIndexRebuildCoordinator _fullIndexRebuildCoordinator;
-    private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
-    private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
         IAlgoliaFullIndexRebuildCoordinator fullIndexRebuildCoordinator,
-        IAlgoliaProductIndexService algoliaProductIndexService,
-        IAlgoliaCategoryIndexService algoliaCategoryIndexService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
         _fullIndexRebuildCoordinator = fullIndexRebuildCoordinator;
-        _algoliaProductIndexService = algoliaProductIndexService;
-        _algoliaCategoryIndexService = algoliaCategoryIndexService;
         _logger = logger;
     }
 
@@ -38,13 +32,13 @@ public class EkomAlgoliaBackofficeController : UmbracoAuthorizedApiController
 
     [HttpGet]
     [HttpPost]
-    public async Task<IActionResult> RebuildStoreIndexesAsync([FromQuery] string storeAlias, CancellationToken ct = default)
+    public IActionResult RebuildStoreIndexesAsync([FromQuery] string storeAlias)
     {
         if (string.IsNullOrWhiteSpace(storeAlias))
             return BadRequest(new { error = "Store alias is required." });
 
-        await _algoliaProductIndexService.RebuildStoreAsync(storeAlias, ct).ConfigureAwait(false);
-        await _algoliaCategoryIndexService.RebuildStoreAsync(storeAlias, ct).ConfigureAwait(false);
+        if (!_fullIndexRebuildCoordinator.TryStartStore(storeAlias))
+            return Conflict(new { error = $"An Algolia reindex is already running for store '{storeAlias}'." });
 
         _logger.LogInformation("Algolia manual reindex requested for store {StoreAlias}.", storeAlias);
 

--- a/Plugins/Ekom.Algolia/Umbraco/U17/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U17/AlgoliaBackofficeController.cs
@@ -12,21 +12,15 @@ namespace Ekom.Algolia.Controllers;
 public class EkomAlgoliaBackofficeController : ControllerBase
 {
     private readonly IAlgoliaFullIndexRebuildCoordinator _fullIndexRebuildCoordinator;
-    private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
-    private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
     private readonly ISecurityService _securityService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
         IAlgoliaFullIndexRebuildCoordinator fullIndexRebuildCoordinator,
-        IAlgoliaProductIndexService algoliaProductIndexService,
-        IAlgoliaCategoryIndexService algoliaCategoryIndexService,
         ISecurityService securityService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
         _fullIndexRebuildCoordinator = fullIndexRebuildCoordinator;
-        _algoliaProductIndexService = algoliaProductIndexService;
-        _algoliaCategoryIndexService = algoliaCategoryIndexService;
         _securityService = securityService;
         _logger = logger;
     }
@@ -48,7 +42,7 @@ public class EkomAlgoliaBackofficeController : ControllerBase
 
     [HttpGet("RebuildStoreIndexes")]
     [HttpPost("RebuildStoreIndexes")]
-    public async Task<IActionResult> RebuildStoreIndexesAsync([FromQuery] string storeAlias, CancellationToken ct = default)
+    public IActionResult RebuildStoreIndexesAsync([FromQuery] string storeAlias)
     {
         if (!_securityService.IsCurrentUserAdmin())
             return Forbid();
@@ -56,8 +50,8 @@ public class EkomAlgoliaBackofficeController : ControllerBase
         if (string.IsNullOrWhiteSpace(storeAlias))
             return BadRequest(new { error = "Store alias is required." });
 
-        await _algoliaProductIndexService.RebuildStoreAsync(storeAlias, ct).ConfigureAwait(false);
-        await _algoliaCategoryIndexService.RebuildStoreAsync(storeAlias, ct).ConfigureAwait(false);
+        if (!_fullIndexRebuildCoordinator.TryStartStore(storeAlias))
+            return Conflict(new { error = $"An Algolia reindex is already running for store '{storeAlias}'." });
 
         _logger.LogInformation("Algolia manual reindex requested for store {StoreAlias}.", storeAlias);
 

--- a/Plugins/Ekom.Algolia/Umbraco/U18/AlgoliaBackofficeController.cs
+++ b/Plugins/Ekom.Algolia/Umbraco/U18/AlgoliaBackofficeController.cs
@@ -12,21 +12,15 @@ namespace Ekom.Algolia.Controllers;
 public class EkomAlgoliaBackofficeController : ControllerBase
 {
     private readonly IAlgoliaFullIndexRebuildCoordinator _fullIndexRebuildCoordinator;
-    private readonly IAlgoliaProductIndexService _algoliaProductIndexService;
-    private readonly IAlgoliaCategoryIndexService _algoliaCategoryIndexService;
     private readonly ISecurityService _securityService;
     private readonly ILogger<EkomAlgoliaBackofficeController> _logger;
 
     public EkomAlgoliaBackofficeController(
         IAlgoliaFullIndexRebuildCoordinator fullIndexRebuildCoordinator,
-        IAlgoliaProductIndexService algoliaProductIndexService,
-        IAlgoliaCategoryIndexService algoliaCategoryIndexService,
         ISecurityService securityService,
         ILogger<EkomAlgoliaBackofficeController> logger)
     {
         _fullIndexRebuildCoordinator = fullIndexRebuildCoordinator;
-        _algoliaProductIndexService = algoliaProductIndexService;
-        _algoliaCategoryIndexService = algoliaCategoryIndexService;
         _securityService = securityService;
         _logger = logger;
     }
@@ -48,7 +42,7 @@ public class EkomAlgoliaBackofficeController : ControllerBase
 
     [HttpGet("RebuildStoreIndexes")]
     [HttpPost("RebuildStoreIndexes")]
-    public async Task<IActionResult> RebuildStoreIndexesAsync([FromQuery] string storeAlias, CancellationToken ct = default)
+    public IActionResult RebuildStoreIndexesAsync([FromQuery] string storeAlias)
     {
         if (!_securityService.IsCurrentUserAdmin())
             return Forbid();
@@ -56,8 +50,8 @@ public class EkomAlgoliaBackofficeController : ControllerBase
         if (string.IsNullOrWhiteSpace(storeAlias))
             return BadRequest(new { error = "Store alias is required." });
 
-        await _algoliaProductIndexService.RebuildStoreAsync(storeAlias, ct).ConfigureAwait(false);
-        await _algoliaCategoryIndexService.RebuildStoreAsync(storeAlias, ct).ConfigureAwait(false);
+        if (!_fullIndexRebuildCoordinator.TryStartStore(storeAlias))
+            return Conflict(new { error = $"An Algolia reindex is already running for store '{storeAlias}'." });
 
         _logger.LogInformation("Algolia manual reindex requested for store {StoreAlias}.", storeAlias);
 


### PR DESCRIPTION
## Summary
- coordinate full and store-specific Algolia rebuild requests
- reject duplicate rebuilds for the same store while allowing different stores to rebuild concurrently
- route backoffice store rebuilds through the coordinator and wait for product/category job completion before releasing the store

## Test Plan
- `dotnet test "Ekom/Tests/Ekom.Tests/Ekom.Tests.csproj" --filter "FullyQualifiedName~AlgoliaFullIndexRebuildCoordinatorTests"`
- `dotnet build "Plugins/Ekom.Algolia/Ekom.Algolia.csproj"`
- `dotnet build "Plugins/Ekom.Algolia/U18/Ekom.Algolia.U18.csproj"`
