### PR TITLE
fix(backoffice): filter editor stores by category disable state

### DIFF
--- a/Ekom/CHANGELOG.md
+++ b/Ekom/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* **backoffice:** keep stores available when products are disabled so their values can still be edited; store selectors, node languages, warehouse editors, and the variant manager now respect only category disable settings on the current node and its ancestors.
 * **discounts:** treat missing constraints on legacy and custom discounts as unrestricted when creating ordered discounts.
 
 ### Features

--- a/Ekom/Ekom.Core/Ekom/Controllers/EkomBackofficeApiController.cs
+++ b/Ekom/Ekom.Core/Ekom/Controllers/EkomBackofficeApiController.cs
@@ -188,40 +188,7 @@ public class EkomBackofficeApiController : ControllerBase
     private IEnumerable<IStore> FilterEnabledStores(UmbracoContent node, IEnumerable<IStore> allStores)
     {
         var ancestors = _nodeService.GetAllCatalogAncestors(node);
-        var disabledAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var result = new List<IStore>();
-
-        foreach (var store in allStores)
-        {
-            var alias = store.Alias;
-
-            // First check if this store is disabled on the node itself
-            var isSelfDisabled = node.Properties.GetValue("disable", alias).IsBoolean();
-            if (isSelfDisabled)
-            {
-                disabledAliases.Add(alias);
-                continue;
-            }
-
-            // Skip ancestor check if already disabled
-            bool isDisabledInAncestors = false;
-            foreach (var ancestor in ancestors)
-            {
-                if (ancestor.Properties.GetValue("disable", alias).IsBoolean())
-                {
-                    isDisabledInAncestors = true;
-                    disabledAliases.Add(alias);
-                    break;
-                }
-            }
-
-            if (!isDisabledInAncestors)
-            {
-                result.Add(store);
-            }
-        }
-
-        return result;
+        return BackofficeStoreAvailability.FilterEnabledStores(node, ancestors, allStores);
     }
 
     /// <summary>

--- a/Ekom/Ekom.Core/Ekom/Utilities/BackofficeStoreAvailability.cs
+++ b/Ekom/Ekom.Core/Ekom/Utilities/BackofficeStoreAvailability.cs
@@ -1,0 +1,32 @@
+using Ekom.Models;
+
+namespace Ekom.Utilities;
+
+internal static class BackofficeStoreAvailability
+{
+    internal static IEnumerable<IStore> FilterEnabledStores(
+        UmbracoContent node,
+        IEnumerable<UmbracoContent> ancestors,
+        IEnumerable<IStore> allStores)
+    {
+        var stores = new List<IStore>();
+
+        foreach (var store in allStores)
+        {
+            if (IsCategoryDisabled(node, store.Alias)
+                || ancestors.Any(ancestor => IsCategoryDisabled(ancestor, store.Alias)))
+            {
+                continue;
+            }
+
+            stores.Add(store);
+        }
+
+        return stores;
+    }
+
+    // Product disable values must remain editable in every category-enabled store.
+    private static bool IsCategoryDisabled(UmbracoContent node, string storeAlias) =>
+        node.ContentTypeAlias == "ekmCategory"
+        && node.Properties.GetValue("disable", storeAlias).IsBoolean();
+}

--- a/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/VariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U10/VariantApp/Services/VariantAppService.cs
@@ -584,26 +584,7 @@ internal sealed class VariantAppService : IVariantAppService
         }
 
         var ancestors = _nodeService.GetAllCatalogAncestors(node);
-        var stores = new List<IStore>();
-
-        foreach (var store in allStores)
-        {
-            var alias = store.Alias;
-
-            if (node.Properties.GetValue("disable", alias).IsBoolean())
-            {
-                continue;
-            }
-
-            if (ancestors.Any(ancestor => ancestor.Properties.GetValue("disable", alias).IsBoolean()))
-            {
-                continue;
-            }
-
-            stores.Add(store);
-        }
-
-        return stores;
+        return BackofficeStoreAvailability.FilterEnabledStores(node, ancestors, allStores);
     }
 
     private IReadOnlyList<UmbracoLanguage> LoadVariantLanguages(IReadOnlyList<VariantManagerStore> stores)

--- a/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/VariantAppService.cs
+++ b/Ekom/Ekom.Umbraco/Ekom.U17/VariantApp/Services/VariantAppService.cs
@@ -596,26 +596,7 @@ internal sealed class VariantAppService : IVariantAppService
         }
 
         var ancestors = _nodeService.GetAllCatalogAncestors(node);
-        var stores = new List<IStore>();
-
-        foreach (var store in allStores)
-        {
-            var alias = store.Alias;
-
-            if (node.Properties.GetValue("disable", alias).IsBoolean())
-            {
-                continue;
-            }
-
-            if (ancestors.Any(ancestor => ancestor.Properties.GetValue("disable", alias).IsBoolean()))
-            {
-                continue;
-            }
-
-            stores.Add(store);
-        }
-
-        return stores;
+        return BackofficeStoreAvailability.FilterEnabledStores(node, ancestors, allStores);
     }
 
     private IReadOnlyList<UmbracoLanguage> LoadVariantLanguages(IReadOnlyList<VariantManagerStore> stores)

--- a/Ekom/Tests/Ekom.Tests/Tests/BackofficeStoreAvailabilityTests.cs
+++ b/Ekom/Tests/Ekom.Tests/Tests/BackofficeStoreAvailabilityTests.cs
@@ -1,0 +1,115 @@
+using Ekom.Models;
+using Ekom.Utilities;
+using Moq;
+using Xunit;
+
+namespace Ekom.Tests.Tests;
+
+public class BackofficeStoreAvailabilityTests
+{
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("y", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("Enable", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("Y", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void CurrentCategoryPreservesDisableTruthConversion(string? disable, bool disabled)
+    {
+        var store = CreateStore("is");
+        var node = CreateNode("ekmCategory", disable);
+
+        var result = BackofficeStoreAvailability.FilterEnabledStores(node, Array.Empty<UmbracoContent>(), new[] { store });
+
+        Assert.Equal(disabled ? Array.Empty<IStore>() : new[] { store }, result);
+    }
+
+    [Theory]
+    [InlineData("ekmCategory")]
+    [InlineData("ekmProduct")]
+    [InlineData("ekmProductVariant")]
+    public void DisabledAncestorCategoryExcludesStore(string contentTypeAlias)
+    {
+        var node = CreateNode(contentTypeAlias, "false");
+        var ancestors = new[] { CreateNode("ekmProduct", "false"), CreateNode("ekmCategory", "true") };
+
+        var result = BackofficeStoreAvailability.FilterEnabledStores(node, ancestors, new[] { CreateStore("is") });
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData("ekmProduct")]
+    [InlineData("ekmProductVariant")]
+    [InlineData("ekmProductVariantGroup")]
+    [InlineData("customContent")]
+    public void DisabledNonCategoryCurrentNodeIsIgnored(string contentTypeAlias)
+    {
+        var store = CreateStore("is");
+        var node = CreateNode(contentTypeAlias, "true");
+
+        var result = BackofficeStoreAvailability.FilterEnabledStores(node, Array.Empty<UmbracoContent>(), new[] { store });
+
+        Assert.Same(store, Assert.Single(result));
+    }
+
+    [Theory]
+    [InlineData("ekmCategory")]
+    [InlineData("ekmProduct")]
+    [InlineData("ekmProductVariant")]
+    public void DisabledProductAndNonCategoryAncestorsAreIgnored(string contentTypeAlias)
+    {
+        var store = CreateStore("is");
+        var node = CreateNode(contentTypeAlias, "false");
+        var ancestors = new[]
+        {
+            CreateNode("ekmProduct", "true"),
+            CreateNode("customContent", "true"),
+            CreateNode("ekmCategory", "false"),
+        };
+
+        var result = BackofficeStoreAvailability.FilterEnabledStores(node, ancestors, new[] { store });
+
+        Assert.Same(store, Assert.Single(result));
+    }
+
+    [Fact]
+    public void MixedStoresPreserveAliasMatchingOrderAndDuplicates()
+    {
+        var node = CreateNode("ekmCategory", "{\"IS\":true}");
+        var ancestors = new[]
+        {
+            CreateNode("ekmProduct", "true"),
+            CreateNode("ekmCategory", "{\"UK\":\"1\",\"us\":false}"),
+        };
+        var stores = new[] { CreateStore("us"), CreateStore("is"), CreateStore("dk"), CreateStore("uk"), CreateStore("US") };
+
+        var result = BackofficeStoreAvailability.FilterEnabledStores(node, ancestors, stores);
+
+        Assert.Equal(new[] { stores[0], stores[2], stores[4] }, result);
+    }
+
+    private static UmbracoContent CreateNode(string contentTypeAlias, string? disable)
+    {
+        var properties = new Dictionary<string, string>();
+        if (disable != null)
+        {
+            properties["disable"] = disable;
+        }
+
+        return new UmbracoContent(new Dictionary<string, string>(), properties)
+        {
+            ContentTypeAlias = contentTypeAlias,
+        };
+    }
+
+    private static IStore CreateStore(string alias)
+    {
+        var store = new Mock<IStore>();
+        store.SetupGet(x => x.Alias).Returns(alias);
+        return store.Object;
+    }
+}


### PR DESCRIPTION
## Summary
- Apply store disable filtering only to the current category and category ancestors in backoffice editors.
- Ignore product and other noncategory disable values so their store-specific values remain editable.
- Share filtering between the store-list endpoint and U10/U17 Variant Manager (also used by U18).
- Preserve public catalog/cache disable behavior and add regression coverage and release notes.

## Validation
- 21 focused tests passed: availability cases and the existing backoffice route test.
- Core builds passed for .NET 8 and .NET 10.
- U10, U17, and U18 builds passed with warnings and no errors.
- git diff --check passed.
- Live backoffice UI testing has not been performed.